### PR TITLE
Fix cart page email and pricing schedule references

### DIFF
--- a/Pages/Cart.cshtml.cs
+++ b/Pages/Cart.cshtml.cs
@@ -8,6 +8,7 @@ using SysJaky_N.Extensions;
 using SysJaky_N.Models;
 using SysJaky_N.Services;
 using SysJaky_N.EmailTemplates.Models;
+using EmailTemplate = SysJaky_N.Services.EmailTemplate;
 
 namespace SysJaky_N.Pages;
 
@@ -570,7 +571,7 @@ public class CartModel : PageModel
             .GroupBy(term => term.CourseId)
             .ToDictionary(group => group.Key, group => group.Min(t => t.StartUtc));
 
-        var schedules = await _context.PriceSchedules
+        var schedules = await _context.Set<PriceSchedule>()
             .AsNoTracking()
             .Where(schedule => courseIds.Contains(schedule.CourseId))
             .ToListAsync();


### PR DESCRIPTION
## Summary
- add an alias for the EmailTemplate enum so the cart page can access it unambiguously
- resolve the price schedule lookup by using DbContext.Set to query PriceSchedule entities

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9b3013bac8321afb803716186f815