### PR TITLE
Add admin dashboard with order metrics and charts

### DIFF
--- a/Pages/Admin/Dashboard/Index.cshtml
+++ b/Pages/Admin/Dashboard/Index.cshtml
@@ -1,0 +1,73 @@
+@page
+@model SysJaky_N.Pages.Admin.Dashboard.IndexModel
+@{
+    ViewData["Title"] = "Dashboard";
+}
+
+<h1>Dashboard</h1>
+
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">Počet objednávek</h5>
+                <p class="card-text display-6">@Model.OrderCount</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">Celkové tržby</h5>
+                <p class="card-text display-6">@Model.TotalRevenue.ToString("C")</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        <h3>Nejprodávanější kurzy</h3>
+        <canvas id="topCoursesChart"></canvas>
+    </div>
+    <div class="col-md-6">
+        <h3>Tržby dle měsíce</h3>
+        <canvas id="revenueChart"></canvas>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const topCourseLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TopCourseLabels));
+        const topCourseData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TopCourseValues));
+
+        new Chart(document.getElementById('topCoursesChart'), {
+            type: 'bar',
+            data: {
+                labels: topCourseLabels,
+                datasets: [{
+                    label: 'Počet prodaných kusů',
+                    data: topCourseData,
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)'
+                }]
+            }
+        });
+
+        const revenueLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueLabels));
+        const revenueData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueValues));
+
+        new Chart(document.getElementById('revenueChart'), {
+            type: 'line',
+            data: {
+                labels: revenueLabels,
+                datasets: [{
+                    label: 'Tržby',
+                    data: revenueData,
+                    borderColor: 'rgba(75, 192, 192, 1)',
+                    fill: false
+                }]
+            }
+        });
+    </script>
+}

--- a/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+
+namespace SysJaky_N.Pages.Admin.Dashboard;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public int OrderCount { get; set; }
+    public decimal TotalRevenue { get; set; }
+    public List<string> TopCourseLabels { get; set; } = new();
+    public List<int> TopCourseValues { get; set; } = new();
+    public List<string> RevenueLabels { get; set; } = new();
+    public List<decimal> RevenueValues { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        OrderCount = await _context.Orders.CountAsync();
+        TotalRevenue = await _context.Orders.SumAsync(o => o.TotalPrice);
+
+        var topCourses = await _context.OrderItems
+            .Include(oi => oi.Course)
+            .GroupBy(oi => oi.Course!.Title)
+            .Select(g => new
+            {
+                Course = g.Key,
+                Quantity = g.Sum(oi => oi.Quantity)
+            })
+            .OrderByDescending(g => g.Quantity)
+            .Take(5)
+            .ToListAsync();
+
+        foreach (var item in topCourses)
+        {
+            TopCourseLabels.Add(item.Course);
+            TopCourseValues.Add(item.Quantity);
+        }
+
+        var revenue = await _context.Orders
+            .GroupBy(o => new { o.CreatedAt.Year, o.CreatedAt.Month })
+            .Select(g => new
+            {
+                Period = new DateTime(g.Key.Year, g.Key.Month, 1),
+                Total = g.Sum(o => o.TotalPrice)
+            })
+            .OrderBy(g => g.Period)
+            .ToListAsync();
+
+        foreach (var item in revenue)
+        {
+            RevenueLabels.Add(item.Period.ToString("yyyy-MM"));
+            RevenueValues.Add(item.Total);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add admin dashboard page that displays total orders and revenue
- Query ApplicationDbContext for top courses and monthly revenue
- Render top-course and revenue charts with Chart.js

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c0521a5128832184c6a70d8adeaa33