### PR TITLE
Implement course management pages with admin access

### DIFF
--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -1,6 +1,21 @@
 namespace SysJaky_N.Models;
 
+using System.ComponentModel.DataAnnotations;
+
 public class Course
 {
     public int Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string Title { get; set; } = string.Empty;
+
+    [StringLength(1000)]
+    public string? Description { get; set; }
+
+    [Range(0, double.MaxValue)]
+    public decimal Price { get; set; }
+
+    [DataType(DataType.Date)]
+    public DateTime Date { get; set; }
 }

--- a/Pages/Courses/Create.cshtml
+++ b/Pages/Courses/Create.cshtml
@@ -1,0 +1,36 @@
+@page
+@model SysJaky_N.Pages.Courses.CreateModel
+@{
+    ViewData["Title"] = "Create Course";
+}
+
+<h1>Create Course</h1>
+
+<form method="post">
+    <div class="form-group">
+        <label asp-for="Course.Title"></label>
+        <input asp-for="Course.Title" class="form-control" />
+        <span asp-validation-for="Course.Title" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Description"></label>
+        <textarea asp-for="Course.Description" class="form-control"></textarea>
+        <span asp-validation-for="Course.Description" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Price"></label>
+        <input asp-for="Course.Price" class="form-control" />
+        <span asp-validation-for="Course.Price" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Date"></label>
+        <input asp-for="Course.Date" class="form-control" />
+        <span asp-validation-for="Course.Date" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Courses/Create.cshtml.cs
+++ b/Pages/Courses/Create.cshtml.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Courses;
+
+[Authorize(Roles = "Admin")]
+public class CreateModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public CreateModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [BindProperty]
+    public Course Course { get; set; } = new();
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        _context.Courses.Add(Course);
+        await _context.SaveChangesAsync();
+        return RedirectToPage("Index");
+    }
+}

--- a/Pages/Courses/Delete.cshtml
+++ b/Pages/Courses/Delete.cshtml
@@ -1,0 +1,19 @@
+@page "{id:int}"
+@model SysJaky_N.Pages.Courses.DeleteModel
+@{
+    ViewData["Title"] = "Delete Course";
+}
+
+<h1>Delete Course</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>@Model.Course.Title</h4>
+    <p>@Model.Course.Description</p>
+</div>
+
+<form method="post">
+    <input type="hidden" asp-for="Course.Id" />
+    <button type="submit" class="btn btn-danger">Delete</button>
+    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+</form>

--- a/Pages/Courses/Delete.cshtml.cs
+++ b/Pages/Courses/Delete.cshtml.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Courses;
+
+[Authorize(Roles = "Admin")]
+public class DeleteModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public DeleteModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [BindProperty]
+    public Course Course { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        Course? course = await _context.Courses.AsNoTracking().FirstOrDefaultAsync(m => m.Id == id);
+        if (course == null)
+        {
+            return NotFound();
+        }
+        Course = course;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(int id)
+    {
+        Course? course = await _context.Courses.FindAsync(id);
+        if (course == null)
+        {
+            return NotFound();
+        }
+
+        _context.Courses.Remove(course);
+        await _context.SaveChangesAsync();
+        return RedirectToPage("Index");
+    }
+}

--- a/Pages/Courses/Edit.cshtml
+++ b/Pages/Courses/Edit.cshtml
@@ -1,0 +1,37 @@
+@page "{id:int}"
+@model SysJaky_N.Pages.Courses.EditModel
+@{
+    ViewData["Title"] = "Edit Course";
+}
+
+<h1>Edit Course</h1>
+
+<form method="post">
+    <input type="hidden" asp-for="Course.Id" />
+    <div class="form-group">
+        <label asp-for="Course.Title"></label>
+        <input asp-for="Course.Title" class="form-control" />
+        <span asp-validation-for="Course.Title" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Description"></label>
+        <textarea asp-for="Course.Description" class="form-control"></textarea>
+        <span asp-validation-for="Course.Description" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Price"></label>
+        <input asp-for="Course.Price" class="form-control" />
+        <span asp-validation-for="Course.Price" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Date"></label>
+        <input asp-for="Course.Date" class="form-control" />
+        <span asp-validation-for="Course.Date" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Pages/Courses/Edit.cshtml.cs
+++ b/Pages/Courses/Edit.cshtml.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Courses;
+
+[Authorize(Roles = "Admin")]
+public class EditModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public EditModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [BindProperty]
+    public Course Course { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        Course? course = await _context.Courses.FindAsync(id);
+        if (course == null)
+        {
+            return NotFound();
+        }
+        Course = course;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        _context.Attach(Course).State = EntityState.Modified;
+
+        try
+        {
+            await _context.SaveChangesAsync();
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            if (!await _context.Courses.AnyAsync(e => e.Id == Course.Id))
+            {
+                return NotFound();
+            }
+            else
+            {
+                throw;
+            }
+        }
+
+        return RedirectToPage("Index");
+    }
+}

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -1,0 +1,50 @@
+@page
+@model SysJaky_N.Pages.Courses.IndexModel
+@{
+    ViewData["Title"] = "Courses";
+}
+
+<h1>Courses</h1>
+
+<p>
+    <a asp-page="Create">Create New</a>
+</p>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th>Price</th>
+            <th>Date</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var item in Model.Courses)
+    {
+        <tr>
+            <td>@item.Title</td>
+            <td>@item.Price</td>
+            <td>@item.Date.ToString("d")</td>
+            <td>
+                <a asp-page="Edit" asp-route-id="@item.Id">Edit</a> |
+                <a asp-page="Delete" asp-route-id="@item.Id">Delete</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>
+
+@if (Model.TotalPages > 1)
+{
+    <nav>
+        <ul class="pagination">
+            <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)">Previous</a>
+            </li>
+            <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)">Next</a>
+            </li>
+        </ul>
+    </nav>
+}

--- a/Pages/Courses/Index.cshtml.cs
+++ b/Pages/Courses/Index.cshtml.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Courses;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IList<Course> Courses { get; set; } = new List<Course>();
+
+    [BindProperty(SupportsGet = true)]
+    public int PageNumber { get; set; } = 1;
+
+    public int TotalPages { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        const int pageSize = 10;
+        var query = _context.Courses.OrderBy(c => c.Date);
+        var count = await query.CountAsync();
+        TotalPages = (int)Math.Ceiling(count / (double)pageSize);
+        Courses = await query.Skip((PageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- expand Course model with details like title, description, price, and date
- add admin-only CRUD Razor pages for managing courses
- include validation and pagination on course listing

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bff1b050208321b17b141b7cabf547