### PR TITLE
Use singleton AltchaService with secure randomness

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -40,11 +40,10 @@ builder.Services.AddSingleton<IConverter>(new SynchronizedConverter(new PdfTools
 builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp"));
 builder.Services.AddScoped<IEmailSender, EmailSender>();
 builder.Services.AddScoped<IAuditService, AuditService>();
-builder.Services.AddScoped<IAltchaService, AltchaService>();
 builder.Services.AddHostedService<CourseReminderService>();
 builder.Services.AddMemoryCache();
 builder.Services.Configure<AltchaOptions>(builder.Configuration.GetSection("Altcha"));
-builder.Services.AddScoped<IAltchaService, AltchaService>();
+builder.Services.AddSingleton<IAltchaService, AltchaService>();
 
 builder.Services.AddRateLimiter(options =>
 {

--- a/Services/AltchaService.cs
+++ b/Services/AltchaService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Security.Cryptography;
 using System.Text.Json;
 using SysJaky_N.Models;
 
@@ -7,12 +8,11 @@ namespace SysJaky_N.Services;
 public class AltchaService : IAltchaService
 {
     private readonly ConcurrentDictionary<string, int> _solutions = new();
-    private readonly Random _random = new();
 
     public AltchaChallenge CreateChallenge()
     {
-        var a = _random.Next(1, 10);
-        var b = _random.Next(1, 10);
+        var a = RandomNumberGenerator.GetInt32(1, 10);
+        var b = RandomNumberGenerator.GetInt32(1, 10);
         var id = Guid.NewGuid().ToString("N");
         _solutions[id] = a + b;
         var expires = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds();


### PR DESCRIPTION
## Summary
- Register `IAltchaService` as a singleton in Program setup
- Generate Altcha challenges using `RandomNumberGenerator` for thread-safe randomness

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c44c7b755883218be4ee21436fca57