### PR TITLE
Fix OrderItem snapshot configuration

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -883,7 +883,7 @@ namespace SysJaky_N.Migrations
                     b.ToTable("Orders");
                 });
 
-            modelBuilder.Entity(typeof(SysJaky_N.Models.OrderItem), b =>
+            modelBuilder.Entity("SysJaky_N.Models.OrderItem", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -1355,7 +1355,7 @@ namespace SysJaky_N.Migrations
                     b.Navigation("AppliesToCourse");
                 });
 
-            modelBuilder.Entity(typeof(SysJaky_N.Models.OrderItem), b =>
+            modelBuilder.Entity("SysJaky_N.Models.OrderItem", b =>
                 {
                     b.HasOne("SysJaky_N.Models.Course", "Course")
                         .WithMany()


### PR DESCRIPTION
## Summary
- update the ApplicationDbContext model snapshot to configure OrderItem using the string-based entity registration
- ensure the snapshot no longer triggers EF Core treating OrderItem as a shared-type entity, avoiding the navigation type mismatch during migration operations

## Testing
- not run (dotnet CLI is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68c9bb448b848321b70bf46cd96cb2db