### PR TITLE
Add calendar feeds for course terms and user enrollments

### DIFF
--- a/Pages/Account/Manage.cshtml
+++ b/Pages/Account/Manage.cshtml
@@ -38,6 +38,50 @@
     </form>
 </section>
 
+<section>
+    <h2>Moje kurzy</h2>
+    <p>
+        <strong>iCal feed:</strong>
+        <a href="@Model.CalendarFeedUrl">@Model.CalendarFeedUrl</a>
+    </p>
+
+    @if (Model.Enrollments.Any())
+    {
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Kurz</th>
+                    <th>Zahájení</th>
+                    <th>Ukončení</th>
+                    <th>Kalendář</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach (var enrollment in Model.Enrollments)
+            {
+                var term = enrollment.CourseTerm;
+                var course = term?.Course;
+                if (term == null || course == null)
+                {
+                    continue;
+                }
+
+                <tr>
+                    <td>@course.Title</td>
+                    <td>@term.StartUtc.ToLocalTime().ToString("g")</td>
+                    <td>@term.EndUtc.ToLocalTime().ToString("g")</td>
+                    <td><a href="/CourseTerms/ICS/@term.Id">Stáhnout .ics</a></td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p>Momentálně nemáte žádné přihlášené termíny.</p>
+    }
+</section>
+
   @if (Model.Company != null)
   {
       <p>Firma: @Model.Company.Name</p>

--- a/Program.cs
+++ b/Program.cs
@@ -163,6 +163,35 @@ try
         return Results.Ok();
     });
 
+    static string EscapeIcsText(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value
+            .Replace("\\", "\\\\")
+            .Replace("\r\n", "\\n")
+            .Replace("\n", "\\n")
+            .Replace(",", "\\,")
+            .Replace(";", "\\;");
+    }
+
+    static string FormatUtcDateTime(DateTime dateTime)
+    {
+        if (dateTime.Kind == DateTimeKind.Unspecified)
+        {
+            dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+        }
+        else
+        {
+            dateTime = dateTime.ToUniversalTime();
+        }
+
+        return dateTime.ToString("yyyyMMddTHHmmssZ");
+    }
+
     app.MapGet("/Courses/ICS/{id:int}", async (int id, ApplicationDbContext context) =>
     {
         var course = await context.Courses.FindAsync(id);
@@ -180,10 +209,10 @@ try
         builder.AppendLine($"DTSTAMP:{DateTime.UtcNow:yyyyMMddTHHmmssZ}");
         builder.AppendLine($"DTSTART;VALUE=DATE:{course.Date:yyyyMMdd}");
         builder.AppendLine($"DTEND;VALUE=DATE:{course.Date.AddDays(1):yyyyMMdd}");
-        builder.AppendLine($"SUMMARY:{course.Title}");
+        builder.AppendLine($"SUMMARY:{EscapeIcsText(course.Title)}");
         if (!string.IsNullOrWhiteSpace(course.Description))
         {
-            builder.AppendLine($"DESCRIPTION:{course.Description}");
+            builder.AppendLine($"DESCRIPTION:{EscapeIcsText(course.Description)}");
         }
         builder.AppendLine("END:VEVENT");
         builder.AppendLine("END:VCALENDAR");
@@ -191,6 +220,95 @@ try
         var bytes = Encoding.UTF8.GetBytes(builder.ToString());
         return Results.File(bytes, "text/calendar", $"{course.Title}.ics");
     });
