### PR TITLE
Add Altcha challenge and verification endpoints

### DIFF
--- a/Controllers/AltchaController.cs
+++ b/Controllers/AltchaController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using SysJaky_N.Services;
+
+namespace SysJaky_N.Controllers;
+
+[ApiController]
+[Route("altcha")]
+public class AltchaController : ControllerBase
+{
+    private readonly IAltchaService _altchaService;
+
+    public AltchaController(IAltchaService altchaService)
+    {
+        _altchaService = altchaService;
+    }
+
+    [HttpGet("challenge")]
+    public ActionResult<AltchaChallenge> GetChallenge()
+    {
+        return _altchaService.CreateChallenge();
+    }
+
+    [HttpPost("verify")]
+    public ActionResult<object> Verify([FromBody] AltchaVerifyPayload payload)
+    {
+        var success = _altchaService.Verify(payload);
+        return new { success };
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession();
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddRazorPages().AddViewLocalization();
+builder.Services.AddControllers();
 builder.Services.Configure<PaymentGatewayOptions>(builder.Configuration.GetSection("PaymentGateway"));
 builder.Services.AddScoped<PaymentService>();
 builder.Services.AddSingleton<IConverter>(new SynchronizedConverter(new PdfTools()));
@@ -38,6 +39,9 @@ builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp")
 builder.Services.AddScoped<IEmailSender, EmailSender>();
 builder.Services.AddScoped<IAuditService, AuditService>();
 builder.Services.AddHostedService<CourseReminderService>();
+builder.Services.AddMemoryCache();
+builder.Services.Configure<AltchaOptions>(builder.Configuration.GetSection("Altcha"));
+builder.Services.AddScoped<IAltchaService, AltchaService>();
 
 var app = builder.Build();
 
@@ -74,6 +78,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapRazorPages();
+app.MapControllers();
 app.MapPost("/payment/webhook", async (HttpRequest request, PaymentService paymentService) =>
 {
     await paymentService.HandleWebhookAsync(request);

--- a/Services/AltchaService.cs
+++ b/Services/AltchaService.cs
@@ -1,0 +1,73 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace SysJaky_N.Services;
+
+public class AltchaOptions
+{
+    public string ChallengeRoute { get; set; } = "/altcha/challenge";
+    public string VerifyRoute { get; set; } = "/altcha/verify";
+    public int TokenTtlSeconds { get; set; } = 300;
+    public int Difficulty { get; set; } = 4;
+}
+
+public class AltchaChallenge
+{
+    public string Challenge { get; set; } = string.Empty;
+    public int Difficulty { get; set; }
+}
+
+public class AltchaVerifyPayload
+{
+    public string Challenge { get; set; } = string.Empty;
+    public long Number { get; set; }
+}
+
+public interface IAltchaService
+{
+    AltchaChallenge CreateChallenge();
+    bool Verify(AltchaVerifyPayload payload);
+}
+
+public class AltchaService : IAltchaService
+{
+    private readonly IMemoryCache _cache;
+    private readonly AltchaOptions _options;
+
+    public AltchaService(IOptions<AltchaOptions> options, IMemoryCache cache)
+    {
+        _options = options.Value;
+        _cache = cache;
+    }
+
+    public AltchaChallenge CreateChallenge()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        var token = Convert.ToBase64String(bytes);
+        _cache.Set(token, true, TimeSpan.FromSeconds(_options.TokenTtlSeconds));
+        return new AltchaChallenge
+        {
+            Challenge = token,
+            Difficulty = _options.Difficulty
+        };
+    }
+
+    public bool Verify(AltchaVerifyPayload payload)
+    {
+        if (!_cache.TryGetValue(payload.Challenge, out _))
+            return false;
+
+        using var sha = SHA256.Create();
+        var input = Encoding.UTF8.GetBytes($"{payload.Challenge}:{payload.Number}");
+        var hash = sha.ComputeHash(input);
+        var hex = Convert.ToHexString(hash).ToLowerInvariant();
+        var prefix = new string('0', _options.Difficulty);
+        var ok = hex.StartsWith(prefix);
+        if (ok)
+            _cache.Remove(payload.Challenge);
+        return ok;
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -29,5 +29,11 @@
     "User": "",
     "Password": "",
     "From": ""
+  },
+  "Altcha": {
+    "ChallengeRoute": "/altcha/challenge",
+    "VerifyRoute": "/altcha/verify",
+    "TokenTtlSeconds": 300,
+    "Difficulty": 4
   }
 }


### PR DESCRIPTION
## Summary
- configure Altcha options and register Altcha service with memory cache
- expose `/altcha/challenge` and `/altcha/verify` controller endpoints
- add application settings for Altcha challenge and verification

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cb8526a88321889fa9175ec09ff1