### PR TITLE
Define CourseGroup relationships

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -11,11 +11,11 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
     }
 
-    public DbSet<Course> Courses => Set<Course>();
-    public DbSet<CourseGroup> CourseGroups => Set<CourseGroup>();
-    public DbSet<Order> Orders => Set<Order>();
-    public DbSet<OrderItem> OrderItems => Set<OrderItem>();
-    public DbSet<DiscountCode> DiscountCodes => Set<DiscountCode>();
-    public DbSet<Article> Articles => Set<Article>();
+    public DbSet<Course> Courses { get; set; } = default!;
+    public DbSet<CourseGroup> CourseGroups { get; set; } = default!;
+    public DbSet<Order> Orders { get; set; } = default!;
+    public DbSet<OrderItem> OrderItems { get; set; } = default!;
+    public DbSet<DiscountCode> DiscountCodes { get; set; } = default!;
+    public DbSet<Article> Articles { get; set; } = default!;
 
 }

--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -21,5 +21,5 @@ public class Course
 
     public int? CourseGroupId { get; set; }
 
-    public CourseGroup? CourseGroup { get; set; }
+    public virtual CourseGroup? CourseGroup { get; set; }
 }


### PR DESCRIPTION
## Summary
- expose CourseGroup DbSet and other sets as auto properties
- mark Course.CourseGroup navigation property virtual for EF

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f74e0248321b08b8aca58237651