### PR TITLE
Add admin pages for courses and orders

### DIFF
--- a/Pages/Admin/Courses/Index.cshtml
+++ b/Pages/Admin/Courses/Index.cshtml
@@ -1,0 +1,62 @@
+@page
+@model SysJaky_N.Pages.Admin.Courses.IndexModel
+@{
+    ViewData["Title"] = "Courses";
+}
+
+<h1>Courses</h1>
+
+<form method="get" class="mb-3">
+    <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" style="width:auto;display:inline-block" aria-label="Search courses" />
+    <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-control" style="width:auto;display:inline-block" aria-label="Filter by group">
+        <option value="">All Groups</option>
+    </select>
+    <button type="submit" class="btn btn-primary">Filter</button>
+    <a class="btn btn-secondary" asp-page="/Admin/Courses/Index">Reset</a>
+</form>
+
+<p>
+    <a asp-page="/Courses/Create">Create New</a>
+</p>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th>Group</th>
+            <th>Price</th>
+            <th>Date</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var item in Model.Courses)
+    {
+        <tr>
+            <td>@item.Title</td>
+            <td>@item.CourseGroup?.Name</td>
+            <td>@item.Price</td>
+            <td>@item.Date.ToString("d")</td>
+            <td>
+                <a asp-page="/Courses/Edit" asp-route-id="@item.Id">Edit</a>
+                <a asp-page="/Courses/Delete" asp-route-id="@item.Id">Delete</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>
+
+@if (Model.TotalPages > 1)
+{
+    <nav>
+        <ul class="pagination">
+            <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Previous</a>
+            </li>
+            <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Next</a>
+            </li>
+        </ul>
+    </nav>
+}
+

--- a/Pages/Admin/Courses/Index.cshtml.cs
+++ b/Pages/Admin/Courses/Index.cshtml.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Courses;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IList<Course> Courses { get; set; } = new List<Course>();
+
+    [BindProperty(SupportsGet = true)]
+    public int PageNumber { get; set; } = 1;
+
+    [BindProperty(SupportsGet = true)]
+    public int? CourseGroupId { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public string? SearchString { get; set; }
+
+    public SelectList CourseGroups { get; set; } = default!;
+
+    public int TotalPages { get; set; }
+
+    public async Task OnGetAsync()
+    {
+        const int pageSize = 10;
+        CourseGroups = new SelectList(_context.CourseGroups, "Id", "Name");
+        var query = _context.Courses
+            .Include(c => c.CourseGroup)
+            .AsQueryable();
+
+        if (CourseGroupId.HasValue)
+        {
+            query = query.Where(c => c.CourseGroupId == CourseGroupId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(SearchString))
+        {
+            var pattern = $"%{SearchString.Trim()}%";
+            query = query.Where(c => EF.Functions.Like(c.Title, pattern));
+        }
+
+        query = query.OrderBy(c => c.Date);
+
+        var count = await query.CountAsync();
+        TotalPages = (int)Math.Ceiling(count / (double)pageSize);
+        Courses = await query.Skip((PageNumber - 1) * pageSize).Take(pageSize).ToListAsync();
+    }
+}
+

--- a/Pages/Admin/Orders/Index.cshtml
+++ b/Pages/Admin/Orders/Index.cshtml
@@ -1,0 +1,35 @@
+@page
+@model SysJaky_N.Pages.Admin.Orders.IndexModel
+@{
+    ViewData["Title"] = "Orders";
+}
+
+<h1>Orders</h1>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Id</th>
+            <th>Date</th>
+            <th>Status</th>
+            <th>Total</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach (var order in Model.Orders)
+    {
+        <tr>
+            <td>@order.Id</td>
+            <td>@order.CreatedAt.ToString("g")</td>
+            <td>@order.Status</td>
+            <td>@order.TotalPrice</td>
+            <td>
+                <a asp-page="/Orders/Details" asp-route-id="@order.Id">Details</a> |
+                <a asp-page="/Orders/Edit" asp-route-id="@order.Id">Change Status</a>
+            </td>
+        </tr>
+    }
+    </tbody>
+</table>
+

--- a/Pages/Admin/Orders/Index.cshtml.cs
+++ b/Pages/Admin/Orders/Index.cshtml.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Orders;
+
+[Authorize(Roles = "Admin")]
+public class IndexModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public IndexModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IList<Order> Orders { get; set; } = new List<Order>();
+
+    public async Task OnGetAsync()
+    {
+        Orders = await _context.Orders
+            .Include(o => o.Items)
+            .OrderByDescending(o => o.CreatedAt)
+            .ToListAsync();
+    }
+}
+

--- a/Pages/Admin/_Layout.cshtml
+++ b/Pages/Admin/_Layout.cshtml
@@ -24,13 +24,13 @@
                     <a class="nav-link" asp-page="/Admin/Users/Index">Users</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" asp-page="/Admin/Courses/Index">Courses</a>
+                    <a class="nav-link" asp-page="/Admin/Courses/Index">Manage Courses</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" asp-page="/Admin/CourseBlocks/Index">Course Blocks</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" asp-page="/Admin/Orders/Index">Orders</a>
+                    <a class="nav-link" asp-page="/Admin/Orders/Index">Manage Orders</a>
                 </li>
             </ul>
             <hr />


### PR DESCRIPTION
## Summary
- add dedicated admin pages for managing courses and orders
- update admin layout links to point to new management pages

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2980792588321a7b9fdaedcc3a14a