### PR TITLE
Implement proof-of-work Altcha verification

### DIFF
--- a/Models/AltchaChallenge.cs
+++ b/Models/AltchaChallenge.cs
@@ -1,13 +1,33 @@
 namespace SysJaky_N.Models;
 
+/// <summary>
+/// Represents a proof-of-work challenge for Altcha verification.
+/// </summary>
 public class AltchaChallenge
 {
-    public string Id { get; set; } = string.Empty;
-    public string Challenge { get; set; } = string.Empty;
-    public string Question { get; set; } = string.Empty;
-    public string Salt { get; set; } = string.Empty;
-    public string Algorithm { get; set; } = "SHA-256";
-    public string Signature { get; set; } = string.Empty;
+    /// <summary>
+    /// Random seed used for the proof-of-work calculation.
+    /// </summary>
+    public string Seed { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Required difficulty (number of leading zeros) for the hash.
+    /// </summary>
+    public int Difficulty { get; set; }
+
+    /// <summary>
+    /// Salt containing an expiry query string to prevent replay.
+    /// </summary>
+    public string Salt { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Hash algorithm used for the challenge.
+    /// </summary>
+    public string Algorithm { get; set; } = "SHA-256";
+
+    /// <summary>
+    /// HMAC signature of the challenge parameters.
+    /// </summary>
+    public string Signature { get; set; } = string.Empty;
 }
 

--- a/Models/AltchaOptions.cs
+++ b/Models/AltchaOptions.cs
@@ -1,7 +1,23 @@
 namespace SysJaky_N.Models;
 
+/// <summary>
+/// Configuration options for the Altcha service.
+/// </summary>
 public class AltchaOptions
 {
+    /// <summary>
+    /// Secret key used for signing challenges.
+    /// </summary>
     public string SecretKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Proof-of-work difficulty (number of leading zeros).
+    /// </summary>
+    public int Difficulty { get; set; } = 4;
+
+    /// <summary>
+    /// Lifetime of a challenge token in seconds.
+    /// </summary>
+    public int TokenTtlSeconds { get; set; } = 300;
 }
 

--- a/Models/AltchaVerifyPayload.cs
+++ b/Models/AltchaVerifyPayload.cs
@@ -1,8 +1,38 @@
 namespace SysJaky_N.Models;
 
+/// <summary>
+/// Payload used to verify an Altcha proof-of-work solution.
+/// </summary>
 public class AltchaVerifyPayload
 {
-    public string Id { get; set; } = string.Empty;
-    public int Answer { get; set; }
+    /// <summary>
+    /// The seed from the original challenge.
+    /// </summary>
+    public string Seed { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Required difficulty of the challenge.
+    /// </summary>
+    public int Difficulty { get; set; }
+
+    /// <summary>
+    /// Salt containing expiry information.
+    /// </summary>
+    public string Salt { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Hash algorithm used.
+    /// </summary>
+    public string Algorithm { get; set; } = "SHA-256";
+
+    /// <summary>
+    /// HMAC signature proving the challenge validity.
+    /// </summary>
+    public string Signature { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Nonce solving the proof-of-work.
+    /// </summary>
+    public int Nonce { get; set; }
 }
 

--- a/Services/AltchaService.cs
+++ b/Services/AltchaService.cs
@@ -1,46 +1,47 @@
 using System;
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SysJaky_N.Models;
 
 namespace SysJaky_N.Services;
 
+/// <summary>
+/// Service implementing Altcha proof-of-work challenge generation and verification.
+/// </summary>
 public class AltchaService : IAltchaService
 {
-    private readonly ConcurrentDictionary<string, (int Answer, DateTime Expires)> _solutions = new();
     private readonly string _secretKey;
+    private readonly int _difficulty;
+    private readonly int _ttlSeconds;
 
     public AltchaService(IOptions<AltchaOptions> options)
     {
         _secretKey = options.Value.SecretKey;
+        _difficulty = options.Value.Difficulty;
+        _ttlSeconds = options.Value.TokenTtlSeconds;
     }
 
     public AltchaChallenge CreateChallenge()
     {
-        var a = RandomNumberGenerator.GetInt32(1, 10);
-        var b = RandomNumberGenerator.GetInt32(1, 10);
-        var challengeId = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
-
-        var expiresAt = DateTime.UtcNow.AddMinutes(5);
-        _solutions[challengeId] = (a + b, expiresAt);
-        var expires = new DateTimeOffset(expiresAt).ToUnixTimeSeconds();
+        var seed = Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+        var expires = DateTimeOffset.UtcNow.AddSeconds(_ttlSeconds).ToUnixTimeSeconds();
         var salt = $"{Guid.NewGuid()}?expires={expires}";
         const string algorithm = "SHA-256";
-        var challenge = new AltchaChallenge
-        {
-            Id = challengeId,
-            Challenge = challengeId,
-            Question = $"{a} + {b}",
-            Salt = salt,
-            Algorithm = algorithm
-        };
-        var data = $"{challenge.Challenge}:{challenge.Salt}:{challenge.Algorithm}";
+        var data = $"{seed}:{_difficulty}:{salt}:{algorithm}";
         using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secretKey));
-        challenge.Signature = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(data))).ToLowerInvariant();
-        return challenge;
+        var signature = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(data))).ToLowerInvariant();
+
+        return new AltchaChallenge
+        {
+            Seed = seed,
+            Difficulty = _difficulty,
+            Salt = salt,
+            Algorithm = algorithm,
+            Signature = signature
+        };
     }
 
     public bool Verify(AltchaVerifyPayload payload)
