### PR TITLE
Add course tags and filtering options

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -40,6 +40,8 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<Certificate> Certificates { get; set; } = default!;
     public DbSet<Attendance> Attendances { get; set; } = default!;
     public DbSet<EmailLog> EmailLogs { get; set; } = default!;
+    public DbSet<Tag> Tags { get; set; } = default!;
+    public DbSet<CourseTag> CourseTags { get; set; } = default!;
 
 
     protected override void OnModelCreating(ModelBuilder builder)
@@ -190,6 +192,25 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
             .HasOne(lp => lp.User)
             .WithMany(u => u.LessonProgresses)
             .HasForeignKey(lp => lp.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<Tag>()
+            .HasIndex(t => t.Name)
+            .IsUnique();
+
+        builder.Entity<CourseTag>()
+            .HasKey(ct => new { ct.CourseId, ct.TagId });
+
+        builder.Entity<CourseTag>()
+            .HasOne(ct => ct.Course)
+            .WithMany(c => c.CourseTags)
+            .HasForeignKey(ct => ct.CourseId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Entity<CourseTag>()
+            .HasOne(ct => ct.Tag)
+            .WithMany(t => t.CourseTags)
+            .HasForeignKey(ct => ct.TagId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/Data/Migrations/AddCourseTagsAndFilters.cs
+++ b/Data/Migrations/AddCourseTagsAndFilters.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SysJaky_N.Data.Migrations;
+
+public partial class AddCourseTagsAndFilters : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "Duration",
+            table: "Courses",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.AddColumn<int>(
+            name: "Level",
+            table: "Courses",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.AddColumn<int>(
+            name: "Mode",
+            table: "Courses",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.CreateTable(
+            name: "Tags",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "int", nullable: false)
+                    .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                Name = table.Column<string>(type: "longtext", nullable: false)
+                    .Annotation("MySql:CharSet", "utf8mb4")
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Tags", x => x.Id);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.CreateTable(
+            name: "CourseTags",
+            columns: table => new
+            {
+                CourseId = table.Column<int>(type: "int", nullable: false),
+                TagId = table.Column<int>(type: "int", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_CourseTags", x => new { x.CourseId, x.TagId });
+                table.ForeignKey(
+                    name: "FK_CourseTags_Courses_CourseId",
+                    column: x => x.CourseId,
+                    principalTable: "Courses",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_CourseTags_Tags_TagId",
+                    column: x => x.TagId,
+                    principalTable: "Tags",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            })
+            .Annotation("MySql:CharSet", "utf8mb4");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_CourseTags_TagId",
+            table: "CourseTags",
+            column: "TagId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Tags_Name",
+            table: "Tags",
+            column: "Name",
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "CourseTags");
+
+        migrationBuilder.DropTable(
+            name: "Tags");
+
+        migrationBuilder.DropColumn(
+            name: "Duration",
+            table: "Courses");
+
+        migrationBuilder.DropColumn(
+            name: "Level",
+            table: "Courses");
+
+        migrationBuilder.DropColumn(
+            name: "Mode",
+            table: "Courses");
+    }
+}

--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -19,6 +19,13 @@ public class Course
     [DataType(DataType.Date)]
     public DateTime Date { get; set; }
 
+    public CourseLevel Level { get; set; } = CourseLevel.Beginner;
+
+    public CourseMode Mode { get; set; } = CourseMode.SelfPaced;
+
+    [Range(0, int.MaxValue)]
+    public int Duration { get; set; }
+
     [Range(0, int.MaxValue)]
     public int ReminderDays { get; set; }
 
@@ -38,6 +45,8 @@ public class Course
     public virtual CourseBlock? CourseBlock { get; set; }
 
     public ICollection<Lesson> Lessons { get; set; } = new List<Lesson>();
+
+    public ICollection<CourseTag> CourseTags { get; set; } = new List<CourseTag>();
 }
 
 public enum CourseType
@@ -45,4 +54,18 @@ public enum CourseType
     Online,
     InPerson,
     Hybrid
+}
+
+public enum CourseLevel
+{
+    Beginner,
+    Intermediate,
+    Advanced
+}
+
+public enum CourseMode
+{
+    SelfPaced,
+    InstructorLed,
+    Blended
 }

--- a/Models/CourseTag.cs
+++ b/Models/CourseTag.cs
@@ -1,0 +1,12 @@
+namespace SysJaky_N.Models;
+
+public class CourseTag
+{
+    public int CourseId { get; set; }
+
+    public Course Course { get; set; } = default!;
+
+    public int TagId { get; set; }
+
+    public Tag Tag { get; set; } = default!;
+}

--- a/Models/Tag.cs
+++ b/Models/Tag.cs
@@ -1,0 +1,14 @@
+namespace SysJaky_N.Models;
+
+using System.ComponentModel.DataAnnotations;
+
+public class Tag
+{
+    public int Id { get; set; }
+
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    public ICollection<CourseTag> CourseTags { get; set; } = new List<CourseTag>();
+}

--- a/Pages/Courses/Create.cshtml
+++ b/Pages/Courses/Create.cshtml
@@ -34,6 +34,21 @@
         <input asp-for="Course.Date" class="form-control" />
         <span asp-validation-for="Course.Date" class="text-danger"></span>
     </div>
+    <div class="form-group">
+        <label asp-for="Course.Level"></label>
+        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseLevel>()"></select>
+        <span asp-validation-for="Course.Level" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Mode"></label>
+        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseMode>()"></select>
+        <span asp-validation-for="Course.Mode" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Duration"></label>
+        <input asp-for="Course.Duration" class="form-control" min="0" />
+        <span asp-validation-for="Course.Duration" class="text-danger"></span>
+    </div>
     <button type="submit" class="btn btn-primary">Create</button>
     <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </form>

--- a/Pages/Courses/Edit.cshtml
+++ b/Pages/Courses/Edit.cshtml
@@ -35,6 +35,21 @@
         <input asp-for="Course.Date" class="form-control" />
         <span asp-validation-for="Course.Date" class="text-danger"></span>
     </div>
+    <div class="form-group">
+        <label asp-for="Course.Level"></label>
+        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseLevel>()"></select>
+        <span asp-validation-for="Course.Level" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Mode"></label>
+        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseMode>()"></select>
+        <span asp-validation-for="Course.Mode" class="text-danger"></span>
+    </div>
+    <div class="form-group">
+        <label asp-for="Course.Duration"></label>
+        <input asp-for="Course.Duration" class="form-control" min="0" />
+        <span asp-validation-for="Course.Duration" class="text-danger"></span>
+    </div>
     <button type="submit" class="btn btn-primary">Save</button>
     <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </form>

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -12,11 +12,44 @@
 }
 
 <form method="get" class="mb-3">
