### PR TITLE
Add audit logging and admin log viewer

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -18,5 +18,6 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<DiscountCode> DiscountCodes { get; set; } = default!;
     public DbSet<Article> Articles { get; set; } = default!;
     public DbSet<CourseReview> CourseReviews { get; set; } = default!;
+    public DbSet<AuditLog> AuditLogs { get; set; } = default!;
 
 }

--- a/Data/Migrations/AddAuditLog.cs
+++ b/Data/Migrations/AddAuditLog.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Data.Migrations;
+
+public partial class AddAuditLog : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "AuditLogs",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                UserId = table.Column<string>(type: "varchar(255)", nullable: true)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                Action = table.Column<string>(type: "longtext", nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                Timestamp = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                Data = table.Column<string>(type: "longtext", nullable: true)
+                    .Annotation("MySql:CharSet", "utf8mb4")
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AuditLogs", x => x.Id);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "AuditLogs");
+    }
+}
+

--- a/Models/AuditLog.cs
+++ b/Models/AuditLog.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace SysJaky_N.Models;
+
+public class AuditLog
+{
+    public int Id { get; set; }
+    public string? UserId { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; }
+    public string? Data { get; set; }
+}
+

--- a/Pages/Account/Login.cshtml.cs
+++ b/Pages/Account/Login.cshtml.cs
@@ -2,16 +2,19 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SysJaky_N.Models;
+using SysJaky_N.Services;
 
 namespace SysJaky_N.Pages.Account;
 
 public class LoginModel : PageModel
 {
     private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly IAuditService _auditService;
 
-    public LoginModel(SignInManager<ApplicationUser> signInManager)
+    public LoginModel(SignInManager<ApplicationUser> signInManager, IAuditService auditService)
     {
         _signInManager = signInManager;
+        _auditService = auditService;
     }
 
     [BindProperty]
@@ -38,6 +41,8 @@ public class LoginModel : PageModel
         var result = await _signInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
         if (result.Succeeded)
         {
+            var user = await _signInManager.UserManager.FindByEmailAsync(Input.Email);
+            await _auditService.LogAsync(user?.Id, "Login");
             return RedirectToPage("/Index");
         }
 

--- a/Pages/Admin/AuditLogs/Index.cshtml
+++ b/Pages/Admin/AuditLogs/Index.cshtml
@@ -1,0 +1,29 @@
+@page
+@model SysJaky_N.Pages.Admin.AuditLogs.IndexModel
+@{
+    ViewData["Title"] = "Audit Logs";
+}
+
+<h1>Audit Logs</h1>
+<table class="table">
+    <thead>
+        <tr>
+            <th>User</th>
+            <th>Action</th>
+            <th>Timestamp</th>
+            <th>Data</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var log in Model.Logs)
+    {
+        <tr>
+            <td>@log.UserId</td>
+            <td>@log.Action</td>
+            <td>@log.Timestamp</td>
+            <td>@log.Data</td>
+        </tr>
+    }
+    </tbody>
+</table>
+

--- a/Pages/Admin/AuditLogs/Index.cshtml.cs
+++ b/Pages/Admin/AuditLogs/Index.cshtml.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.AuditLogs;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IList<AuditLog> Logs { get; set; } = new List<AuditLog>();
+
+    public async Task OnGetAsync()
+    {
+        Logs = await _context.AuditLogs.OrderByDescending(a => a.Timestamp).ToListAsync();
+    }
+}
+

--- a/Pages/Cart.cshtml.cs
+++ b/Pages/Cart.cshtml.cs
@@ -16,12 +16,14 @@ public class CartModel : PageModel
     private readonly ApplicationDbContext _context;
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly IEmailSender _emailSender;
+    private readonly IAuditService _auditService;
 
-    public CartModel(ApplicationDbContext context, UserManager<ApplicationUser> userManager, IEmailSender emailSender)
+    public CartModel(ApplicationDbContext context, UserManager<ApplicationUser> userManager, IEmailSender emailSender, IAuditService auditService)
     {
         _context = context;
         _userManager = userManager;
         _emailSender = emailSender;
+        _auditService = auditService;
     }
 
     public List<CartItemView> Items { get; set; } = new();
