### PR TITLE
Guard Enrollment navigation when building AddCertificates snapshot

### DIFF
--- a/Migrations/20251501090000_AddCertificates.Designer.cs
+++ b/Migrations/20251501090000_AddCertificates.Designer.cs
@@ -1012,7 +1012,11 @@ namespace SysJaky_N.Migrations
                     b.Navigation("CourseTerm");
 
                     b.Navigation("User");
-                    b.Navigation("Certificate");
+                    var navigation = b.Metadata.FindNavigation("Certificate");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Certificate");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.Certificate", b =>


### PR DESCRIPTION
## Summary
- guard the Enrollment Certificate navigation in the AddCertificates model snapshot
- avoid InvalidOperationException when the navigation metadata is absent while scaffolding migrations

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c98e5122c083219239b83ae315525b