### PR TITLE
Fix missing entity closures in EF snapshot

### DIFF
--- a/Migrations/20250912120000_ReplaceDiscountCodeWithVoucher.Designer.cs
+++ b/Migrations/20250912120000_ReplaceDiscountCodeWithVoucher.Designer.cs
@@ -774,6 +774,8 @@ namespace SysJaky_N.Migrations
                     b.Navigation("CourseTerm");
 
                     b.Navigation("User");
+                });
+
             modelBuilder.Entity("SysJaky_N.Models.CourseTerm", b =>
                 {
                     b.HasOne("SysJaky_N.Models.Course", "Course")

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -710,6 +710,7 @@ namespace SysJaky_N.Migrations
                         .IsUnique();
 
                     b.ToTable("SeatTokens");
+                });
 
             modelBuilder.Entity("SysJaky_N.Models.PaymentId", b =>
                 {
@@ -914,6 +915,8 @@ namespace SysJaky_N.Migrations
                     b.Navigation("CourseTerm");
 
                     b.Navigation("User");
+                });
+
             modelBuilder.Entity("SysJaky_N.Models.CourseTerm", b =>
                 {
                     b.HasOne("SysJaky_N.Models.Course", "Course")


### PR DESCRIPTION
## Summary
- close the SeatToken entity configuration block in the model snapshot
- restore the Enrollment entity block termination in both the snapshot and the ReplaceDiscountCodeWithVoucher designer

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c938f96cbc8321b5fa6bd7d0d057f9