### PR TITLE
Use available RazorLight NuGet package version

### DIFF
--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="RazorLight" Version="2.5.0" />
+    <PackageReference Include="RazorLight" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update the RazorLight package reference to the latest available release on NuGet to allow restores

## Testing
- dotnet restore *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ae4f44488321afc2ae91c98ea1a3