### PR TITLE
Add wishlist functionality and company profiles

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -21,5 +21,21 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<AuditLog> AuditLogs { get; set; } = default!;
     public DbSet<ContactMessage> ContactMessages { get; set; } = default!;
     public DbSet<CourseBlock> CourseBlocks { get; set; } = default!;
+    public DbSet<WishlistItem> WishlistItems { get; set; } = default!;
+    public DbSet<CompanyProfile> CompanyProfiles { get; set; } = default!;
 
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+        builder.Entity<WishlistItem>().HasKey(w => new { w.UserId, w.CourseId });
+        builder.Entity<CompanyProfile>().HasIndex(c => c.ReferenceCode).IsUnique();
+        builder.Entity<CompanyProfile>()
+            .HasMany(c => c.Users)
+            .WithOne(u => u.CompanyProfile)
+            .HasForeignKey(u => u.CompanyProfileId);
+        builder.Entity<CompanyProfile>()
+            .HasOne(c => c.Manager)
+            .WithMany()
+            .HasForeignKey(c => c.ManagerId);
+    }
 }

--- a/Migrations/20251201000000_AddWishlistAndCompanies.cs
+++ b/Migrations/20251201000000_AddWishlistAndCompanies.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Migrations
+{
+    public partial class AddWishlistAndCompanies : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CompanyProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Name = table.Column<string>(type: "varchar(100)", maxLength: 100, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ReferenceCode = table.Column<string>(type: "varchar(100)", maxLength: 100, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ManagerId = table.Column<string>(type: "varchar(255)", nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompanyProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompanyProfiles_AspNetUsers_ManagerId",
+                        column: x => x.ManagerId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id");
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "WishlistItems",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "varchar(255)", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    CourseId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WishlistItems", x => new { x.UserId, x.CourseId });
+                    table.ForeignKey(
+                        name: "FK_WishlistItems_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WishlistItems_Courses_CourseId",
+                        column: x => x.CourseId,
+                        principalTable: "Courses",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompanyProfileId",
+                table: "AspNetUsers",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_CompanyProfileId",
+                table: "AspNetUsers",
+                column: "CompanyProfileId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompanyProfiles_ManagerId",
+                table: "CompanyProfiles",
+                column: "ManagerId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompanyProfiles_ReferenceCode",
+                table: "CompanyProfiles",
+                column: "ReferenceCode",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WishlistItems_CourseId",
+                table: "WishlistItems",
+                column: "CourseId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetUsers_CompanyProfiles_CompanyProfileId",
+                table: "AspNetUsers",
+                column: "CompanyProfileId",
+                principalTable: "CompanyProfiles",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetUsers_CompanyProfiles_CompanyProfileId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropTable(
+                name: "WishlistItems");
+
+            migrationBuilder.DropTable(
+                name: "CompanyProfiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_CompanyProfileId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "CompanyProfileId",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -195,11 +195,16 @@ namespace SysJaky_N.Migrations
                     b.Property<bool>("TwoFactorEnabled")
                         .HasColumnType("tinyint(1)");
 
+                    b.Property<int?>("CompanyProfileId")
+                        .HasColumnType("int");
+
                     b.Property<string>("UserName")
                         .HasMaxLength(256)
                         .HasColumnType("varchar(256)");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CompanyProfileId");
 
                     b.HasIndex("NormalizedEmail")
                         .HasDatabaseName("EmailIndex");
@@ -404,6 +409,54 @@ namespace SysJaky_N.Migrations
                     b.ToTable("OrderItems");
                 });
 
+            modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<string>("ManagerId")
+                        .HasColumnType("varchar(255)")
+                        .HasAnnotation("MySql:CharSet", "utf8mb4");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("varchar(100)")
+                        .HasAnnotation("MySql:CharSet", "utf8mb4");
+
+                    b.Property<string>("ReferenceCode")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("varchar(100)")
+                        .HasAnnotation("MySql:CharSet", "utf8mb4");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ManagerId");
+
+                    b.HasIndex("ReferenceCode")
+                        .IsUnique();
+
+                    b.ToTable("CompanyProfiles");
+                });
+
+            modelBuilder.Entity("SysJaky_N.Models.WishlistItem", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasColumnType("varchar(255)")
+                        .HasAnnotation("MySql:CharSet", "utf8mb4");
+
+                    b.Property<int>("CourseId")
+                        .HasColumnType("int");
+
+                    b.HasKey("UserId", "CourseId");
+
+                    b.HasIndex("CourseId");
+
+                    b.ToTable("WishlistItems");
+                });
+
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
                 {
                     b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
@@ -469,6 +522,15 @@ namespace SysJaky_N.Migrations
                     b.Navigation("CourseGroup");
                 });
 
