### PR TITLE
Add company membership support during registration

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -24,6 +24,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<CourseBlock> CourseBlocks { get; set; } = default!;
     public DbSet<WishlistItem> WishlistItems { get; set; } = default!;
     public DbSet<CompanyProfile> CompanyProfiles { get; set; } = default!;
+    public DbSet<Company> Companies { get; set; } = default!;
+    public DbSet<CompanyUser> CompanyUsers { get; set; } = default!;
     public DbSet<Enrollment> Enrollments { get; set; } = default!;
     public DbSet<SeatToken> SeatTokens { get; set; } = default!;
     public DbSet<LogEntry> LogEntries { get; set; } = default!;
@@ -47,6 +49,20 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             .HasOne(c => c.Manager)
             .WithMany()
             .HasForeignKey(c => c.ManagerId);
+        builder.Entity<Company>().HasIndex(c => c.ReferralCode).IsUnique();
+        builder.Entity<Company>()
+            .HasMany(c => c.Users)
+            .WithOne(u => u.Company)
+            .HasForeignKey(u => u.CompanyId)
+            .OnDelete(DeleteBehavior.Cascade);
+        builder.Entity<CompanyUser>()
+            .HasIndex(cu => new { cu.CompanyId, cu.UserId })
+            .IsUnique();
+        builder.Entity<CompanyUser>()
+            .HasOne(cu => cu.User)
+            .WithMany(u => u.CompanyMemberships)
+            .HasForeignKey(cu => cu.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
         builder.Entity<Voucher>()
             .HasIndex(v => v.Code)
             .IsUnique();

--- a/Migrations/20251402120000_AddCompanyEntities.cs
+++ b/Migrations/20251402120000_AddCompanyEntities.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Migrations
+{
+    public partial class AddCompanyEntities : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Companies",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Name = table.Column<string>(type: "varchar(200)", maxLength: 200, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    ReferralCode = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Companies", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateTable(
+                name: "CompanyUsers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    CompanyId = table.Column<int>(type: "int", nullable: false),
+                    UserId = table.Column<string>(type: "varchar(255)", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Role = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CompanyUsers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CompanyUsers_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CompanyUsers_Companies_CompanyId",
+                        column: x => x.CompanyId,
+                        principalTable: "Companies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Companies_ReferralCode",
+                table: "Companies",
+                column: "ReferralCode",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompanyUsers_CompanyId_UserId",
+                table: "CompanyUsers",
+                columns: new[] { "CompanyId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CompanyUsers_UserId",
+                table: "CompanyUsers",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CompanyUsers");
+
+            migrationBuilder.DropTable(
+                name: "Companies");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -305,6 +305,30 @@ namespace SysJaky_N.Migrations
                     b.ToTable("LogEntries");
                 });
 
+            modelBuilder.Entity("SysJaky_N.Models.Company", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("varchar(200)");
+
+                    b.Property<string>("ReferralCode")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("varchar(64)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ReferralCode")
+                        .IsUnique();
+
+                    b.ToTable("Companies");
+                });
+
             modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>
                 {
                     b.Property<int>("Id")
@@ -330,6 +354,32 @@ namespace SysJaky_N.Migrations
                         .IsUnique();
 
                     b.ToTable("CompanyProfiles");
+                });
+
+            modelBuilder.Entity("SysJaky_N.Models.CompanyUser", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    b.Property<int>("CompanyId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Role")
+                        .HasColumnType("int");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasColumnType("varchar(255)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CompanyId", "UserId")
+                        .IsUnique();
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("CompanyUsers");
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.ContactMessage", b =>
@@ -860,7 +910,13 @@ namespace SysJaky_N.Migrations
 
                     b.Navigation("CompanyProfile");
 
-                    var navigation = b.Metadata.FindNavigation("Enrollments");
+                    var navigation = b.Metadata.FindNavigation("CompanyMemberships");
+                    if (navigation != null)
+                    {
+                        b.Navigation("CompanyMemberships");
+                    }
+
+                    navigation = b.Metadata.FindNavigation("Enrollments");
                     if (navigation != null)
                     {
                         b.Navigation("Enrollments");
@@ -871,6 +927,25 @@ namespace SysJaky_N.Migrations
                     {
                         b.Navigation("WaitlistEntries");
                     }
+                });
+
+            modelBuilder.Entity("SysJaky_N.Models.CompanyUser", b =>
+                {
+                    b.HasOne("SysJaky_N.Models.Company", "Company")
+                        .WithMany("Users")
+                        .HasForeignKey("CompanyId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("SysJaky_N.Models.ApplicationUser", "User")
+                        .WithMany("CompanyMemberships")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Company");
+
+                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>
@@ -1080,6 +1155,11 @@ namespace SysJaky_N.Migrations
                     b.Navigation("CourseTerm");
 
                     b.Navigation("User");
+                });
+
+            modelBuilder.Entity("SysJaky_N.Models.Company", b =>
+                {
+                    b.Navigation("Users");
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.CompanyProfile", b =>

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -8,4 +8,5 @@ public class ApplicationUser : IdentityUser
     public CompanyProfile? CompanyProfile { get; set; }
     public ICollection<Enrollment> Enrollments { get; set; } = new List<Enrollment>();
     public ICollection<WaitlistEntry> WaitlistEntries { get; set; } = new List<WaitlistEntry>();
+    public ICollection<CompanyUser> CompanyMemberships { get; set; } = new List<CompanyUser>();
 }

--- a/Models/Company.cs
+++ b/Models/Company.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace SysJaky_N.Models;
+
+public class Company
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(64)]
+    public string ReferralCode { get; set; } = string.Empty;
+
+    public ICollection<CompanyUser> Users { get; set; } = new List<CompanyUser>();
+}

--- a/Models/CompanyUser.cs
+++ b/Models/CompanyUser.cs
@@ -1,0 +1,21 @@
+namespace SysJaky_N.Models;
+
+public class CompanyUser
+{
+    public int Id { get; set; }
+
+    public int CompanyId { get; set; }
+    public Company Company { get; set; } = null!;
+
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser User { get; set; } = null!;
+
+    public CompanyRole Role { get; set; } = CompanyRole.Viewer;
+}
+
+public enum CompanyRole
+{
+    Owner,
+    Manager,
+    Viewer
+}

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -16,6 +16,11 @@
         <span asp-validation-for="Input.Password"></span>
     </div>
     <div>
+        <label asp-for="Input.ReferralCode"></label>
+        <input asp-for="Input.ReferralCode" />
+        <span asp-validation-for="Input.ReferralCode"></span>
+    </div>
+    <div>
         <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
         <noscript>Prosím povolte JavaScript.</noscript>
         <span asp-validation-for="Input.Captcha"></span>

--- a/Pages/Account/Register.cshtml.cs
+++ b/Pages/Account/Register.cshtml.cs
@@ -1,9 +1,11 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Models;
 using SysJaky_N.Attributes;
 using SysJaky_N.Services;
+using SysJaky_N.Data;
 using System.ComponentModel.DataAnnotations;
 
 namespace SysJaky_N.Pages.Account;
@@ -13,12 +15,14 @@ public class RegisterModel : PageModel
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly IEmailSender _emailSender;
+    private readonly ApplicationDbContext _context;
 
-    public RegisterModel(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IEmailSender emailSender)
+    public RegisterModel(UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager, IEmailSender emailSender, ApplicationDbContext context)
     {
         _userManager = userManager;
         _signInManager = signInManager;
         _emailSender = emailSender;
+        _context = context;
     }
 
     [BindProperty]
@@ -36,6 +40,9 @@ public class RegisterModel : PageModel
         [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Password must contain upper and lower case letters and numbers.")]
         public string Password { get; set; } = string.Empty;
         public string Captcha { get; set; } = string.Empty;
+
+        [Display(Name = "Referral code")]
+        public string? ReferralCode { get; set; }
     }
 
     public void OnGet()
@@ -49,10 +56,38 @@ public class RegisterModel : PageModel
         {
             return Page();
         }
+        Company? company = null;
+
+        if (!string.IsNullOrWhiteSpace(Input.ReferralCode))
+        {
+            var referralCode = Input.ReferralCode.Trim();
+            company = await _context.Companies.FirstOrDefaultAsync(c => c.ReferralCode == referralCode);
+
+            if (company == null)
+            {
+                ModelState.AddModelError(nameof(Input.ReferralCode), "Referral code was not found.");
+                return Page();
+            }
+
+            Input.ReferralCode = referralCode;
+        }
+
         var user = new ApplicationUser { UserName = Input.Email, Email = Input.Email };
         var result = await _userManager.CreateAsync(user, Input.Password);
         if (result.Succeeded)
         {
+            if (company != null)
+            {
+                _context.CompanyUsers.Add(new CompanyUser
+                {
+                    CompanyId = company.Id,
+                    UserId = user.Id,
+                    Role = CompanyRole.Viewer
+                });
+
+                await _context.SaveChangesAsync();
+            }
+
             await _signInManager.SignInAsync(user, isPersistent: false);
             await _emailSender.SendEmailAsync(user.Email!, "Welcome", "Thank you for registering.");
             return RedirectToPage("/Index");


### PR DESCRIPTION
## Summary
- add Company and CompanyUser models to represent memberships with role support and update the EF Core context
- let registration accept an optional referral code, automatically assigning new accounts to matching companies and expose the field in the form
- create an EF Core migration for the new company tables and relationships

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c95e85c2308321adf32fa36cbb8efe