### PR TITLE
Add search and pagination to Courses and Articles pages

### DIFF
--- a/Pages/Articles/Index.cshtml
+++ b/Pages/Articles/Index.cshtml
@@ -5,6 +5,10 @@
 }
 
 <h1>Articles</h1>
+<form method="get" class="mb-3">
+    <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" style="width:auto;display:inline-block" />
+    <button type="submit" class="btn btn-primary">Search</button>
+</form>
 
 <ul>
 @foreach (var item in Model.Articles)
@@ -14,3 +18,17 @@
     </li>
 }
 </ul>
+
+@if (Model.TotalPages > 1)
+{
+    <nav>
+        <ul class="pagination">
+            <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-SearchString="@Model.SearchString">Previous</a>
+            </li>
+            <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-SearchString="@Model.SearchString">Next</a>
+            </li>
+        </ul>
+    </nav>
+}

--- a/Pages/Articles/Index.cshtml.cs
+++ b/Pages/Articles/Index.cshtml.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
@@ -11,6 +12,14 @@ public class IndexModel : PageModel
 
     public IList<Article> Articles { get; set; } = new List<Article>();
 
+    [BindProperty(SupportsGet = true)]
+    public string? SearchString { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int PageNumber { get; set; } = 1;
+
+    public int TotalPages { get; set; }
+
     public IndexModel(ApplicationDbContext context)
     {
         _context = context;
@@ -18,8 +27,19 @@ public class IndexModel : PageModel
 
     public async Task OnGetAsync()
     {
-        Articles = await _context.Articles
-            .OrderByDescending(a => a.CreatedAt)
-            .ToListAsync();
+        const int pageSize = 10;
+        var query = _context.Articles.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(SearchString))
+        {
+            var pattern = $"%{SearchString.Trim()}%";
+            query = query.Where(a => EF.Functions.Like(a.Title, pattern));
+        }
+
+        query = query.OrderByDescending(a => a.CreatedAt);
+
+        var count = await query.CountAsync();
+        TotalPages = (int)Math.Ceiling(count / (double)pageSize);
+        Articles = await query.Skip((PageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
     }
 }

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -7,6 +7,7 @@
 <h1>Courses</h1>
 
 <form method="get" class="mb-3">
+    <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" style="width:auto;display:inline-block" />
     <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-control" style="width:auto;display:inline-block">
         <option value="">All Groups</option>
     </select>
@@ -62,10 +63,10 @@
     <nav>
         <ul class="pagination">
             <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId">Previous</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Previous</a>
             </li>
             <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId">Next</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Next</a>
             </li>
         </ul>
     </nav>

--- a/Pages/Courses/Index.cshtml.cs
+++ b/Pages/Courses/Index.cshtml.cs
@@ -25,6 +25,9 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public int? CourseGroupId { get; set; }
 
+    [BindProperty(SupportsGet = true)]
+    public string? SearchString { get; set; }
+
     public SelectList CourseGroups { get; set; } = default!;
 
     public int TotalPages { get; set; }
@@ -33,11 +36,23 @@ public class IndexModel : PageModel
     {
         const int pageSize = 10;
         CourseGroups = new SelectList(_context.CourseGroups, "Id", "Name");
-        var query = _context.Courses.Include(c => c.CourseGroup).OrderBy(c => c.Date);
+        var query = _context.Courses
+            .Include(c => c.CourseGroup)
+            .AsQueryable();
+
         if (CourseGroupId.HasValue)
         {
-            query = query.Where(c => c.CourseGroupId == CourseGroupId).OrderBy(c => c.Date);
+            query = query.Where(c => c.CourseGroupId == CourseGroupId);
         }
+
+        if (!string.IsNullOrWhiteSpace(SearchString))
+        {
+            var pattern = $"%{SearchString.Trim()}%";
+            query = query.Where(c => EF.Functions.Like(c.Title, pattern));
+        }
+
+        query = query.OrderBy(c => c.Date);
+
         var count = await query.CountAsync();
         TotalPages = (int)Math.Ceiling(count / (double)pageSize);
         Courses = await query.Skip((PageNumber - 1) * pageSize).Take(pageSize).ToListAsync();


### PR DESCRIPTION
## Summary
- Add SearchString filter to Courses index with EF.Functions.Like and paginate results
- Introduce search and pagination to Articles index, filtering titles with EF.Functions.Like

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c05be7b9b88321988936834cb12e39