### PR TITLE
Notify wishlist users about new course terms

### DIFF
--- a/EmailTemplates/CourseTermCreated.cshtml
+++ b/EmailTemplates/CourseTermCreated.cshtml
@@ -1,0 +1,21 @@
+@model SysJaky_N.EmailTemplates.Models.CourseTermCreatedEmailModel
+@using System.Globalization
+@{
+    Layout = null;
+    var startLocal = Model.StartUtc.ToLocalTime();
+    var endLocal = Model.EndUtc.ToLocalTime();
+}
+<!DOCTYPE html>
+<html>
+<body style="font-family: Arial, sans-serif; color: #111;">
+    <p>Dobrý den,</p>
+    <p>u kurzu "<strong>@Model.CourseTitle</strong>" byl přidán nový termín.</p>
+    <p>
+        Začíná @startLocal.ToString("f", CultureInfo.CurrentCulture)
+        a končí @endLocal.ToString("f", CultureInfo.CurrentCulture).
+    </p>
+    <p>Více informací najdete na stránce termínu:</p>
+    <p><a href="@Model.DetailUrl">@Model.DetailUrl</a></p>
+    <p>Těšíme se na vás.</p>
+</body>
+</html>

--- a/EmailTemplates/Models/CourseTermCreatedEmailModel.cs
+++ b/EmailTemplates/Models/CourseTermCreatedEmailModel.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace SysJaky_N.EmailTemplates.Models;
+
+public record class CourseTermCreatedEmailModel(
+    string CourseTitle,
+    DateTime StartUtc,
+    DateTime EndUtc,
+    string DetailUrl);

--- a/Pages/Admin/CourseTerms/Create.cshtml.cs
+++ b/Pages/Admin/CourseTerms/Create.cshtml.cs
@@ -7,8 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using SysJaky_N.Data;
+using SysJaky_N.EmailTemplates.Models;
 using SysJaky_N.Models;
+using SysJaky_N.Services;
 
 namespace SysJaky_N.Pages.Admin.CourseTerms;
 
@@ -16,10 +19,14 @@ namespace SysJaky_N.Pages.Admin.CourseTerms;
 public class CreateModel : PageModel
 {
     private readonly ApplicationDbContext _context;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<CreateModel> _logger;
 
-    public CreateModel(ApplicationDbContext context)
+    public CreateModel(ApplicationDbContext context, IEmailSender emailSender, ILogger<CreateModel> logger)
     {
         _context = context;
+        _emailSender = emailSender;
+        _logger = logger;
         Input.StartUtc = DateTime.UtcNow.ToLocalTime();
         Input.EndUtc = Input.StartUtc.AddHours(1);
     }
@@ -54,6 +61,16 @@ public class CreateModel : PageModel
             return Page();
         }
 
+        var course = await _context.Courses
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == Input.CourseId);
+
+        if (course == null)
+        {
+            ModelState.AddModelError("Input.CourseId", "Selected course was not found.");
+            return Page();
+        }
+
         var term = new CourseTerm
         {
             CourseId = Input.CourseId,
@@ -68,7 +85,81 @@ public class CreateModel : PageModel
         _context.CourseTerms.Add(term);
         await _context.SaveChangesAsync();
 
+        await NotifyWishlistUsersAsync(term, course);
+
         return RedirectToPage("Index");
+    }
+
+    private async Task NotifyWishlistUsersAsync(CourseTerm term, Course course)
+    {
+        var wishlistedUsers = await _context.WishlistItems
+            .AsNoTracking()
+            .Where(w => w.CourseId == course.Id)
+            .Select(w => w.User)
+            .OfType<ApplicationUser>()
+            .Where(user => !string.IsNullOrWhiteSpace(user.Email))
+            .ToListAsync();
+
+        if (wishlistedUsers.Count == 0)
+        {
+            _logger.LogInformation(
+                "Žádní uživatelé ve wishlistu pro kurz {CourseId}, oznámení nebudou odeslána.",
+                course.Id);
+            return;
+        }
+
+        var host = Request.Host.HasValue ? Request.Host.Value : null;
+        var detailUrl = Url.Page(
+            "/CourseTerms/Details",
+            pageHandler: null,
+            values: new { id = term.Id },
+            protocol: Request.Scheme,
+            host: host);
+
+        if (string.IsNullOrWhiteSpace(detailUrl))
+        {
+            detailUrl = $"/CourseTerms/Details/{term.Id}";
+            _logger.LogWarning(
+                "Nepodařilo se vygenerovat absolutní odkaz na termín {TermId}. Používám relativní cestu {Url}.",
+                term.Id,
+                detailUrl);
+        }
+
+        var courseTitle = string.IsNullOrWhiteSpace(course.Title) ? $"Kurz {course.Id}" : course.Title;
+
+        _logger.LogInformation(
+            "Odesílám oznámení o novém termínu {TermId} ({CourseTitle}) {RecipientCount} uživatelům.",
+            term.Id,
+            courseTitle,
+            wishlistedUsers.Count);
+
+        foreach (var user in wishlistedUsers)
+        {
+            var email = user.Email;
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                continue;
+            }
+
+            var model = new CourseTermCreatedEmailModel(
+                courseTitle,
+                term.StartUtc,
+                term.EndUtc,
+                detailUrl);
+
+            try
+            {
+                await _emailSender.SendEmailAsync(email, EmailTemplate.CourseTermCreated, model);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Odeslání oznámení o termínu {TermId} uživateli {Email} selhalo.",
+                    term.Id,
+                    email);
+            }
+        }
     }
 
     private async Task LoadSelectListsAsync()

