### PR TITLE
Add configurable online payment gateway

### DIFF
--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -19,6 +19,8 @@ public class Order
     public int? DiscountCodeId { get; set; }
     public DiscountCode? DiscountCode { get; set; }
 
+    public string? PaymentConfirmation { get; set; }
+
     [DataType(DataType.DateTime)]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/Pages/Orders/Details.cshtml
+++ b/Pages/Orders/Details.cshtml
@@ -35,3 +35,10 @@
 {
     <img src="@Model.QrCodeImage" alt="QR code" />
 }
+
+@if (Model.PaymentEnabled && Model.Order.Status != OrderStatus.Paid)
+{
+    <form method="post" asp-page-handler="Pay">
+        <button type="submit" class="btn btn-primary">Zaplatit online</button>
+    </form>
+}

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
+using SysJaky_N.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -24,6 +25,8 @@ builder.Services.ConfigureApplicationCookie(options =>
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession();
 builder.Services.AddRazorPages();
+builder.Services.Configure<PaymentGatewayOptions>(builder.Configuration.GetSection("PaymentGateway"));
+builder.Services.AddScoped<PaymentService>();
 
 var app = builder.Build();
 
@@ -54,5 +57,10 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapRazorPages();
+app.MapPost("/payment/webhook", async (HttpRequest request, PaymentService paymentService) =>
+{
+    await paymentService.HandleWebhookAsync(request);
+    return Results.Ok();
+});
 
 app.Run();

--- a/Services/PaymentService.cs
+++ b/Services/PaymentService.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.Options;
+using Stripe;
+using Stripe.Checkout;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Services;
+
+public class PaymentGatewayOptions
+{
+    public bool Enabled { get; set; } = false;
+    public string ApiKey { get; set; } = string.Empty;
+    public string WebhookSecret { get; set; } = string.Empty;
+}
+
+public class PaymentService
+{
+    private readonly PaymentGatewayOptions _options;
+    private readonly ApplicationDbContext _context;
+
+    public bool IsEnabled => _options.Enabled;
+
+    public PaymentService(IOptions<PaymentGatewayOptions> options, ApplicationDbContext context)
+    {
+        _options = options.Value;
+        _context = context;
+
+        if (_options.Enabled)
+            StripeConfiguration.ApiKey = _options.ApiKey;
+    }
+
+    public async Task<string?> CreatePaymentAsync(Order order, string successUrl, string cancelUrl)
+    {
+        if (!_options.Enabled)
+            return null;
+
+        var service = new SessionService();
+        var sessionOptions = new SessionCreateOptions
+        {
+            Mode = "payment",
+            SuccessUrl = successUrl + "?session_id={CHECKOUT_SESSION_ID}",
+            CancelUrl = cancelUrl,
+            LineItems = new List<SessionLineItemOptions>
+            {
+                new SessionLineItemOptions
+                {
+                    PriceData = new SessionLineItemPriceDataOptions
+                    {
+                        Currency = "czk",
+                        UnitAmountDecimal = order.TotalPrice * 100m,
+                        ProductData = new SessionLineItemPriceDataProductDataOptions
+                        {
+                            Name = $"Order {order.Id}"
+                        }
+                    },
+                    Quantity = 1
+                }
+            },
+            Metadata = new Dictionary<string, string>
+            {
+                { "orderId", order.Id.ToString() }
+            }
+        };
+
+        var session = await service.CreateAsync(sessionOptions);
+        order.PaymentConfirmation = session.Id;
+        await _context.SaveChangesAsync();
+        return session.Url;
+    }
+
+    public async Task HandleSuccessAsync(string sessionId)
+    {
+        if (!_options.Enabled)
+            return;
+
+        var service = new SessionService();
+        var session = await service.GetAsync(sessionId);
+        if (session.PaymentStatus == "paid")
+        {
+            var orderIdStr = session.Metadata.GetValueOrDefault("orderId");
+            if (int.TryParse(orderIdStr, out var orderId))
+            {
+                var order = await _context.Orders.FindAsync(orderId);
+                if (order != null)
+                {
+                    order.Status = OrderStatus.Paid;
+                    order.PaymentConfirmation = session.PaymentIntentId ?? session.Id;
+                    await _context.SaveChangesAsync();
+                }
+            }
+        }
+    }
+
+    public async Task HandleWebhookAsync(HttpRequest request)
+    {
+        if (!_options.Enabled)
+            return;
+
+        var json = await new StreamReader(request.Body).ReadToEndAsync();
+        try
+        {
+            var stripeEvent = EventUtility.ConstructEvent(json, request.Headers["Stripe-Signature"], _options.WebhookSecret);
+            if (stripeEvent.Type == Events.CheckoutSessionCompleted)
+            {
+                if (stripeEvent.Data.Object is Session session)
+                {
+                    await HandleSuccessAsync(session.Id);
+                }
+            }
+        }
+        catch
+        {
+            // ignore invalid webhook calls
+        }
+    }
+}
+

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -14,6 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="QRCoder" Version="1.4.3" />
+    <PackageReference Include="Stripe.net" Version="44.4.0" />
   </ItemGroup>
 
 </Project>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -5,5 +5,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "PaymentGateway": {
+    "Enabled": false,
+    "ApiKey": "",
+    "WebhookSecret": ""
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -17,5 +17,10 @@
   "Payment": {
     "Iban": "CZ0000000000000000000000",
     "VsPrefix": "123"
+  },
+  "PaymentGateway": {
+    "Enabled": false,
+    "ApiKey": "",
+    "WebhookSecret": ""
   }
 }


### PR DESCRIPTION
## Summary
- add Stripe SDK and payment service for creating checkout sessions and handling webhooks
- expose payment gateway configuration through appsettings
- enable online payment button on order details and update orders when payment completes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c04fb84db08321aaefe4a2fb885204