### PR TITLE
Add MySQL EF Core DbContext

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Data;
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<Course> Courses => Set<Course>();
+    public DbSet<Order> Orders => Set<Order>();
+    public DbSet<ApplicationUser> ApplicationUsers => Set<ApplicationUser>();
+}

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -1,0 +1,6 @@
+namespace SysJaky_N.Models;
+
+public class ApplicationUser
+{
+    public int Id { get; set; }
+}

--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -1,0 +1,6 @@
+namespace SysJaky_N.Models;
+
+public class Course
+{
+    public int Id { get; set; }
+}

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -1,0 +1,6 @@
+namespace SysJaky_N.Models;
+
+public class Order
+{
+    public int Id { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,13 @@
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseMySql(connectionString, new MySqlServerVersion(new Version(8, 0, 36))));
 builder.Services.AddRazorPages();
 
 var app = builder.Build();

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -6,4 +6,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Database=SysJaky_N;User=root;Password=;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- Add Pomelo MySQL provider and EF Core design package
- Register ApplicationDbContext with MySQL connection string
- Scaffold simple Course, Order, and ApplicationUser models

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet ef migrations add InitialCreate` *(fails: command not found)*
- `dotnet ef database update` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfefb259308321b96a9a85d8907926