### PR TITLE
Add daily sales statistics aggregation

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -25,6 +25,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<WishlistItem> WishlistItems { get; set; } = default!;
     public DbSet<CompanyProfile> CompanyProfiles { get; set; } = default!;
     public DbSet<Enrollment> Enrollments { get; set; } = default!;
+    public DbSet<SalesStat> SalesStats { get; set; } = default!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -64,5 +65,6 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             .WithMany(t => t.Enrollments)
             .HasForeignKey(e => e.CourseTermId)
             .OnDelete(DeleteBehavior.Cascade);
+        builder.Entity<SalesStat>().HasKey(s => s.Date);
     }
 }

--- a/Data/Migrations/AddSalesStats.cs
+++ b/Data/Migrations/AddSalesStats.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Data.Migrations;
+
+public partial class AddSalesStats : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "SalesStats",
+            columns: table => new
+            {
+                Date = table.Column<DateOnly>(type: "date", nullable: false),
+                Revenue = table.Column<decimal>(type: "decimal(65,30)", nullable: false),
+                OrderCount = table.Column<int>(type: "int", nullable: false),
+                AverageOrderValue = table.Column<decimal>(type: "decimal(65,30)", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SalesStats", x => x.Date);
+            });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "SalesStats");
+    }
+}

--- a/Models/SalesStats.cs
+++ b/Models/SalesStats.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SysJaky_N.Models;
+
+public class SalesStat
+{
+    [Key]
+    [DataType(DataType.Date)]
+    public DateOnly Date { get; set; }
+
+    [DataType(DataType.Currency)]
+    public decimal Revenue { get; set; }
+
+    public int OrderCount { get; set; }
+
+    [DataType(DataType.Currency)]
+    public decimal AverageOrderValue { get; set; }
+}

--- a/Pages/Admin/Dashboard/Index.cshtml
+++ b/Pages/Admin/Dashboard/Index.cshtml
@@ -31,7 +31,7 @@
         <canvas id="topCoursesChart"></canvas>
     </div>
     <div class="col-md-6">
-        <h3>Tržby dle měsíce</h3>
+        <h3>Denní statistiky prodeje</h3>
         <canvas id="revenueChart"></canvas>
     </div>
 </div>
@@ -56,17 +56,87 @@
 
         const revenueLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueLabels));
         const revenueData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueValues));
