### PR TITLE
Add salt to Altcha challenge

### DIFF
--- a/Models/AltchaChallenge.cs
+++ b/Models/AltchaChallenge.cs
@@ -4,5 +4,6 @@ public class AltchaChallenge
 {
     public string Id { get; set; } = string.Empty;
     public string Question { get; set; } = string.Empty;
+    public string Salt { get; set; } = string.Empty;
 }
 

--- a/Services/AltchaService.cs
+++ b/Services/AltchaService.cs
@@ -15,7 +15,9 @@ public class AltchaService : IAltchaService
         var b = _random.Next(1, 10);
         var id = Guid.NewGuid().ToString("N");
         _solutions[id] = a + b;
-        return new AltchaChallenge { Id = id, Question = $"{a} + {b}" };
+        var expires = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds();
+        var salt = $"{Guid.NewGuid()}?expires={expires}";
+        return new AltchaChallenge { Id = id, Question = $"{a} + {b}", Salt = salt };
     }
 
     public bool Verify(AltchaVerifyPayload payload)


### PR DESCRIPTION
## Summary
- provide salt with expiration in Altcha challenge response
- add salt field to AltchaChallenge model

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4422224408321a380eca323056bcf