### PR TITLE
Handle missing navigation when building snapshot

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1283,8 +1283,18 @@ namespace SysJaky_N.Migrations
                     b.Navigation("CourseTerm");
 
                     b.Navigation("User");
-                    b.Navigation("Attendance");
-                    b.Navigation("Certificate");
+
+                    var navigation = b.Metadata.FindNavigation("Attendance");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Attendance");
+                    }
+
+                    navigation = b.Metadata.FindNavigation("Certificate");
+                    if (navigation != null)
+                    {
+                        b.Navigation("Certificate");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.Attendance", b =>


### PR DESCRIPTION
## Summary
- guard the Enrollment navigation configuration in ApplicationDbContextModelSnapshot against missing relationships to prevent EF tooling exceptions

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9b7c6ce248321a1b909b3cf5239c0