### PR TITLE
Fix duplicate content item inclusion for email templates

### DIFF
--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="EmailTemplates/**/*.cshtml">
+    <Content Update="EmailTemplates/**/*.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>


### PR DESCRIPTION
## Summary
- switch the EmailTemplates content declaration to use Update metadata so the SDK's implicit items are not duplicated while retaining copy behavior

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9af2fc5008321977c1c08e1fb616b