### PR TITLE
Fix invalid Users navigation in EF snapshot

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -655,7 +655,6 @@ namespace SysJaky_N.Migrations
                         .HasForeignKey("ManagerId");
 
                     b.Navigation("Manager");
-                    b.Navigation("Users");
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.WishlistItem", b =>


### PR DESCRIPTION
## Summary
- remove obsolete `Users` navigation from `ApplicationDbContextModelSnapshot` to restore EF migration generation

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet ef migrations add TestMigration` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c2967b588321930fed41eabfe1ec