+            modelBuilder.Entity("SysJaky_N.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("SysJaky_N.Models.CompanyProfile", "CompanyProfile")
+                        .WithMany("Users")
+                        .HasForeignKey("CompanyProfileId");
+
+                    b.Navigation("CompanyProfile");
+                });
+
             modelBuilder.Entity("SysJaky_N.Models.Order", b =>
                 {
                     b.HasOne("SysJaky_N.Models.DiscountCode", "DiscountCode")
@@ -506,6 +568,34 @@ namespace SysJaky_N.Migrations
             modelBuilder.Entity("SysJaky_N.Models.CourseGroup", b =>
                 {
                     b.Navigation("Courses");
+                });
+
+            modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>
+                {
+                    b.HasOne("SysJaky_N.Models.ApplicationUser", "Manager")
+                        .WithMany()
+                        .HasForeignKey("ManagerId");
+
+                    b.Navigation("Manager");
+                    b.Navigation("Users");
+                });
+
+            modelBuilder.Entity("SysJaky_N.Models.WishlistItem", b =>
+                {
+                    b.HasOne("SysJaky_N.Models.Course", "Course")
+                        .WithMany()
+                        .HasForeignKey("CourseId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SysJaky_N.Models.ApplicationUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Course");
+                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CourseBlock", b =>

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -4,4 +4,6 @@ namespace SysJaky_N.Models;
 
 public class ApplicationUser : IdentityUser
 {
+    public int? CompanyProfileId { get; set; }
+    public CompanyProfile? CompanyProfile { get; set; }
 }

--- a/Models/CompanyProfile.cs
+++ b/Models/CompanyProfile.cs
@@ -1,0 +1,11 @@
+namespace SysJaky_N.Models;
+
+public class CompanyProfile
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string ReferenceCode { get; set; } = string.Empty;
+    public string? ManagerId { get; set; }
+    public ApplicationUser? Manager { get; set; }
+    public List<ApplicationUser> Users { get; set; } = new();
+}

--- a/Models/WishlistItem.cs
+++ b/Models/WishlistItem.cs
@@ -1,0 +1,9 @@
+namespace SysJaky_N.Models;
+
+public class WishlistItem
+{
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser? User { get; set; }
+    public int CourseId { get; set; }
+    public Course? Course { get; set; }
+}

--- a/Pages/Account/Dashboard.cshtml
+++ b/Pages/Account/Dashboard.cshtml
@@ -33,8 +33,40 @@
         </tbody>
     </table>
 }
+  else
+  {
+      <p>Nemáte žádné nadcházející kurzy.</p>
+  }
+<h2>Wishlist</h2>
+@if (Model.WishlistItems.Any())
+{
+    <ul>
+    @foreach (var item in Model.WishlistItems)
+    {
+        <li>@item.Course?.Title</li>
+    }
+    </ul>
+}
 else
 {
-    <p>Nemáte žádné nadcházející kurzy.</p>
+    <p>Wishlist je prázdný.</p>
 }
 
+@if (Model.CompanyWishlistItems.Any())
+{
+    <h2>Wishlist uživatelů firmy</h2>
+    <table class="table">
+        <thead>
+            <tr><th>Uživatel</th><th>Kurz</th></tr>
+        </thead>
+        <tbody>
+        @foreach (var item in Model.CompanyWishlistItems)
+        {
+            <tr>
+                <td>@item.User?.Email</td>
+                <td>@item.Course?.Title</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}

--- a/Pages/Account/Dashboard.cshtml.cs
+++ b/Pages/Account/Dashboard.cshtml.cs
@@ -18,6 +18,8 @@ public class DashboardModel : PageModel
     }
 
     public List<OrderItem> UpcomingItems { get; set; } = new();
+    public List<WishlistItem> WishlistItems { get; set; } = new();
+    public List<WishlistItem> CompanyWishlistItems { get; set; } = new();
 
     public async Task OnGetAsync()
     {
@@ -32,6 +34,17 @@ public class DashboardModel : PageModel
                 && oi.Order.UserId == userId
                 && oi.Course != null
                 && oi.Course.Date >= DateTime.Today)
+            .ToListAsync();
+
+        WishlistItems = await _context.WishlistItems
+            .Include(w => w.Course)
+            .Where(w => w.UserId == userId)
+            .ToListAsync();
+
+        CompanyWishlistItems = await _context.WishlistItems
+            .Include(w => w.Course)
+            .Include(w => w.User)
+            .Where(w => w.User.CompanyProfile != null && w.User.CompanyProfile.ManagerId == userId)
             .ToListAsync();
     }
 }

--- a/Pages/Account/Manage.cshtml
+++ b/Pages/Account/Manage.cshtml
@@ -9,12 +9,21 @@
         <label asp-for="Input.Email"></label>
         <input asp-for="Input.Email" />
     </div>
