### PR TITLE
Fix certificate number generation for C# 12

### DIFF
--- a/Services/CertificateService.cs
+++ b/Services/CertificateService.cs
@@ -187,9 +187,11 @@ public class CertificateService
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            Span<byte> buffer = stackalloc byte[8];
+
+            var buffer = new byte[8];
             RandomNumberGenerator.Fill(buffer);
             var candidate = Convert.ToHexString(buffer);
+
             var exists = await _context.Certificates.AnyAsync(c => c.Number == candidate, cancellationToken);
             if (!exists)
             {


### PR DESCRIPTION
## Summary
- replace the stackalloc-based random buffer with a standard byte array when generating fallback certificate numbers to avoid C# 12 limitations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9823d03a88321a1993850b8bd4b2a