### PR TITLE
Add account dashboard for upcoming courses

### DIFF
--- a/Pages/Account/Dashboard.cshtml
+++ b/Pages/Account/Dashboard.cshtml
@@ -1,0 +1,40 @@
+@page
+@model SysJaky_N.Pages.Account.DashboardModel
+@{
+    ViewData["Title"] = "Dashboard";
+}
+
+<h1>Přihlášené kurzy</h1>
+
+@if (Model.UpcomingItems.Any())
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Datum</th>
+                <th>Stav</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model.UpcomingItems)
+        {
+            <tr>
+                <td>@item.Course?.Date.ToString("d")</td>
+                <td>@item.Order?.Status</td>
+                <td>
+                    @if (item.Order?.Status == OrderStatus.Paid)
+                    {
+                        <a class="btn btn-secondary" asp-page="/Orders/Details" asp-route-id="@item.Order.Id" asp-page-handler="DownloadInvoice">Stáhnout fakturu</a>
+                    }
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+else
+{
+    <p>Nemáte žádné nadcházející kurzy.</p>
+}
+

--- a/Pages/Account/Dashboard.cshtml.cs
+++ b/Pages/Account/Dashboard.cshtml.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+using System.Security.Claims;
+
+namespace SysJaky_N.Pages.Account;
+
+[Authorize]
+public class DashboardModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public DashboardModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public List<OrderItem> UpcomingItems { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null)
+            return;
+
+        UpcomingItems = await _context.OrderItems
+            .Include(oi => oi.Order)
+            .Include(oi => oi.Course)
+            .Where(oi => oi.Order != null
+                && oi.Order.UserId == userId
+                && oi.Course != null
+                && oi.Course.Date >= DateTime.Today)
+            .ToListAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- Add account dashboard page listing upcoming courses
- Display course date, order status, and allow invoice download

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c05bebe0608321a08f9f951dba685f