### PR TITLE
Guard SeatTokens navigation in model snapshot

### DIFF
--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1373,7 +1373,11 @@ namespace SysJaky_N.Migrations
 
                     b.Navigation("Order");
 
-                    b.Navigation("SeatTokens");
+                    var navigation = b.Metadata.FindNavigation("SeatTokens");
+                    if (navigation != null)
+                    {
+                        b.Navigation("SeatTokens");
+                    }
                 });
 
             modelBuilder.Entity("SysJaky_N.Models.SeatToken", b =>


### PR DESCRIPTION
## Summary
- guard the SeatTokens navigation lookup in ApplicationDbContextModelSnapshot so migrations can be scaffolded even when EF hasn't created the navigation yet

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9c18ce3c08321b82b1902896f84d1