### PR TITLE
Seed admin account from configuration

### DIFF
--- a/Data/AdminSeeder.cs
+++ b/Data/AdminSeeder.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Data;
+
+public class AdminSeeder
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public AdminSeeder(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public async Task SeedAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
+
+        var email = configuration["SeedAdmin:Email"];
+        var password = configuration["SeedAdmin:Password"];
+        var role = configuration["SeedAdmin:Role"];
+
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password) || string.IsNullOrWhiteSpace(role))
+        {
+            return;
+        }
+
+        if (await context.ApplicationUsers.AnyAsync(u => u.Email == email))
+        {
+            return;
+        }
+
+        var user = new ApplicationUser
+        {
+            Email = email,
+            Password = password,
+            Role = role
+        };
+
+        context.ApplicationUsers.Add(user);
+        await context.SaveChangesAsync();
+    }
+}
+

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -3,4 +3,7 @@ namespace SysJaky_N.Models;
 public class ApplicationUser
 {
     public int Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string Role { get; set; } = string.Empty;
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using SysJaky_N.Data;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +12,15 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    var context = services.GetRequiredService<ApplicationDbContext>();
+    context.Database.Migrate();
+    var seeder = new AdminSeeder(services);
+    await seeder.SeedAsync();
+}
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,5 +8,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "SeedAdmin": {
+    "Email": "admin@example.com",
+    "Password": "Admin123!",
+    "Role": "Admin"
+  }
 }


### PR DESCRIPTION
## Summary
- add SeedAdmin section to config for default admin credentials
- create AdminSeeder to provision admin user if missing
- invoke seeding after migrations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bff0913144832192cbc349948d76f0