-    <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" style="width:auto;display:inline-block" aria-label="Search courses" />
-    <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-control" style="width:auto;display:inline-block" aria-label="Filter by group">
-        <option value="">All Groups</option>
-    </select>
-    <button type="submit" class="btn btn-primary">Filter</button>
+    <div class="row g-2">
+        <div class="col-sm-6 col-lg-3">
+            <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" aria-label="Search courses" />
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-select" aria-label="Filter by group">
+                <option value="">All Groups</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <select asp-for="Level" asp-items="Model.LevelOptions" class="form-select" aria-label="Filter by level">
+                <option value="">All Levels</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <select asp-for="Mode" asp-items="Model.ModeOptions" class="form-select" aria-label="Filter by mode">
+                <option value="">All Modes</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <div class="input-group">
+                <span class="input-group-text" id="minDurationLabel">Min duration</span>
+                <input type="number" asp-for="MinDuration" class="form-control" aria-labelledby="minDurationLabel" min="0" />
+            </div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+            <div class="input-group">
+                <span class="input-group-text" id="maxDurationLabel">Max duration</span>
+                <input type="number" asp-for="MaxDuration" class="form-control" aria-labelledby="maxDurationLabel" min="0" />
+            </div>
+        </div>
+        <div class="col-12 col-lg-6">
+            <select asp-for="SelectedTagIds" asp-items="Model.TagOptions" class="form-select" multiple size="4" aria-label="Filter by tags"></select>
+        </div>
+        <div class="col-12 text-end">
+            <button type="submit" class="btn btn-primary">Filter</button>
+        </div>
+    </div>
 </form>
 
 @if (User.IsInRole("Admin"))
@@ -31,6 +64,10 @@
         <tr>
             <th>Title</th>
             <th>Group</th>
+            <th>Level</th>
+            <th>Mode</th>
+            <th>Duration (min)</th>
+            <th>Tags</th>
             <th>Price</th>
             <th>Date</th>
             <th></th>
@@ -42,6 +79,15 @@
         <tr>
             <td>@item.Title</td>
             <td>@item.CourseGroup?.Name</td>