+        const orderCounts = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.OrderCounts));
+        const averageOrderValues = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.AverageOrderValues));
 
         new Chart(document.getElementById('revenueChart'), {
-            type: 'line',
+            type: 'bar',
             data: {
                 labels: revenueLabels,
-                datasets: [{
-                    label: 'Tržby',
-                    data: revenueData,
-                    borderColor: 'rgba(75, 192, 192, 1)',
-                    fill: false
-                }]
+                datasets: [
+                    {
+                        type: 'bar',
+                        label: 'Počet objednávek',
+                        data: orderCounts,
+                        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                        borderColor: 'rgba(54, 162, 235, 1)',
+                        borderWidth: 1,
+                        yAxisID: 'yOrders'
+                    },
+                    {
+                        type: 'line',
+                        label: 'Tržby',
+                        data: revenueData,
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                        fill: true,
+                        tension: 0.3,
+                        yAxisID: 'yRevenue'
+                    },
+                    {
+                        type: 'line',
+                        label: 'Průměrná hodnota objednávky',
+                        data: averageOrderValues,
+                        borderColor: 'rgba(255, 159, 64, 1)',
+                        backgroundColor: 'rgba(255, 159, 64, 0.2)',
+                        tension: 0.3,
+                        borderDash: [5, 5],
+                        yAxisID: 'yAverage'
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                interaction: {
+                    mode: 'index',
+                    intersect: false
+                },
+                stacked: false,
+                scales: {
+                    yOrders: {
+                        type: 'linear',
+                        position: 'left',
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: 'Objednávky'
+                        }
+                    },
+                    yRevenue: {
+                        type: 'linear',
+                        position: 'right',
+                        beginAtZero: true,
+                        grid: {
+                            drawOnChartArea: false
+                        },
+                        title: {
+                            display: true,
+                            text: 'Tržby'
+                        }
+                    },
+                    yAverage: {
+                        type: 'linear',
+                        position: 'right',
+                        beginAtZero: true,
+                        grid: {
+                            drawOnChartArea: false
+                        },
+                        title: {
+                            display: true,
+                            text: 'Průměrná hodnota'
+                        }
+                    }
+                }
             }
         });
     </script>

--- a/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -21,6 +21,8 @@ public class IndexModel : PageModel
     public List<int> TopCourseValues { get; set; } = new();
     public List<string> RevenueLabels { get; set; } = new();
     public List<decimal> RevenueValues { get; set; } = new();
+    public List<int> OrderCounts { get; set; } = new();
+    public List<decimal> AverageOrderValues { get; set; } = new();
 
     public async Task OnGetAsync()
     {
@@ -45,23 +47,16 @@ public class IndexModel : PageModel
             TopCourseValues.Add(item.Quantity);
         }
 
-        var revenue = await _context.Orders
-            .GroupBy(o => new { o.CreatedAt.Year, o.CreatedAt.Month })
-            .Select(g => new
-            {
-                g.Key.Year,
-                g.Key.Month,
-                Total = g.Sum(o => o.Total)
-            })
-            .OrderBy(g => g.Year)
-            .ThenBy(g => g.Month)
+        var dailyStats = await _context.SalesStats
+            .OrderBy(s => s.Date)
             .ToListAsync();
 
-        foreach (var item in revenue)
+        foreach (var stat in dailyStats)
         {
-            var period = new DateTime(item.Year, item.Month, 1);
-            RevenueLabels.Add(period.ToString("yyyy-MM"));
-            RevenueValues.Add(item.Total);
+            RevenueLabels.Add(stat.Date.ToString("yyyy-MM-dd"));
+            RevenueValues.Add(stat.Revenue);
+            OrderCounts.Add(stat.OrderCount);
+            AverageOrderValues.Add(stat.AverageOrderValue);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -45,6 +45,7 @@ builder.Services.Configure<SmtpOptions>(builder.Configuration.GetSection("Smtp")
 builder.Services.AddScoped<IEmailSender, EmailSender>();
 builder.Services.AddScoped<IAuditService, AuditService>();
 builder.Services.AddHostedService<CourseReminderService>();
+builder.Services.AddHostedService<SalesStatsService>();
 builder.Services.AddMemoryCache();
 builder.Services.Configure<AltchaOptions>(builder.Configuration.GetSection("Altcha"));
 builder.Services.AddSingleton<IAltchaService, AltchaService>();

--- a/Services/SalesStatsService.cs
+++ b/Services/SalesStatsService.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Services;
+
+public class SalesStatsService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SalesStatsService> _logger;
+
+    public SalesStatsService(IServiceScopeFactory scopeFactory, ILogger<SalesStatsService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await UpdateSalesStatsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating sales statistics");
+            }
+
+            try
+            {
+                var now = DateTime.UtcNow;
+                var nextRun = now.Date.AddDays(1);
+                var delay = nextRun - now;
+                if (delay <= TimeSpan.Zero)
+                {
+                    delay = TimeSpan.FromDays(1);
+                }
+
+                await Task.Delay(delay, stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+                // ignored
+            }
+        }
+    }
+
+    private async Task UpdateSalesStatsAsync(CancellationToken token)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var salesByDate = await context.Orders
+            .Where(o => o.Status == OrderStatus.Paid)
+            .GroupBy(o => o.CreatedAt.Date)
+            .Select(g => new
+            {
+                Date = g.Key,
+                Revenue = g.Sum(o => o.Total),
+                OrderCount = g.Count(),
+                AverageOrderValue = g.Average(o => o.Total)
+            })
+            .ToListAsync(token);
+
+        var existingStats = await context.SalesStats
+            .ToDictionaryAsync(s => s.Date, token);
+
+        foreach (var stat in salesByDate)
+        {
+            var date = DateOnly.FromDateTime(stat.Date);
+            if (existingStats.TryGetValue(date, out var entity))
+            {
+                entity.Revenue = stat.Revenue;
+                entity.OrderCount = stat.OrderCount;
+                entity.AverageOrderValue = stat.AverageOrderValue;
+            }
+            else
+            {
+                context.SalesStats.Add(new SalesStat
+                {
+                    Date = date,
+                    Revenue = stat.Revenue,
+                    OrderCount = stat.OrderCount,
+                    AverageOrderValue = stat.AverageOrderValue
+                });
+            }
+        }
+
+        await context.SaveChangesAsync(token);
+    }
+}


### PR DESCRIPTION
## Summary
- add a SalesStat entity and migration for persisting daily revenue metrics
- schedule a hosted service that aggregates paid orders into SalesStat records each day
- update the admin dashboard to visualise daily order counts, revenue and average order value from the new data

## Testing
- not run (missing dotnet SDK in container)

------
https://chatgpt.com/codex/tasks/task_e_68c91d9c1a6083219d628e1d2de5ba66