### PR TITLE
Fix revenue grouping translation

### DIFF
--- a/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -49,15 +49,18 @@ public class IndexModel : PageModel
             .GroupBy(o => new { o.CreatedAt.Year, o.CreatedAt.Month })
             .Select(g => new
             {
-                Period = new DateTime(g.Key.Year, g.Key.Month, 1),
+                g.Key.Year,
+                g.Key.Month,
                 Total = g.Sum(o => o.TotalPrice)
             })
-            .OrderBy(g => g.Period)
+            .OrderBy(g => g.Year)
+            .ThenBy(g => g.Month)
             .ToListAsync();
 
         foreach (var item in revenue)
         {
-            RevenueLabels.Add(item.Period.ToString("yyyy-MM"));
+            var period = new DateTime(item.Year, item.Month, 1);
+            RevenueLabels.Add(period.ToString("yyyy-MM"));
             RevenueValues.Add(item.Total);
         }
     }


### PR DESCRIPTION
## Summary
- adjust admin dashboard revenue query to avoid server-side translation issues by ordering on grouped year/month and creating periods client-side
- continue populating revenue chart labels and values from computed period

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9035bb9648321bf22c22fbc900818