+            <td>@item.Level</td>
+            <td>@item.Mode</td>
+            <td>@item.Duration</td>
+            <td>
+                @if (item.CourseTags.Any())
+                {
+                    <span>@string.Join(", ", item.CourseTags.Select(ct => ct.Tag.Name))</span>
+                }
+            </td>
             <td>@item.Price</td>
             <td>@item.Date.ToString("d")</td>
             <td>
@@ -68,10 +114,10 @@
     <nav>
         <ul class="pagination">
             <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Previous</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">Previous</a>
             </li>
             <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Next</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">Next</a>
             </li>
         </ul>
     </nav>

--- a/Pages/Courses/Index.cshtml.cs
+++ b/Pages/Courses/Index.cshtml.cs
@@ -30,7 +30,28 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public string? SearchString { get; set; }
 
+    [BindProperty(SupportsGet = true)]
+    public CourseLevel? Level { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public CourseMode? Mode { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? MinDuration { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public int? MaxDuration { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public List<int> SelectedTagIds { get; set; } = new();
+
     public SelectList CourseGroups { get; set; } = default!;
+
+    public IEnumerable<SelectListItem> LevelOptions { get; set; } = Enumerable.Empty<SelectListItem>();
+
+    public IEnumerable<SelectListItem> ModeOptions { get; set; } = Enumerable.Empty<SelectListItem>();
+
+    public IEnumerable<SelectListItem> TagOptions { get; set; } = Enumerable.Empty<SelectListItem>();
 
     public int TotalPages { get; set; }
 
@@ -38,8 +59,38 @@ public class IndexModel : PageModel
     {
         const int pageSize = 10;
         CourseGroups = new SelectList(_context.CourseGroups, "Id", "Name");
+        LevelOptions = Enum.GetValues<CourseLevel>()
+            .Select(level => new SelectListItem
+            {
+                Text = level.ToString(),
+                Value = level.ToString(),
+                Selected = Level == level
+            })
+            .ToList();
+        ModeOptions = Enum.GetValues<CourseMode>()
+            .Select(mode => new SelectListItem
+            {
+                Text = mode.ToString(),
+                Value = mode.ToString(),
+                Selected = Mode == mode
+            })
+            .ToList();
+
+        SelectedTagIds ??= new List<int>();
+        TagOptions = await _context.Tags
+            .OrderBy(t => t.Name)
+            .Select(t => new SelectListItem
+            {
+                Text = t.Name,
+                Value = t.Id.ToString(),
+                Selected = SelectedTagIds.Contains(t.Id)
+            })
+            .ToListAsync();
+
         var query = _context.Courses
             .Include(c => c.CourseGroup)
+            .Include(c => c.CourseTags)
+                .ThenInclude(ct => ct.Tag)
             .AsQueryable();
 
         if (CourseGroupId.HasValue)
@@ -51,6 +102,38 @@ public class IndexModel : PageModel
         {
             var pattern = $"%{SearchString.Trim()}%";
             query = query.Where(c => EF.Functions.Like(c.Title, pattern));
+        }
+
+        if (Level.HasValue)
+        {
+            query = query.Where(c => c.Level == Level.Value);
+        }
+
+        if (Mode.HasValue)
+        {
+            query = query.Where(c => c.Mode == Mode.Value);
+        }
+
+        var minDuration = MinDuration;
+        var maxDuration = MaxDuration;
+        if (minDuration.HasValue && maxDuration.HasValue && minDuration > maxDuration)
+        {
+            (minDuration, maxDuration) = (maxDuration, minDuration);
+        }
+
+        if (minDuration.HasValue)
+        {
+            query = query.Where(c => c.Duration >= minDuration.Value);
+        }
+
+        if (maxDuration.HasValue)
+        {
+            query = query.Where(c => c.Duration <= maxDuration.Value);
+        }
+
+        if (SelectedTagIds.Count > 0)
+        {
+            query = query.Where(c => c.CourseTags.Any(ct => SelectedTagIds.Contains(ct.TagId)));
         }
 
         query = query.OrderBy(c => c.Date);


### PR DESCRIPTION
## Summary
- add Tag and CourseTag models and configure EF context for course tagging
- extend the Course entity with level, mode and duration metadata with admin form inputs
- update the course catalog page to filter by tags, level, mode and duration and create a migration for the new schema

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9c59c06388321b74a3aeecdfea227