### PR TITLE
Add course reminder service with daily emails

### DIFF
--- a/Migrations/20251118120000_AddCourseReminders.cs
+++ b/Migrations/20251118120000_AddCourseReminders.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Migrations
+{
+    public partial class AddCourseReminders : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ReminderDays",
+                table: "Courses",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReminderMessage",
+                table: "Courses",
+                type: "varchar(1000)",
+                maxLength: 1000,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Type",
+                table: "Courses",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReminderDays",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "ReminderMessage",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "Courses");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -259,6 +259,16 @@ namespace SysJaky_N.Migrations
                     b.Property<decimal>("Price")
                         .HasColumnType("decimal(65,30)");
 
+                    b.Property<int>("ReminderDays")
+                        .HasColumnType("int");
+
+                    b.Property<string>("ReminderMessage")
+                        .HasMaxLength(1000)
+                        .HasColumnType("varchar(1000)");
+
+                    b.Property<int>("Type")
+                        .HasColumnType("int");
+
                     b.Property<string>("Title")
                         .IsRequired()
                         .HasMaxLength(100)

--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -19,6 +19,14 @@ public class Course
     [DataType(DataType.Date)]
     public DateTime Date { get; set; }
 
+    [Range(0, int.MaxValue)]
+    public int ReminderDays { get; set; }
+
+    [StringLength(1000)]
+    public string? ReminderMessage { get; set; }
+
+    public CourseType Type { get; set; } = CourseType.Online;
+
     public int? CourseGroupId { get; set; }
 
     public virtual CourseGroup? CourseGroup { get; set; }
@@ -26,4 +34,11 @@ public class Course
     public int? CourseBlockId { get; set; }
 
     public virtual CourseBlock? CourseBlock { get; set; }
+}
+
+public enum CourseType
+{
+    Online,
+    InPerson,
+    Hybrid
 }

--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddSingleton<IConverter>(new SynchronizedConverter(new PdfTools
 builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp"));
 builder.Services.AddScoped<IEmailSender, EmailSender>();
 builder.Services.AddScoped<IAuditService, AuditService>();
+builder.Services.AddHostedService<CourseReminderService>();
 
 var app = builder.Build();
 

--- a/Services/CourseReminderService.cs
+++ b/Services/CourseReminderService.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Services;
+
+public class CourseReminderService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<CourseReminderService> _logger;
+
+    public CourseReminderService(IServiceScopeFactory scopeFactory, IEmailSender emailSender, ILogger<CourseReminderService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _emailSender = emailSender;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SendRemindersAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error sending course reminders");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromDays(1), stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                // ignored
+            }
+        }
+    }
+
+    private async Task SendRemindersAsync(CancellationToken token)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var today = DateTime.UtcNow.Date;
+        var courses = await context.Courses
+            .Where(c => c.ReminderDays > 0 && c.Date.Date == today.AddDays(c.ReminderDays))
+            .ToListAsync(token);
+
+        foreach (var course in courses)
+        {
+            var orders = await context.Orders
+                .Include(o => o.User)
+                .Include(o => o.Items)
+                .Where(o => o.Status == OrderStatus.Paid && o.Items.Any(i => i.CourseId == course.Id))
+                .ToListAsync(token);
+
+            var recipients = orders
+                .Select(o => o.User?.Email)
+                .Where(e => !string.IsNullOrWhiteSpace(e))
+                .Distinct();
+
+            var subject = $"Reminder: {course.Title}";
+            var message = course.ReminderMessage ?? $"The course {course.Title} is coming on {course.Date:d}.";
+
+            message += course.Type switch
+            {
+                CourseType.Online => " This course is online.",
+                CourseType.InPerson => " This course is in person.",
+                _ => " This course can be taken online or in person."
+            };
+
+            foreach (var email in recipients)
+            {
+                await _emailSender.SendEmailAsync(email!, subject, message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend Course model with reminder configuration and type (online, in person, hybrid)
- add CourseReminderService hosted service to email registered participants about upcoming courses
- register reminder service and create database migration

## Testing
- `apt-get update` *(fails: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c291a3b8988321b6413f580418dac1