### PR TITLE
Guard navigation configuration when metadata is absent

### DIFF
--- a/Migrations/20250912120000_ReplaceDiscountCodeWithVoucher.Designer.cs
+++ b/Migrations/20250912120000_ReplaceDiscountCodeWithVoucher.Designer.cs
@@ -700,7 +700,11 @@ namespace SysJaky_N.Migrations
 
                     b.Navigation("CompanyProfile");
 
-                    b.Navigation("Enrollments");
+                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Enrollments");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>
@@ -736,6 +740,12 @@ namespace SysJaky_N.Migrations
                         .IsRequired();
 
                     b.Navigation("Course");
+
+                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Enrollments");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CourseReview", b =>
@@ -867,7 +877,11 @@ namespace SysJaky_N.Migrations
 
             modelBuilder.Entity("SysJaky_N.Models.CourseTerm", b =>
                 {
-                    b.Navigation("Enrollments");
+                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Enrollments");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.Order", b =>

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -835,9 +835,17 @@ namespace SysJaky_N.Migrations
 
                     b.Navigation("CompanyProfile");
 
-                    b.Navigation("Enrollments");
+                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Enrollments");
+                    }
 
-                    b.Navigation("WaitlistEntries");
+                    navigation = b.Metadata.FindNavigation("WaitlistEntries");
+                    if (navigation != null)
+                    {
+                        b.Navigation("WaitlistEntries");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>
@@ -874,9 +882,17 @@ namespace SysJaky_N.Migrations
 
                     b.Navigation("Course");
 
-                    b.Navigation("Enrollments");
+                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Enrollments");
+                    }
 
-                    b.Navigation("WaitlistEntries");
+                    navigation = b.Metadata.FindNavigation("WaitlistEntries");
+                    if (navigation != null)
+                    {
+                        b.Navigation("WaitlistEntries");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CourseReview", b =>
@@ -1047,7 +1063,17 @@ namespace SysJaky_N.Migrations
 
             modelBuilder.Entity("SysJaky_N.Models.CourseTerm", b =>
                 {
-                    b.Navigation("Enrollments");
+                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Enrollments");
+                    }
+
+                    navigation = b.Metadata.FindNavigation("WaitlistEntries");
+                    if (navigation != null)
+                    {
+                        b.Navigation("WaitlistEntries");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.Order", b =>


### PR DESCRIPTION
## Summary
- guard the ApplicationUser and CourseTerm navigation registrations in the model snapshot so EF only configures them once the metadata exists, keeping the navigation metadata without triggering missing navigation errors
- apply the same guarded navigation configuration in the ReplaceDiscountCodeWithVoucher designer to keep the historical migration model aligned with the snapshot adjustments

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c943c265488321b2c564dfd5dc497b