### PR TITLE
Add Altcha widget fallback, logging, and rate limiting

### DIFF
--- a/Controllers/AltchaController.cs
+++ b/Controllers/AltchaController.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
 using SysJaky_N.Services;
+using Microsoft.Extensions.Logging;
 
 namespace SysJaky_N.Controllers;
 
@@ -8,22 +10,37 @@ namespace SysJaky_N.Controllers;
 public class AltchaController : ControllerBase
 {
     private readonly IAltchaService _altchaService;
+    private readonly ILogger<AltchaController> _logger;
 
-    public AltchaController(IAltchaService altchaService)
+    public AltchaController(IAltchaService altchaService, ILogger<AltchaController> logger)
     {
         _altchaService = altchaService;
+        _logger = logger;
     }
 
     [HttpGet("challenge")]
     public ActionResult<AltchaChallenge> GetChallenge()
     {
+        var correlationId = HttpContext.TraceIdentifier;
+        _logger.LogInformation("ChallengeIssued {CorrelationId}", correlationId);
         return _altchaService.CreateChallenge();
     }
 
     [HttpPost("verify")]
+    [EnableRateLimiting("AltchaVerify")]
     public ActionResult<object> Verify([FromBody] AltchaVerifyPayload payload)
     {
+        var correlationId = HttpContext.TraceIdentifier;
+        _logger.LogInformation("VerifyAttempted {CorrelationId}", correlationId);
         var success = _altchaService.Verify(payload);
+        if (success)
+        {
+            _logger.LogInformation("VerifySucceeded {CorrelationId}", correlationId);
+        }
+        else
+        {
+            _logger.LogWarning("VerifyFailed {CorrelationId}", correlationId);
+        }
         return new { success };
     }
 }

--- a/Pages/Account/Login.cshtml
+++ b/Pages/Account/Login.cshtml
@@ -17,6 +17,7 @@
     </div>
     <div>
         <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+        <noscript>Prosím povolte JavaScript.</noscript>
         <span asp-validation-for="Input.Captcha"></span>
     </div>
     <div>

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -17,6 +17,7 @@
     </div>
     <div>
         <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+        <noscript>Prosím povolte JavaScript.</noscript>
         <span asp-validation-for="Input.Captcha"></span>
     </div>
     <button type="submit">Register</button>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -104,6 +104,7 @@
                         <div class="tab-content" id="authTabContent">
                             <div class="tab-pane fade show active" id="login-tab-pane" role="tabpanel" aria-labelledby="login-tab">
                                 <form method="post" asp-page="/Account/Login">
+                                    <div asp-validation-summary="All" class="text-danger"></div>
                                     <div class="mb-3">
                                         <label for="loginEmail" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="loginEmail" name="Input.Email" required />
@@ -114,6 +115,7 @@
                                     </div>
                                     <div class="mb-3">
                                         <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+                                        <noscript>Prosím povolte JavaScript.</noscript>
                                     </div>
                                     <div class="mb-3 form-check">
                                         <input type="hidden" name="Input.RememberMe" value="false" />
@@ -125,6 +127,7 @@
                             </div>
                             <div class="tab-pane fade" id="register-tab-pane" role="tabpanel" aria-labelledby="register-tab">
                                 <form method="post" asp-page="/Account/Register">
+                                    <div asp-validation-summary="All" class="text-danger"></div>
                                     <div class="mb-3">
                                         <label for="registerEmail" class="form-label">Email</label>
                                         <input type="email" class="form-control" id="registerEmail" name="Input.Email" required />
@@ -135,6 +138,7 @@
                                     </div>
                                     <div class="mb-3">
                                         <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+                                        <noscript>Prosím povolte JavaScript.</noscript>
                                     </div>
                                     <button type="submit" class="btn btn-success w-100">Register</button>
                                 </form>


### PR DESCRIPTION
## Summary
- Add noscript fallback and validation summary for Altcha widget forms
- Log Altcha challenge and verification events with correlation IDs
- Rate limit Altcha verification requests

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c40ab793808321acfe251e2dade6a0