### PR TITLE
Add payment id tracking for webhooks

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -27,6 +27,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<Enrollment> Enrollments { get; set; } = default!;
     public DbSet<LogEntry> LogEntries { get; set; } = default!;
     public DbSet<SalesStat> SalesStats { get; set; } = default!;
+    public DbSet<PaymentId> PaymentIds { get; set; } = default!;
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -68,5 +69,6 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             .OnDelete(DeleteBehavior.Cascade);
         builder.Entity<LogEntry>().HasIndex(e => e.Timestamp);
         builder.Entity<SalesStat>().HasKey(s => s.Date);
+        builder.Entity<PaymentId>().HasKey(p => p.Id);
     }
 }

--- a/Migrations/20251302000000_AddPaymentId.cs
+++ b/Migrations/20251302000000_AddPaymentId.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Migrations
+{
+    public partial class AddPaymentId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PaymentIds",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ProcessedUtc = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaymentIds", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PaymentIds");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -680,6 +680,20 @@ namespace SysJaky_N.Migrations
                     b.ToTable("OrderItems");
                 });
 
+            modelBuilder.Entity("SysJaky_N.Models.PaymentId", b =>
+                {
+                    b.Property<string>("Id")
+                        .HasMaxLength(255)
+                        .HasColumnType("varchar(255)");
+
+                    b.Property<DateTime>("ProcessedUtc")
+                        .HasColumnType("datetime(6)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("PaymentIds");
+                });
+
             modelBuilder.Entity("SysJaky_N.Models.WishlistItem", b =>
                 {
                     b.Property<string>("UserId")

--- a/Models/PaymentId.cs
+++ b/Models/PaymentId.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SysJaky_N.Models;
+
+public class PaymentId
+{
+    [Key]
+    [StringLength(255)]
+    public string Id { get; set; } = string.Empty;
+
+    [DataType(DataType.DateTime)]
+    public DateTime ProcessedUtc { get; set; } = DateTime.UtcNow;
+}

--- a/Services/PaymentService.cs
+++ b/Services/PaymentService.cs
@@ -195,10 +195,24 @@ public class PaymentService
             var stripeEvent = EventUtility.ConstructEvent(json, request.Headers["Stripe-Signature"], _options.WebhookSecret);
             if (stripeEvent.Type == Events.CheckoutSessionCompleted)
             {
+                var alreadyProcessed = await _context.PaymentIds.AnyAsync(p => p.Id == stripeEvent.Id);
+                if (alreadyProcessed)
+                {
+                    return;
+                }
+
+                _context.PaymentIds.Add(new PaymentId
+                {
+                    Id = stripeEvent.Id,
+                    ProcessedUtc = DateTime.UtcNow
+                });
+
                 if (stripeEvent.Data.Object is Session session)
                 {
                     await HandleSuccessAsync(session.Id);
                 }
+
+                await _context.SaveChangesAsync();
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- add a PaymentId entity for tracking processed webhook events
- register the new set in the DbContext and create the AddPaymentId migration
- guard HandleWebhookAsync so duplicate Stripe events are ignored after recording their ids

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c925793fac8321a13e5ed64c5c0b27