@@ -73,6 +75,7 @@ public class CartModel : PageModel
         };
         _context.Orders.Add(order);
         await _context.SaveChangesAsync();
+        await _auditService.LogAsync(userId, "OrderCreated", $"Order {order.Id} created");
         await _emailSender.SendEmailAsync(user.Email!, "Order Created", $"Your order {order.Id} has been created.");
         HttpContext.Session.Remove("Cart");
         HttpContext.Session.Remove("DiscountCodeId");

--- a/Pages/Courses/Create.cshtml.cs
+++ b/Pages/Courses/Create.cshtml.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
+using SysJaky_N.Services;
+using System.Security.Claims;
 
 namespace SysJaky_N.Pages.Courses;
 
@@ -11,10 +13,12 @@ namespace SysJaky_N.Pages.Courses;
 public class CreateModel : PageModel
 {
     private readonly ApplicationDbContext _context;
+    private readonly IAuditService _auditService;
 
-    public CreateModel(ApplicationDbContext context)
+    public CreateModel(ApplicationDbContext context, IAuditService auditService)
     {
         _context = context;
+        _auditService = auditService;
     }
 
     [BindProperty]
@@ -37,6 +41,8 @@ public class CreateModel : PageModel
 
         _context.Courses.Add(Course);
         await _context.SaveChangesAsync();
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        await _auditService.LogAsync(userId, "CourseCreated", $"Course {Course.Id} created");
         return RedirectToPage("Index");
     }
 }

--- a/Pages/Courses/Edit.cshtml.cs
+++ b/Pages/Courses/Edit.cshtml.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
+using SysJaky_N.Services;
+using System.Security.Claims;
 
 namespace SysJaky_N.Pages.Courses;
 
@@ -12,10 +14,12 @@ namespace SysJaky_N.Pages.Courses;
 public class EditModel : PageModel
 {
     private readonly ApplicationDbContext _context;
+    private readonly IAuditService _auditService;
 
-    public EditModel(ApplicationDbContext context)
+    public EditModel(ApplicationDbContext context, IAuditService auditService)
     {
         _context = context;
+        _auditService = auditService;
     }
 
     [BindProperty]
@@ -48,6 +52,8 @@ public class EditModel : PageModel
         try
         {
             await _context.SaveChangesAsync();
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            await _auditService.LogAsync(userId, "CourseEdited", $"Course {Course.Id} edited");
         }
         catch (DbUpdateConcurrencyException)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddScoped<PaymentService>();
 builder.Services.AddSingleton<IConverter>(new SynchronizedConverter(new PdfTools()));
 builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp"));
 builder.Services.AddScoped<IEmailSender, EmailSender>();
+builder.Services.AddScoped<IAuditService, AuditService>();
 
 var app = builder.Build();
 

--- a/Services/AuditService.cs
+++ b/Services/AuditService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Services;
+
+public class AuditService : IAuditService
+{
+    private readonly ApplicationDbContext _context;
+
+    public AuditService(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task LogAsync(string? userId, string action, string? data = null)
+    {
+        var log = new AuditLog
+        {
+            UserId = userId,
+            Action = action,
+            Timestamp = DateTime.UtcNow,
+            Data = data
+        };
+        _context.AuditLogs.Add(log);
+        await _context.SaveChangesAsync();
+    }
+}
+

--- a/Services/IAuditService.cs
+++ b/Services/IAuditService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace SysJaky_N.Services;
+
+public interface IAuditService
+{
+    Task LogAsync(string? userId, string action, string? data = null);
+}
+


### PR DESCRIPTION
## Summary
- add `AuditLog` entity and database migration
- implement `IAuditService` for logging and register in DI
- log logins, course create/edit, and order creation
- add admin page to view audit logs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05435d8088321b10bb042cbd88f2c