### PR TITLE
Add contact page with message storage and admin notification

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -19,5 +19,6 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<Article> Articles { get; set; } = default!;
     public DbSet<CourseReview> CourseReviews { get; set; } = default!;
     public DbSet<AuditLog> AuditLogs { get; set; } = default!;
+    public DbSet<ContactMessage> ContactMessages { get; set; } = default!;
 
 }

--- a/Data/Migrations/AddContactMessage.cs
+++ b/Data/Migrations/AddContactMessage.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Data.Migrations;
+
+public partial class AddContactMessage : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "ContactMessages",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                Name = table.Column<string>(type: "longtext", nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                Email = table.Column<string>(type: "longtext", nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                Message = table.Column<string>(type: "longtext", nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4"),
+                CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_ContactMessages", x => x.Id);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "ContactMessages");
+    }
+}
+

--- a/Models/ContactMessage.cs
+++ b/Models/ContactMessage.cs
@@ -1,0 +1,23 @@
+namespace SysJaky_N.Models;
+
+using System.ComponentModel.DataAnnotations;
+
+public class ContactMessage
+{
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(4000)]
+    public string Message { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; }
+}
+

--- a/Pages/Contact.cshtml
+++ b/Pages/Contact.cshtml
@@ -1,0 +1,43 @@
+@page
+@model SysJaky_N.Pages.ContactModel
+@{
+    ViewData["Title"] = "Contact";
+}
+
+<h1>Contact</h1>
+
+<div class="row">
+    <div class="col-md-6">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="mb-3">
+                <label asp-for="Input.Name" class="form-label"></label>
+                <input asp-for="Input.Name" class="form-control" />
+                <span asp-validation-for="Input.Name" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="Input.Email" class="form-label"></label>
+                <input asp-for="Input.Email" class="form-control" />
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="mb-3">
+                <label asp-for="Input.Message" class="form-label"></label>
+                <textarea asp-for="Input.Message" class="form-control"></textarea>
+                <span asp-validation-for="Input.Message" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-primary">Send</button>
+        </form>
+        @if (TempData["Success"] != null)
+        {
+            <div class="alert alert-success mt-3">@TempData["Success"]</div>
+        }
+    </div>
+    <div class="col-md-6">
+        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d10254.995911868303!2d14.42076!3d50.08804!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x470b94b49155b5d3%3A0x6f1234567890abcd!2sPrague%2C%20Czechia!5e0!3m2!1sen!2scz!4v1700000000000!5m2!1sen!2scz" width="100%" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}
+

--- a/Pages/Contact.cshtml.cs
+++ b/Pages/Contact.cshtml.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+using SysJaky_N.Services;
+
+namespace SysJaky_N.Pages;
+
+public class ContactModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IEmailSender _emailSender;
+    private readonly IConfiguration _configuration;
+
+    public ContactModel(ApplicationDbContext context, IEmailSender emailSender, IConfiguration configuration)
+    {
+        _context = context;
+        _emailSender = emailSender;
+        _configuration = configuration;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public class InputModel
+    {
+        [Required]
+        [StringLength(100)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(4000)]
+        public string Message { get; set; } = string.Empty;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            return Page();
+        }
+
+        var entity = new ContactMessage
+        {
+            Name = Input.Name,
+            Email = Input.Email,
+            Message = Input.Message,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _context.ContactMessages.Add(entity);
+        await _context.SaveChangesAsync();
+
+        var adminEmail = _configuration["SeedAdmin:Email"];
+        if (!string.IsNullOrEmpty(adminEmail))
+        {
+            var body = $"From: {Input.Name} <{Input.Email}>\n\n{Input.Message}";
+            await _emailSender.SendEmailAsync(adminEmail, "New contact message", body);
+        }
+
+        TempData["Success"] = "Message sent.";
+        return RedirectToPage();
+    }
+}
+

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -32,6 +32,9 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Articles/Index">Articles</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-page="/Contact">Contact</a>
+                        </li>
                         @if (User.IsInRole("Admin"))
                         {
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
- add ContactMessage entity and migration for storing contact form submissions
- implement Contact page with Google Maps, form, and admin email notification
- add navigation link to new Contact page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c05beb34ec832197e6eb25a6ce71c5