### PR TITLE
Fix Instructor namespace conflicts in admin pages

### DIFF
--- a/Pages/Admin/Instructors/Create.cshtml.cs
+++ b/Pages/Admin/Instructors/Create.cshtml.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
-using SysJaky_N.Models;
+using InstructorModel = SysJaky_N.Models.Instructor;
 
 namespace SysJaky_N.Pages.Admin.Instructors;
 
@@ -19,7 +19,7 @@ public class CreateModel : PageModel
     }
 
     [BindProperty]
-    public Instructor Instructor { get; set; } = new();
+    public InstructorModel Instructor { get; set; } = new();
 
     public void OnGet()
     {

--- a/Pages/Admin/Instructors/Delete.cshtml.cs
+++ b/Pages/Admin/Instructors/Delete.cshtml.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
-using SysJaky_N.Models;
+using InstructorModel = SysJaky_N.Models.Instructor;
 
 namespace SysJaky_N.Pages.Admin.Instructors;
 
@@ -20,7 +20,7 @@ public class DeleteModel : PageModel
     }
 
     [BindProperty]
-    public Instructor Instructor { get; set; } = null!;
+    public InstructorModel Instructor { get; set; } = null!;
 
     public string? ErrorMessage { get; set; }
 
@@ -59,7 +59,7 @@ public class DeleteModel : PageModel
         return RedirectToPage("Index");
     }
 
-    private Task<Instructor?> LoadInstructorAsync(int id)
+    private Task<InstructorModel?> LoadInstructorAsync(int id)
     {
         return _context.Instructors
             .AsNoTracking()

--- a/Pages/Admin/Instructors/Edit.cshtml.cs
+++ b/Pages/Admin/Instructors/Edit.cshtml.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
-using SysJaky_N.Models;
+using InstructorModel = SysJaky_N.Models.Instructor;
 
 namespace SysJaky_N.Pages.Admin.Instructors;
 
@@ -19,7 +19,7 @@ public class EditModel : PageModel
     }
 
     [BindProperty]
-    public Instructor Instructor { get; set; } = null!;
+    public InstructorModel Instructor { get; set; } = null!;
 
     public async Task<IActionResult> OnGetAsync(int id)
     {

--- a/Pages/Admin/Instructors/Index.cshtml.cs
+++ b/Pages/Admin/Instructors/Index.cshtml.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
-using SysJaky_N.Models;
+using InstructorModel = SysJaky_N.Models.Instructor;
 
 namespace SysJaky_N.Pages.Admin.Instructors;
 
@@ -20,7 +20,7 @@ public class IndexModel : PageModel
         _context = context;
     }
 
-    public IList<Instructor> Instructors { get; set; } = new List<Instructor>();
+    public IList<InstructorModel> Instructors { get; set; } = new List<InstructorModel>();
 
     [BindProperty(SupportsGet = true)]
     public string? Search { get; set; }


### PR DESCRIPTION
## Summary
- resolve the namespace collision between the admin instructor pages and the Instructor model by using an explicit alias
- update the page model properties and helpers to reference the aliased Instructor type

## Testing
- dotnet build *(fails: `dotnet` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c998e75b808321806af7bac7d0209a