### PR TITLE
Strengthen account validation and add CAPTCHA

### DIFF
--- a/Pages/Account/Login.cshtml
+++ b/Pages/Account/Login.cshtml
@@ -8,10 +8,17 @@
     <div>
         <label asp-for="Input.Email"></label>
         <input asp-for="Input.Email" />
+        <span asp-validation-for="Input.Email"></span>
     </div>
     <div>
         <label asp-for="Input.Password"></label>
         <input asp-for="Input.Password" type="password" />
+        <span asp-validation-for="Input.Password"></span>
+    </div>
+    <div>
+        <div class="altcha" data-target="#captcha-input"></div>
+        <input type="hidden" id="captcha-input" asp-for="Input.Captcha" />
+        <span asp-validation-for="Input.Captcha"></span>
     </div>
     <div>
         <input asp-for="Input.RememberMe" />
@@ -22,4 +29,5 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script src="https://cdn.jsdelivr.net/npm/altcha@latest/dist/altcha.min.js"></script>
 }

--- a/Pages/Account/Login.cshtml.cs
+++ b/Pages/Account/Login.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SysJaky_N.Models;
 using SysJaky_N.Services;
+using System.ComponentModel.DataAnnotations;
 
 namespace SysJaky_N.Pages.Account;
 
@@ -22,9 +23,20 @@ public class LoginModel : PageModel
 
     public class InputModel
     {
+        [Required]
+        [EmailAddress]
         public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [StringLength(100, MinimumLength = 6)]
+        [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Password must contain upper and lower case letters and numbers.")]
         public string Password { get; set; } = string.Empty;
+
         public bool RememberMe { get; set; }
+
+        [Required(ErrorMessage = "Captcha verification is required.")]
+        public string Captcha { get; set; } = string.Empty;
     }
 
     public void OnGet()
@@ -35,6 +47,12 @@ public class LoginModel : PageModel
     {
         if (!ModelState.IsValid)
         {
+            return Page();
+        }
+
+        if (string.IsNullOrEmpty(Input.Captcha))
+        {
+            ModelState.AddModelError(string.Empty, "Captcha verification failed.");
             return Page();
         }
 

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -8,14 +8,22 @@
     <div>
         <label asp-for="Input.Email"></label>
         <input asp-for="Input.Email" />
+        <span asp-validation-for="Input.Email"></span>
     </div>
     <div>
         <label asp-for="Input.Password"></label>
         <input asp-for="Input.Password" type="password" />
+        <span asp-validation-for="Input.Password"></span>
+    </div>
+    <div>
+        <div class="altcha" data-target="#captcha-input"></div>
+        <input type="hidden" id="captcha-input" asp-for="Input.Captcha" />
+        <span asp-validation-for="Input.Captcha"></span>
     </div>
     <button type="submit">Register</button>
 </form>
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
+    <script src="https://cdn.jsdelivr.net/npm/altcha@latest/dist/altcha.min.js"></script>
 }

--- a/Pages/Account/Register.cshtml.cs
+++ b/Pages/Account/Register.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using SysJaky_N.Models;
 using SysJaky_N.Services;
+using System.ComponentModel.DataAnnotations;
 
 namespace SysJaky_N.Pages.Account;
 
@@ -24,8 +25,18 @@ public class RegisterModel : PageModel
 
     public class InputModel
     {
+        [Required]
+        [EmailAddress]
         public string Email { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [StringLength(100, MinimumLength = 6)]
+        [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Password must contain upper and lower case letters and numbers.")]
         public string Password { get; set; } = string.Empty;
+
+        [Required(ErrorMessage = "Captcha verification is required.")]
+        public string Captcha { get; set; } = string.Empty;
     }
 
     public void OnGet()
@@ -36,6 +47,12 @@ public class RegisterModel : PageModel
     {
         if (!ModelState.IsValid)
         {
+            return Page();
+        }
+
+        if (string.IsNullOrEmpty(Input.Captcha))
+        {
+            ModelState.AddModelError(string.Empty, "Captcha verification failed.");
             return Page();
         }
 


### PR DESCRIPTION
## Summary
- require email and strong password on login and registration
- show field validation messages and integrate Altcha CAPTCHA widgets
- add simple server-side CAPTCHA checks

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a5d3372c8321a765285358f696d3