### PR TITLE
Fix Altcha widget loading

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -81,7 +81,7 @@
 
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="~/lib/altcha/altcha.min.js"></script>
+    <script type="module" src="~/lib/altcha/altcha.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
 
     @if (!User.Identity.IsAuthenticated)


### PR DESCRIPTION
## Summary
- load Altcha script as ES module to prevent `Unexpected token 'export'`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d584feb08321978e50eb095a464e