### PR TITLE
Fix Altcha widget URL paths

### DIFF
--- a/Pages/Account/Login.cshtml
+++ b/Pages/Account/Login.cshtml
@@ -16,7 +16,7 @@
         <span asp-validation-for="Input.Password"></span>
     </div>
     <div>
-        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+        <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
         <noscript>Prosím povolte JavaScript.</noscript>
         <span asp-validation-for="Input.Captcha"></span>
     </div>

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -16,7 +16,7 @@
         <span asp-validation-for="Input.Password"></span>
     </div>
     <div>
-        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+        <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
         <noscript>Prosím povolte JavaScript.</noscript>
         <span asp-validation-for="Input.Captcha"></span>
     </div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -114,7 +114,7 @@
                                         <input type="password" class="form-control" id="loginPassword" name="Input.Password" required />
                                     </div>
                                     <div class="mb-3">
-                                        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+                                        <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
                                         <noscript>Prosím povolte JavaScript.</noscript>
                                     </div>
                                     <div class="mb-3 form-check">
@@ -137,7 +137,7 @@
                                         <input type="password" class="form-control" id="registerPassword" name="Input.Password" required />
                                     </div>
                                     <div class="mb-3">
-                                        <altcha-widget name="altcha" challengeurl="~/altcha/challenge" verifyurl="~/altcha/verify" workerurl="~/lib/altcha/altcha.worker.js" refetchonexpire></altcha-widget>
+                                        <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
                                         <noscript>Prosím povolte JavaScript.</noscript>
                                     </div>
                                     <button type="submit" class="btn btn-success w-100">Register</button>


### PR DESCRIPTION
## Summary
- resolve Altcha widget endpoint URLs with `Url.Content` so the challenge and verify requests hit the correct server routes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c440b218b08321a1f5448cffad0a50