@@ -50,33 +51,36 @@ public class AltchaService : IAltchaService
             return false;
         }
 
-        // remove expired challenges
-        var now = DateTime.UtcNow;
-        foreach (var kv in _solutions.ToArray())
+        // Check expiry from salt query string
+        var expires = ExtractExpiry(payload.Salt);
+        if (expires == null || DateTimeOffset.UtcNow.ToUnixTimeSeconds() > expires)
         {
-            if (kv.Value.Expires <= now)
-            {
-                _solutions.TryRemove(kv.Key, out _);
-            }
+            return false;
         }
 
-        if (_solutions.TryGetValue(payload.Id, out var expected))
+        // Validate signature
+        var data = $"{payload.Seed}:{payload.Difficulty}:{payload.Salt}:{payload.Algorithm}";
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secretKey));
+        var expected = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(data))).ToLowerInvariant();
+        if (!CryptographicOperations.FixedTimeEquals(Convert.FromHexString(expected), Convert.FromHexString(payload.Signature)))
         {
-            if (expected.Expires <= now)
-            {
-                _solutions.TryRemove(payload.Id, out _);
-                return false;
-            }
-
-            var success = expected.Answer == payload.Answer;
-            if (success)
-            {
-                _solutions.TryRemove(payload.Id, out _);
-            }
-            return success;
+            return false;
         }
 
-        return false;
+        // Verify proof-of-work
+        var input = Encoding.UTF8.GetBytes(payload.Seed + payload.Nonce);
+        var hash = SHA256.HashData(input);
+        var hex = Convert.ToHexString(hash).ToLowerInvariant();
+        var prefix = new string('0', payload.Difficulty);
+        return hex.StartsWith(prefix);
+    }
+
+    private static long? ExtractExpiry(string salt)
+    {
+        var idx = salt.IndexOf("expires=", StringComparison.OrdinalIgnoreCase);
+        if (idx < 0) return null;
+        var part = salt[(idx + 8)..];
+        return long.TryParse(part, out var val) ? val : null;
     }
 
     public Task<bool> VerifySolutionAsync(string payload)
@@ -89,11 +93,7 @@ public class AltchaService : IAltchaService
         try
         {
             var model = JsonSerializer.Deserialize<AltchaVerifyPayload>(payload);
-            if (model == null)
-            {
-                return Task.FromResult(false);
-            }
-            return Task.FromResult(Verify(model));
+            return Task.FromResult(model != null && Verify(model));
         }
         catch (JsonException)
         {


### PR DESCRIPTION
## Summary
- redesign Altcha challenge and verification to use proof-of-work algorithm
- expose difficulty and token TTL settings via AltchaOptions
- add cryptographic verification of challenge signature and nonce solution

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c515d8bf388321a4aeb1099a62c5a3