### PR TITLE
Use relative path for Altcha worker

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -118,7 +118,7 @@
                                         <altcha-widget name="altcha"
                                                        challengeurl='@Url.Content("~/altcha/challenge")'
                                                        verifyurl='@Url.Content("~/altcha/verify")'
-                                                       workerurl='@($"{Context.Request.Scheme}://{Context.Request.Host}{Url.Content("~/lib/altcha/altcha.worker.js")}")'>
+                                                       workerurl='@Url.Content("~/lib/altcha/altcha.worker.js")'>
                                         </altcha-widget>
 
                                         <noscript>Prosím povolte JavaScript.</noscript>
@@ -146,7 +146,7 @@
                                         <altcha-widget name="altcha"
                                                        challengeurl='@Url.Content("~/altcha/challenge")'
                                                        verifyurl='@Url.Content("~/altcha/verify")'
-                                                       workerurl='@($"{Context.Request.Scheme}://{Context.Request.Host}{Url.Content("~/lib/altcha/altcha.worker.js")}")'>
+                                                       workerurl='@Url.Content("~/lib/altcha/altcha.worker.js")'>
                                         </altcha-widget>
 
                                         <noscript>Prosím povolte JavaScript.</noscript>


### PR DESCRIPTION
## Summary
- remove Context.Request scheme/host from Altcha widget worker URL and use relative path

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e787f99883219e95d2f2a3635051