-    <div>
-        <label asp-for="Input.PhoneNumber"></label>
-        <input asp-for="Input.PhoneNumber" />
-    </div>
-    <button type="submit">Save</button>
-</form>
+      <div>
+          <label asp-for="Input.PhoneNumber"></label>
+          <input asp-for="Input.PhoneNumber" />
+      </div>
+      <div>
+          <label asp-for="Input.ReferenceCode"></label>
+          <input asp-for="Input.ReferenceCode" />
+      </div>
+      <button type="submit">Save</button>
+  </form>
+
+  @if (Model.Company != null)
+  {
+      <p>Firma: @Model.Company.Name</p>
+  }
 
 @if (Model.Orders.Any())
 {

--- a/Pages/Account/Manage.cshtml.cs
+++ b/Pages/Account/Manage.cshtml.cs
@@ -35,7 +35,11 @@ public class ManageModel : PageModel
 
         [Phone]
         public string? PhoneNumber { get; set; }
+
+        public string? ReferenceCode { get; set; }
     }
+
+    public CompanyProfile? Company { get; set; }
 
     public async Task<IActionResult> OnGetAsync()
     {
@@ -52,6 +56,7 @@ public class ManageModel : PageModel
         };
 
         Orders = await _context.Orders.Where(o => o.UserId == user.Id).OrderByDescending(o => o.CreatedAt).ToListAsync();
+        Company = await _context.CompanyProfiles.FirstOrDefaultAsync(c => c.Id == user.CompanyProfileId);
 
         return Page();
     }
@@ -72,6 +77,16 @@ public class ManageModel : PageModel
         user.Email = Input.Email;
         user.UserName = Input.Email;
         user.PhoneNumber = Input.PhoneNumber;
+
+        if (!string.IsNullOrWhiteSpace(Input.ReferenceCode))
+        {
+            var company = await _context.CompanyProfiles.FirstOrDefaultAsync(c => c.ReferenceCode == Input.ReferenceCode);
+            if (company != null)
+            {
+                user.CompanyProfileId = company.Id;
+            }
+        }
+
         await _userManager.UpdateAsync(user);
         await _signInManager.RefreshSignInAsync(user);
 

--- a/Pages/Admin/Companies/Index.cshtml
+++ b/Pages/Admin/Companies/Index.cshtml
@@ -1,0 +1,35 @@
+@page
+@model SysJaky_N.Pages.Admin.Companies.IndexModel
+<h1>Companies</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="NewCompany.Name"></label>
+        <input asp-for="NewCompany.Name" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="NewCompany.ReferenceCode"></label>
+        <input asp-for="NewCompany.ReferenceCode" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="NewCompany.ManagerId"></label>
+        <input asp-for="NewCompany.ManagerId" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+
+<table class="table mt-3">
+    <thead>
+        <tr><th>Name</th><th>Reference Code</th><th>Manager</th></tr>
+    </thead>
+    <tbody>
+    @foreach (var company in Model.Companies)
+    {
+        <tr>
+            <td>@company.Name</td>
+            <td>@company.ReferenceCode</td>
+            <td>@company.Manager?.Email</td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/Pages/Admin/Companies/Index.cshtml.cs
+++ b/Pages/Admin/Companies/Index.cshtml.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Companies;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public List<CompanyProfile> Companies { get; set; } = new();
+
+    [BindProperty]
+    public CompanyProfile NewCompany { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        Companies = await _context.CompanyProfiles.Include(c => c.Manager).ToListAsync();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        if (!ModelState.IsValid)
+        {
+            Companies = await _context.CompanyProfiles.Include(c => c.Manager).ToListAsync();
+            return Page();
+        }
+        _context.CompanyProfiles.Add(NewCompany);
+        await _context.SaveChangesAsync();
+        return RedirectToPage();
+    }
+}

--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -23,6 +23,13 @@
     <button type="submit" class="btn btn-primary" aria-label="Add @Model.Course.Title to cart">Add to cart</button>
 </form>
 
+@if (User.Identity?.IsAuthenticated ?? false)
+{
+    <form method="post" asp-page-handler="AddToWishlist">
+        <button type="submit" class="btn btn-outline-secondary">Přidat do wishlistu</button>
+    </form>
+}
+
 @if (Model.Reviews.Any())
 {
     <h2>Reviews</h2>

--- a/Pages/Courses/Details.cshtml.cs
+++ b/Pages/Courses/Details.cshtml.cs
@@ -83,6 +83,23 @@ public class DetailsModel : PageModel
     }
 
     [Authorize]
+    public async Task<IActionResult> OnPostAddToWishlistAsync(int id)
+    {
+        var userId = _userManager.GetUserId(User);
+        if (userId == null)
+        {
+            return Challenge();
+        }
+        bool exists = await _context.WishlistItems.AnyAsync(w => w.UserId == userId && w.CourseId == id);
+        if (!exists)
+        {
+            _context.WishlistItems.Add(new WishlistItem { UserId = userId, CourseId = id });
+            await _context.SaveChangesAsync();
+        }
+        return RedirectToPage(new { id });
+    }
+
+    [Authorize]
     public async Task<IActionResult> OnPostReviewAsync(int id)
     {
         Course? course = await _context.Courses.FindAsync(id);


### PR DESCRIPTION
## Summary
- add wishlist items so users can save courses
- introduce company profiles with reference codes and admin page
- allow company managers to view users' wishlists

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2938449648321a9c3ead72078e414