### PR TITLE
Add admin user management pages

### DIFF
--- a/Pages/Admin/Users/Delete.cshtml
+++ b/Pages/Admin/Users/Delete.cshtml
@@ -1,0 +1,18 @@
+@page "{id}"
+@model SysJaky_N.Pages.Admin.Users.DeleteModel
+@{
+    ViewData["Title"] = "Delete User";
+}
+
+<h1>Delete User</h1>
+
+<h3>Are you sure you want to delete this user?</h3>
+<div>
+    <strong>@Model.UserEntity.Email</strong>
+</div>
+
+<form method="post">
+    <input type="hidden" asp-for="UserEntity.Id" />
+    <button type="submit" class="btn btn-danger">Delete</button>
+    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+</form>

--- a/Pages/Admin/Users/Delete.cshtml.cs
+++ b/Pages/Admin/Users/Delete.cshtml.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Users;
+
+[Authorize(Roles = "Admin")]
+public class DeleteModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public DeleteModel(UserManager<ApplicationUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    [BindProperty]
+    public ApplicationUser UserEntity { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(string id)
+    {
+        var user = await _userManager.FindByIdAsync(id);
+        if (user == null)
+        {
+            return NotFound();
+        }
+        UserEntity = user;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(string id)
+    {
+        var user = await _userManager.FindByIdAsync(id);
+        if (user == null)
+        {
+            return NotFound();
+        }
+        await _userManager.DeleteAsync(user);
+        return RedirectToPage("Index");
+    }
+}

--- a/Pages/Admin/Users/Edit.cshtml
+++ b/Pages/Admin/Users/Edit.cshtml
@@ -1,0 +1,35 @@
+@page "{id}"
+@model SysJaky_N.Pages.Admin.Users.EditModel
+@{
+    ViewData["Title"] = "Edit User";
+}
+
+<h1>Edit User</h1>
+
+<form method="post">
+    <div class="form-group">
+        <label asp-for="Input.Email"></label>
+        <input asp-for="Input.Email" class="form-control" />
+    </div>
+    <div class="form-group">
+        <label asp-for="Input.PhoneNumber"></label>
+        <input asp-for="Input.PhoneNumber" class="form-control" />
+    </div>
+    <div class="form-group form-check">
+        <input asp-for="Input.IsLocked" class="form-check-input" />
+        <label asp-for="Input.IsLocked" class="form-check-label"></label>
+    </div>
+    <div class="form-group">
+        <label>Roles</label>
+        @for (int i = 0; i < Model.Input.Roles.Count; i++)
+        {
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" asp-for="Input.Roles[i].Selected" />
+                <label class="form-check-label">@Model.Input.Roles[i].Name</label>
+                <input type="hidden" asp-for="Input.Roles[i].Name" />
+            </div>
+        }
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a asp-page="Index" class="btn btn-secondary">Back</a>
+</form>

--- a/Pages/Admin/Users/Edit.cshtml.cs
+++ b/Pages/Admin/Users/Edit.cshtml.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Users;
+
+[Authorize(Roles = "Admin")]
+public class EditModel : PageModel
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly RoleManager<IdentityRole> _roleManager;
+
+    public EditModel(UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
+    {
+        _userManager = userManager;
+        _roleManager = roleManager;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        public string Email { get; set; } = string.Empty;
+        public string? PhoneNumber { get; set; }
+        public bool IsLocked { get; set; }
+        public List<RoleSelection> Roles { get; set; } = new();
+    }
+
+    public class RoleSelection
+    {
+        public string Name { get; set; } = string.Empty;
+        public bool Selected { get; set; }
+    }
+
+    public async Task<IActionResult> OnGetAsync(string id)
+    {
+        var user = await _userManager.Users.FirstOrDefaultAsync(u => u.Id == id);
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        Input = new InputModel
+        {
+            Email = user.Email ?? string.Empty,
+            PhoneNumber = user.PhoneNumber,
+            IsLocked = user.LockoutEnd.HasValue && user.LockoutEnd.Value > DateTimeOffset.UtcNow
+        };
+
+        var allRoles = await _roleManager.Roles.ToListAsync();
+        foreach (var role in allRoles)
+        {
+            Input.Roles.Add(new RoleSelection
+            {
+                Name = role.Name!,
+                Selected = await _userManager.IsInRoleAsync(user, role.Name!)
+            });
+        }
+
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync(string id)
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var user = await _userManager.FindByIdAsync(id);
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        user.Email = Input.Email;
+        user.UserName = Input.Email;
+        user.PhoneNumber = Input.PhoneNumber;
+        await _userManager.SetLockoutEndDateAsync(user, Input.IsLocked ? DateTimeOffset.MaxValue : null);
+        await _userManager.UpdateAsync(user);
+
+        var selectedRoles = Input.Roles.Where(r => r.Selected).Select(r => r.Name);
+        var userRoles = await _userManager.GetRolesAsync(user);
+        await _userManager.AddToRolesAsync(user, selectedRoles.Except(userRoles));
+        await _userManager.RemoveFromRolesAsync(user, userRoles.Except(selectedRoles));
+
+        return RedirectToPage("Index");
+    }
+}

--- a/Pages/Admin/Users/Index.cshtml
+++ b/Pages/Admin/Users/Index.cshtml
@@ -1,0 +1,31 @@
+@page
+@model SysJaky_N.Pages.Admin.Users.IndexModel
+@{
+    ViewData["Title"] = "Users";
+}
+
+<h1>Users</h1>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Email</th>
+            <th>Phone</th>
+            <th>Roles</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var user in Model.Users)
+    {
+        <tr>
+            <td>@user.Email</td>
+            <td>@user.PhoneNumber</td>
+            <td>@string.Join(", ", user.Roles)</td>
+            <td>
+                <a asp-page="Edit" asp-route-id="@user.Id">Edit</a> |
+                <a asp-page="Delete" asp-route-id="@user.Id">Delete</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/Pages/Admin/Users/Index.cshtml.cs
+++ b/Pages/Admin/Users/Index.cshtml.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Users;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+    private readonly UserManager<ApplicationUser> _userManager;
+
+    public IndexModel(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
+    {
+        _context = context;
+        _userManager = userManager;
+    }
+
+    public IList<UserViewModel> Users { get; set; } = new List<UserViewModel>();
+
+    public class UserViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string? PhoneNumber { get; set; }
+        public IList<string> Roles { get; set; } = new List<string>();
+    }
+
+    public async Task OnGetAsync()
+    {
+        var users = await _context.Users.ToListAsync();
+        foreach (var user in users)
+        {
+            var vm = new UserViewModel
+            {
+                Id = user.Id,
+                Email = user.Email ?? string.Empty,
+                PhoneNumber = user.PhoneNumber
+            };
+            vm.Roles = await _userManager.GetRolesAsync(user);
+            Users.Add(vm);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add admin Razor Pages to list, edit and delete users
- Allow editing basic information and roles using UserManager/RoleManager
- Secure user management under Admin role

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c01eb666848321ba9a6765533670d8