### PR TITLE
Add auth modal with Altcha captcha

### DIFF
--- a/Pages/Account/Login.cshtml
+++ b/Pages/Account/Login.cshtml
@@ -29,5 +29,4 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-    <script type="module" src="~/lib/altcha/altcha.min.js"></script>
 }

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -25,5 +25,4 @@
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-    <script type="module" src="~/lib/altcha/altcha.min.js"></script>
 }

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -31,8 +31,15 @@
     </div>
 </section>
 
+<section class="py-5 bg-white">
+    <div class="container">
+        <h2 class="text-center mb-4">Why Choose Our Platform?</h2>
+        <p class="text-center">Our courses are crafted by experts and delivered in an accessible format that helps you learn quickly and effectively.</p>
+    </div>
+</section>
+
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
     <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
-    <a class="btn btn-primary" asp-page="/Account/Register">Registrace</a>
+    <a class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#authModal">Join Now</a>
 </div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/SysJaky_N.styles.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/lib/altcha/altcha.min.css" />
 </head>
 <body>
     <a class="visually-hidden-focusable" href="#main-content">Přeskočit na obsah</a>
@@ -52,10 +53,7 @@
                         @if (!User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
-                                <a class="btn btn-outline-light me-2" asp-page="/Account/Login" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Account/Login" ? "page" : null)">Login</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="btn btn-primary" asp-page="/Account/Register" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Account/Register" ? "page" : null)">Register</a>
+                                <a class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#authModal">Login / Register</a>
                             </li>
                         }
                         else
@@ -83,7 +81,72 @@
 
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/lib/altcha/altcha.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+
+    @if (!User.Identity.IsAuthenticated)
+    {
+        <div class="modal fade" id="authModal" tabindex="-1" aria-labelledby="authModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="authModalLabel">Login</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <ul class="nav nav-tabs mb-3" id="authTab" role="tablist">
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link active" id="login-tab" data-bs-toggle="tab" data-bs-target="#login-tab-pane" type="button" role="tab">Login</button>
+                            </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="register-tab" data-bs-toggle="tab" data-bs-target="#register-tab-pane" type="button" role="tab">Register</button>
+                            </li>
+                        </ul>
+                        <div class="tab-content" id="authTabContent">
+                            <div class="tab-pane fade show active" id="login-tab-pane" role="tabpanel" aria-labelledby="login-tab">
+                                <form method="post" asp-page="/Account/Login">
+                                    <div class="mb-3">
+                                        <label for="loginEmail" class="form-label">Email</label>
+                                        <input type="email" class="form-control" id="loginEmail" name="Input.Email" required />
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="loginPassword" class="form-label">Password</label>
+                                        <input type="password" class="form-control" id="loginPassword" name="Input.Password" required />
+                                    </div>
+                                    <div class="mb-3">
+                                        <div class="altcha" data-target="#login-captcha"></div>
+                                        <input type="hidden" id="login-captcha" name="Input.Captcha" />
+                                    </div>
+                                    <div class="mb-3 form-check">
+                                        <input type="checkbox" class="form-check-input" id="rememberMe" name="Input.RememberMe" />
+                                        <label class="form-check-label" for="rememberMe">Remember me</label>
+                                    </div>
+                                    <button type="submit" class="btn btn-primary w-100">Login</button>
+                                </form>
+                            </div>
+                            <div class="tab-pane fade" id="register-tab-pane" role="tabpanel" aria-labelledby="register-tab">
+                                <form method="post" asp-page="/Account/Register">
+                                    <div class="mb-3">
+                                        <label for="registerEmail" class="form-label">Email</label>
+                                        <input type="email" class="form-control" id="registerEmail" name="Input.Email" required />
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="registerPassword" class="form-label">Password</label>
+                                        <input type="password" class="form-control" id="registerPassword" name="Input.Password" required />
+                                    </div>
+                                    <div class="mb-3">
+                                        <div class="altcha" data-target="#register-captcha"></div>
+                                        <input type="hidden" id="register-captcha" name="Input.Captcha" />
+                                    </div>
+                                    <button type="submit" class="btn btn-success w-100">Register</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
 
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/wwwroot/lib/altcha/altcha.min.css
+++ b/wwwroot/lib/altcha/altcha.min.css
@@ -1,0 +1,3 @@
+.altcha,altcha-widget{display:flex;align-items:center;gap:.5rem;border:1px solid #ced4da;border-radius:.25rem;padding:.5rem;background:#fff}
+.altcha-spinner{width:1.5rem;height:1.5rem;border:2px solid #ccc;border-top-color:#0d6efd;border-radius:50%;animation:altcha-spin 1s linear infinite}
+@keyframes altcha-spin{to{transform:rotate(360deg)}}


### PR DESCRIPTION
## Summary
- Replace separate login and register links with a unified modal containing tabbed forms.
- Load Altcha captcha library and styling globally and embed challenges in both forms.
- Polish landing page with additional promotional section and modal-based call to action.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d3cb67b483218617461a15b33e70