### PR TITLE
Replace legacy Altcha div with widget

### DIFF
--- a/Pages/Account/Login.cshtml
+++ b/Pages/Account/Login.cshtml
@@ -16,8 +16,7 @@
         <span asp-validation-for="Input.Password"></span>
     </div>
     <div>
-        <div class="altcha" data-target="#captcha-input"></div>
-        <input type="hidden" id="captcha-input" asp-for="Input.Captcha" />
+        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" refetchonexpire></altcha-widget>
         <span asp-validation-for="Input.Captcha"></span>
     </div>
     <div>

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -16,8 +16,7 @@
         <span asp-validation-for="Input.Password"></span>
     </div>
     <div>
-        <div class="altcha" data-target="#captcha-input"></div>
-        <input type="hidden" id="captcha-input" asp-for="Input.Captcha" />
+        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" refetchonexpire></altcha-widget>
         <span asp-validation-for="Input.Captcha"></span>
     </div>
     <button type="submit">Register</button>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -113,8 +113,7 @@
                                         <input type="password" class="form-control" id="loginPassword" name="Input.Password" required />
                                     </div>
                                     <div class="mb-3">
-                                        <div class="altcha" data-target="#login-captcha"></div>
-                                        <input type="hidden" id="login-captcha" name="Input.Captcha" />
+                                        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" refetchonexpire></altcha-widget>
                                     </div>
                                     <div class="mb-3 form-check">
                                         <input type="hidden" name="Input.RememberMe" value="false" />
@@ -135,8 +134,7 @@
                                         <input type="password" class="form-control" id="registerPassword" name="Input.Password" required />
                                     </div>
                                     <div class="mb-3">
-                                        <div class="altcha" data-target="#register-captcha"></div>
-                                        <input type="hidden" id="register-captcha" name="Input.Captcha" />
+                                        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" refetchonexpire></altcha-widget>
                                     </div>
                                     <button type="submit" class="btn btn-success w-100">Register</button>
                                 </form>


### PR DESCRIPTION
## Summary
- use `<altcha-widget>` in account login and registration pages
- switch layout modal forms to `<altcha-widget>` for Altcha challenges

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ca87f6c08321a2a3e199527b9c4a