--- a/Pages/CourseTerms/Details.cshtml
+++ b/Pages/CourseTerms/Details.cshtml
@@ -1,0 +1,50 @@
+@page "{id:int}"
+@model SysJaky_N.Pages.CourseTerms.DetailsModel
+@using System.Globalization
+
+@{
+    ViewData["Title"] = "Detail termínu";
+    var startLocal = Model.Term.StartUtc.ToLocalTime();
+    var endLocal = Model.Term.EndUtc.ToLocalTime();
+    var seatsAvailable = Model.Term.Capacity - Model.Term.SeatsTaken;
+    var instructor = Model.Term.Instructor;
+    var course = Model.Term.Course;
+}
+
+<h1>@Model.CourseTitle</h1>
+
+<section class="mb-4">
+    <h2 class="h4">Detail termínu</h2>
+    <dl class="row">
+        <dt class="col-sm-3">Začátek</dt>
+        <dd class="col-sm-9">@startLocal.ToString("f", CultureInfo.CurrentCulture)</dd>
+        <dt class="col-sm-3">Konec</dt>
+        <dd class="col-sm-9">@endLocal.ToString("f", CultureInfo.CurrentCulture)</dd>
+        <dt class="col-sm-3">Kapacita</dt>
+        <dd class="col-sm-9">@Model.Term.Capacity</dd>
+        <dt class="col-sm-3">Obsazeno</dt>
+        <dd class="col-sm-9">@Model.Term.SeatsTaken</dd>
+        <dt class="col-sm-3">Volná místa</dt>
+        <dd class="col-sm-9">@Math.Max(0, seatsAvailable)</dd>
+        <dt class="col-sm-3">Stav</dt>
+        <dd class="col-sm-9">@(Model.Term.IsActive ? "Aktivní" : "Neaktivní")</dd>
+        @if (instructor != null)
+        {
+            <dt class="col-sm-3">Lektor</dt>
+            <dd class="col-sm-9">@instructor.FullName</dd>
+        }
+    </dl>
+</section>
+
+@if (!string.IsNullOrWhiteSpace(course?.Description))
+{
+    <section class="mb-4">
+        <h2 class="h4">O kurzu</h2>
+        <p>@course.Description</p>
+    </section>
+}
+
+<section class="d-flex flex-column flex-sm-row gap-2">
+    <a class="btn btn-primary" href="/Courses/Details/@Model.Term.CourseId">Detail kurzu</a>
+    <a class="btn btn-outline-secondary" href="/CourseTerms/ICS/@Model.Term.Id">Přidat do kalendáře</a>
+</section>

--- a/Pages/CourseTerms/Details.cshtml.cs
+++ b/Pages/CourseTerms/Details.cshtml.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.CourseTerms;
+
+public class DetailsModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public DetailsModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public CourseTerm Term { get; private set; } = null!;
+
+    public string CourseTitle { get; private set; } = string.Empty;
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        var term = await _context.CourseTerms
+            .AsNoTracking()
+            .Include(t => t.Course)
+            .Include(t => t.Instructor)
+            .FirstOrDefaultAsync(t => t.Id == id);
+
+        if (term == null)
+        {
+            return NotFound();
+        }
+
+        Term = term;
+        CourseTitle = string.IsNullOrWhiteSpace(term.Course?.Title)
+            ? $"Kurz {term.CourseId}"
+            : term.Course!.Title;
+
+        return Page();
+    }
+}

--- a/Services/EmailSender.cs
+++ b/Services/EmailSender.cs
@@ -28,6 +28,7 @@ public enum EmailTemplate
     Welcome,
     OrderCreated,
     ContactMessageNotification,
+    CourseTermCreated,
     WaitlistSeatAvailable,
     CourseReminder,
     CourseReviewRequest
@@ -61,6 +62,14 @@ public class EmailSender : IEmailSender
                 "ContactMessageNotification.cshtml",
                 typeof(ContactMessageEmailModel),
                 _ => "New contact message"),
+            [EmailTemplate.CourseTermCreated] = new(
+                "CourseTermCreated.cshtml",
+                typeof(CourseTermCreatedEmailModel),
+                model =>
+                {
+                    var data = (CourseTermCreatedEmailModel)model;
+                    return $"Nový termín: {data.CourseTitle}";
+                }),
             [EmailTemplate.WaitlistSeatAvailable] = new(
                 "WaitlistSeatAvailable.cshtml",
                 typeof(WaitlistSeatAvailableEmailModel),


### PR DESCRIPTION
## Summary
- notify wishlisted users when an administrator creates a new course term and log the process
- add a dedicated email template and payload model for course-term notifications
- expose a public course term detail page to serve as the email link target

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9c598628c8321a452044bd86b1f11