### PR TITLE
Fix migration snapshot navigation resolution for OrderItem

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -647,7 +647,7 @@ namespace SysJaky_N.Migrations
                     b.ToTable("Orders");
                 });
 
-            modelBuilder.Entity("SysJaky_N.Models.OrderItem", b =>
+            modelBuilder.Entity(typeof(SysJaky_N.Models.OrderItem), b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -1005,7 +1005,7 @@ namespace SysJaky_N.Migrations
                     b.Navigation("AppliesToCourse");
                 });
 
-            modelBuilder.Entity("SysJaky_N.Models.OrderItem", b =>
+            modelBuilder.Entity(typeof(SysJaky_N.Models.OrderItem), b =>
                 {
                     b.HasOne("SysJaky_N.Models.Course", "Course")
                         .WithMany()


### PR DESCRIPTION
## Summary
- update `ApplicationDbContextModelSnapshot` to register the `OrderItem` entity using its CLR type so its navigations remain available when EF builds the snapshot model

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c962ce572c83218ca367527ba5f450