+
+    app.MapGet("/CourseTerms/ICS/{id:int}", async (int id, ApplicationDbContext context) =>
+    {
+        var term = await context.CourseTerms
+            .AsNoTracking()
+            .Include(t => t.Course)
+            .FirstOrDefaultAsync(t => t.Id == id);
+
+        if (term?.Course == null)
+        {
+            return Results.NotFound();
+        }
+
+        var builder = new StringBuilder();
+        builder.AppendLine("BEGIN:VCALENDAR");
+        builder.AppendLine("VERSION:2.0");
+        builder.AppendLine("PRODID:-//SysJaky_N//EN");
+        builder.AppendLine("BEGIN:VEVENT");
+        builder.AppendLine($"UID:course-term-{term.Id}@sysjaky_n");
+        builder.AppendLine($"DTSTAMP:{DateTime.UtcNow:yyyyMMddTHHmmssZ}");
+        builder.AppendLine($"DTSTART:{FormatUtcDateTime(term.StartUtc)}");
+        builder.AppendLine($"DTEND:{FormatUtcDateTime(term.EndUtc)}");
+        builder.AppendLine($"SUMMARY:{EscapeIcsText(term.Course.Title)}");
+        if (!string.IsNullOrWhiteSpace(term.Course.Description))
+        {
+            builder.AppendLine($"DESCRIPTION:{EscapeIcsText(term.Course.Description)}");
+        }
+        builder.AppendLine("END:VEVENT");
+        builder.AppendLine("END:VCALENDAR");
+
+        var fileName = $"{term.Course.Title}-{term.StartUtc:yyyyMMddHHmm}.ics";
+        var bytes = Encoding.UTF8.GetBytes(builder.ToString());
+        return Results.File(bytes, "text/calendar", fileName);
+    });
+
+    app.MapGet("/Account/Calendar/MyCourses.ics", async (
+        HttpContext httpContext,
+        UserManager<ApplicationUser> userManager,
+        ApplicationDbContext context) =>
+    {
+        var user = await userManager.GetUserAsync(httpContext.User);
+        if (user == null)
+        {
+            return Results.Unauthorized();
+        }
+
+        var enrollments = await context.Enrollments
+            .AsNoTracking()
+            .Where(e => e.UserId == user.Id && e.Status == EnrollmentStatus.Confirmed)
+            .Include(e => e.CourseTerm)
+                .ThenInclude(term => term.Course)
+            .ToListAsync();
+
+        var now = DateTime.UtcNow;
+
+        var builder = new StringBuilder();
+        builder.AppendLine("BEGIN:VCALENDAR");
+        builder.AppendLine("VERSION:2.0");
+        builder.AppendLine("PRODID:-//SysJaky_N//EN");
+        builder.AppendLine("CALSCALE:GREGORIAN");
+        builder.AppendLine("X-WR-CALNAME:Moje kurzy");
+
+        foreach (var enrollment in enrollments)
+        {
+            var term = enrollment.CourseTerm;
+            var course = term?.Course;
+            if (term == null || course == null)
+            {
+                continue;
+            }
+
+            builder.AppendLine("BEGIN:VEVENT");
+            builder.AppendLine($"UID:course-term-{term.Id}-user-{user.Id}@sysjaky_n");
+            builder.AppendLine($"DTSTAMP:{now:yyyyMMddTHHmmssZ}");
+            builder.AppendLine($"DTSTART:{FormatUtcDateTime(term.StartUtc)}");
+            builder.AppendLine($"DTEND:{FormatUtcDateTime(term.EndUtc)}");
+            builder.AppendLine($"SUMMARY:{EscapeIcsText(course.Title)}");
+            if (!string.IsNullOrWhiteSpace(course.Description))
+            {
+                builder.AppendLine($"DESCRIPTION:{EscapeIcsText(course.Description)}");
+            }
+            builder.AppendLine("END:VEVENT");
+        }
+
+        builder.AppendLine("END:VCALENDAR");
+
+        var bytes = Encoding.UTF8.GetBytes(builder.ToString());
+        return Results.File(bytes, "text/calendar", "moje-kurzy.ics");
+    }).RequireAuthorization();
 
     app.Run();
 }


### PR DESCRIPTION
## Summary
- add ICS endpoint for individual course terms and escape calendar text consistently
- expose a personal "Moje kurzy" iCal feed composed from confirmed enrollments
- surface calendar feed and per-term download links in the account profile page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9987cd0b88321b0fa051f7e82ba84