### PR TITLE
Add Excel import/export for admin course terms

### DIFF
--- a/Pages/Admin/CourseTerms/Index.cshtml
+++ b/Pages/Admin/CourseTerms/Index.cshtml
@@ -9,6 +9,20 @@
     <a class="btn btn-primary" asp-page="Create">Create term</a>
 </div>
 
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <div class="alert alert-success" role="status">
+        @Model.StatusMessage
+    </div>
+}
+
+@if (!string.IsNullOrEmpty(Model.ErrorMessage))
+{
+    <div class="alert alert-danger" role="alert">
+        @Model.ErrorMessage
+    </div>
+}
+
 <form method="get" class="row g-3 align-items-end mb-4">
     <div class="col-md-4">
         <label asp-for="CourseId" class="form-label">Course</label>
@@ -27,6 +41,21 @@
     </div>
     <div class="col-auto">
         <a asp-page="Index" class="btn btn-outline-secondary">Clear</a>
+    </div>
+</form>
+
+<form method="post" asp-page-handler="Import" enctype="multipart/form-data" class="row g-3 align-items-end mb-4">
+    <div class="col-md-5 col-lg-4">
+        <label asp-for="ImportFile" class="form-label">Import terms from Excel</label>
+        <input asp-for="ImportFile" class="form-control" type="file" accept=".xlsx" />
+        <div class="form-text">Required columns: CourseId, StartUtc, EndUtc, Capacity. Optional columns: Id, IsActive, InstructorId.</div>
+        <span asp-validation-for="ImportFile" class="text-danger"></span>
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-outline-primary">Import XLSX</button>
+    </div>
+    <div class="col-12">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     </div>
 </form>
 
@@ -75,9 +104,14 @@ else
                         }
                     </td>
                     <td class="text-end">
-                        <div class="btn-group btn-group-sm" role="group" aria-label="Actions for @term.Course?.Title term">
-                            <a class="btn btn-outline-secondary" asp-page="Edit" asp-route-id="@term.Id">Edit</a>
-                            <a class="btn btn-outline-danger" asp-page="Delete" asp-route-id="@term.Id">Delete</a>
+                        <div class="d-flex flex-wrap justify-content-end gap-2">
+                            <div class="btn-group btn-group-sm" role="group" aria-label="Actions for @term.Course?.Title term">
+                                <a class="btn btn-outline-secondary" asp-page="Edit" asp-route-id="@term.Id">Edit</a>
+                                <a class="btn btn-outline-danger" asp-page="Delete" asp-route-id="@term.Id">Delete</a>
+                            </div>
+                            <form method="post" asp-page-handler="ExportEnrollments" asp-route-id="@term.Id" class="d-inline">
+                                <button type="submit" class="btn btn-sm btn-outline-primary">Export XLSX</button>
+                            </form>
                         </div>
                     </td>
                 </tr>
@@ -85,4 +119,8 @@ else
             </tbody>
         </table>
     </div>
+}
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
 }

--- a/Pages/Admin/CourseTerms/Index.cshtml.cs
+++ b/Pages/Admin/CourseTerms/Index.cshtml.cs
@@ -1,11 +1,17 @@
+using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
+using OfficeOpenXml;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
 
@@ -21,9 +27,9 @@ public class IndexModel : PageModel
         _context = context;
     }
 
-    public IList<CourseTerm> Terms { get; set; } = new List<CourseTerm>();
+    public IList<CourseTerm> Terms { get; private set; } = new List<CourseTerm>();
 
-    public List<SelectListItem> CourseOptions { get; set; } = new();
+    public List<SelectListItem> CourseOptions { get; private set; } = new();
 
     [BindProperty(SupportsGet = true)]
     public int? CourseId { get; set; }
@@ -31,7 +37,366 @@ public class IndexModel : PageModel
     [BindProperty(SupportsGet = true)]
     public bool OnlyActive { get; set; }
 
+    [BindProperty]
+    public IFormFile? ImportFile { get; set; }
+
+    [TempData]
+    public string? StatusMessage { get; set; }
+
+    [TempData]
+    public string? ErrorMessage { get; set; }
+
     public async Task OnGetAsync()
+    {
+        await LoadPageDataAsync();
+    }
+
+    public async Task<IActionResult> OnPostExportEnrollmentsAsync(int id)
+    {
+        var term = await _context.CourseTerms
+            .AsNoTracking()
+            .Include(t => t.Course)
+            .Include(t => t.Enrollments)
+                .ThenInclude(e => e.User)
+            .FirstOrDefaultAsync(t => t.Id == id);
+
+        if (term == null)
+        {
+            return NotFound();
+        }
+
+        using var package = new ExcelPackage();
+        var worksheet = package.Workbook.Worksheets.Add("Enrollments");
+
+        var headers = new[]
+        {
+            "EnrollmentId",
+            "Status",
+            "UserId",
+            "UserEmail",
+            "UserName",
+            "UserPhoneNumber",
+            "CourseTermId",
+            "CourseTitle",
+            "Start (UTC)",
+            "End (UTC)"
+        };
+
+        for (var column = 0; column < headers.Length; column++)
+        {
+            worksheet.Cells[1, column + 1].Value = headers[column];
+            worksheet.Cells[1, column + 1].Style.Font.Bold = true;
+        }
+
+        var enrollments = term.Enrollments
+            .OrderBy(e => e.Id)
+            .ToList();
+
+        for (var index = 0; index < enrollments.Count; index++)
+        {
+            var row = index + 2;
+            var enrollment = enrollments[index];
+
+            worksheet.Cells[row, 1].Value = enrollment.Id;
+            worksheet.Cells[row, 2].Value = enrollment.Status.ToString();
+            worksheet.Cells[row, 3].Value = enrollment.UserId;
+            worksheet.Cells[row, 4].Value = enrollment.User?.Email;
+            worksheet.Cells[row, 5].Value = enrollment.User?.UserName;
+            worksheet.Cells[row, 6].Value = enrollment.User?.PhoneNumber;
+            worksheet.Cells[row, 7].Value = term.Id;
+            worksheet.Cells[row, 8].Value = term.Course?.Title ?? $"Course {term.CourseId}";
+
+            var startUtc = EnsureUtc(term.StartUtc);
+            var endUtc = EnsureUtc(term.EndUtc);
+
+            worksheet.Cells[row, 9].Value = startUtc;
+            worksheet.Cells[row, 9].Style.Numberformat.Format = "yyyy-mm-dd hh:mm";
+
+            worksheet.Cells[row, 10].Value = endUtc;
+            worksheet.Cells[row, 10].Style.Numberformat.Format = "yyyy-mm-dd hh:mm";
+        }
+
+        if (worksheet.Dimension != null)
+        {
+            worksheet.Cells[worksheet.Dimension.Address].AutoFitColumns();
+        }
+
+        var courseTitle = term.Course?.Title ?? $"Course_{term.CourseId}";
+        var safeCourseTitle = SanitizeForFileName(courseTitle);
+        var fileName = $"{safeCourseTitle}_term_{term.Id}_enrollments.xlsx";
+        var content = package.GetAsByteArray();
+
+        return File(content, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", fileName);
+    }
+
+    public async Task<IActionResult> OnPostImportAsync()
+    {
+        if (ImportFile == null || ImportFile.Length == 0)
+        {
+            ModelState.AddModelError(nameof(ImportFile), "Please select an XLSX file to import.");
+            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            await LoadPageDataAsync();
+            return Page();
+        }
+
+        if (!string.Equals(Path.GetExtension(ImportFile.FileName), ".xlsx", StringComparison.OrdinalIgnoreCase))
+        {
+            ModelState.AddModelError(nameof(ImportFile), "Only XLSX files are supported.");
+            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            await LoadPageDataAsync();
+            return Page();
+        }
+
+        var parsedRows = new List<CourseTermImportRow>();
+        var courseIds = new HashSet<int>();
+        var instructorIds = new HashSet<int>();
+
+        using (var stream = new MemoryStream())
+        {
+            await ImportFile.CopyToAsync(stream);
+            stream.Position = 0;
+
+            using var package = new ExcelPackage(stream);
+            var worksheet = package.Workbook.Worksheets.FirstOrDefault();
+            if (worksheet == null || worksheet.Dimension == null)
+            {
+                ModelState.AddModelError(nameof(ImportFile), "The uploaded file does not contain any data.");
+                ErrorMessage = "Import failed. Please review the highlighted issues.";
+                await LoadPageDataAsync();
+                return Page();
+            }
+
+            var headerMap = ReadHeaderMap(worksheet);
+            var requiredHeaders = new[] { "CourseId", "StartUtc", "EndUtc", "Capacity" };
+            foreach (var header in requiredHeaders)
+            {
+                if (!headerMap.ContainsKey(header))
+                {
+                    ModelState.AddModelError(nameof(ImportFile), $"Missing required column '{header}'.");
+                }
+            }
+
+            if (!ModelState.IsValid)
+            {
+                ErrorMessage = "Import failed. Please review the highlighted issues.";
+                await LoadPageDataAsync();
+                return Page();
+            }
+
+            var lastRow = worksheet.Dimension.End.Row;
+            for (var row = 2; row <= lastRow; row++)
+            {
+                if (IsRowEmpty(worksheet, row))
+                {
+                    continue;
+                }
+
+                var rowErrors = new List<string>();
+
+                int? id = null;
+                if (TryGetColumn(headerMap, "Id", out var idColumn))
+                {
+                    if (!TryGetNullableInt(worksheet.Cells[row, idColumn], out id))
+                    {
+                        rowErrors.Add("Invalid value for Id.");
+                    }
+                }
+
+                if (!TryGetInt(worksheet.Cells[row, headerMap["CourseId"]], out var courseId))
+                {
+                    rowErrors.Add("CourseId is required and must be a number.");
+                }
+                else
+                {
+                    courseIds.Add(courseId);
+                }
+
+                if (!TryGetDateTime(worksheet.Cells[row, headerMap["StartUtc"]], out var startUtc))
+                {
+                    rowErrors.Add("StartUtc is required and must be a valid date/time.");
+                }
+
+                if (!TryGetDateTime(worksheet.Cells[row, headerMap["EndUtc"]], out var endUtc))
+                {
+                    rowErrors.Add("EndUtc is required and must be a valid date/time.");
+                }
+
+                if (!TryGetInt(worksheet.Cells[row, headerMap["Capacity"]], out var capacity))
+                {
+                    rowErrors.Add("Capacity is required and must be a number.");
+                }
+                else if (capacity < 1)
+                {
+                    rowErrors.Add("Capacity must be at least 1.");
+                }
+
+                bool? isActive = null;
+                if (TryGetColumn(headerMap, "IsActive", out var isActiveColumn))
+                {
+                    if (!TryGetNullableBool(worksheet.Cells[row, isActiveColumn], out isActive))
+                    {
+                        rowErrors.Add("IsActive must be a boolean value.");
+                    }
+                }
+
+                int? instructorId = null;
+                if (TryGetColumn(headerMap, "InstructorId", out var instructorColumn))
+                {
+                    if (!TryGetNullableInt(worksheet.Cells[row, instructorColumn], out instructorId))
+                    {
+                        rowErrors.Add("InstructorId must be a number.");
+                    }
+                    else if (instructorId.HasValue)
+                    {
+                        instructorIds.Add(instructorId.Value);
+                    }
+                }
+
+                if (!rowErrors.Any() && EnsureUtc(startUtc) >= EnsureUtc(endUtc))
+                {
+                    rowErrors.Add("StartUtc must be earlier than EndUtc.");
+                }
+
+                if (rowErrors.Count > 0)
+                {
+                    ModelState.AddModelError(nameof(ImportFile), $"Row {row}: {string.Join(" ", rowErrors)}");
+                    continue;
+                }
+
+                parsedRows.Add(new CourseTermImportRow
+                {
+                    RowNumber = row,
+                    Id = id,
+                    CourseId = courseId,
+                    StartUtc = EnsureUtc(startUtc),
+                    EndUtc = EnsureUtc(endUtc),
+                    Capacity = capacity,
+                    IsActive = isActive,
+                    InstructorId = instructorId
+                });
+            }
+        }
+
+        if (!ModelState.IsValid)
+        {
+            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            await LoadPageDataAsync();
+            return Page();
+        }
+
+        if (parsedRows.Count == 0)
+        {
+            StatusMessage = "No course terms were found in the uploaded file.";
+            return RedirectToPage(new { CourseId, OnlyActive });
+        }
+
+        var existingCourseIds = await _context.Courses
+            .Where(c => courseIds.Contains(c.Id))
+            .Select(c => c.Id)
+            .ToListAsync();
+
+        foreach (var missingCourseId in courseIds.Except(existingCourseIds))
+        {
+            ModelState.AddModelError(nameof(ImportFile), $"Course with ID {missingCourseId} does not exist.");
+        }
+
+        if (instructorIds.Count > 0)
+        {
+            var existingInstructorIds = await _context.Instructors
+                .Where(i => instructorIds.Contains(i.Id))
+                .Select(i => i.Id)
+                .ToListAsync();
+
+            foreach (var missingInstructorId in instructorIds.Except(existingInstructorIds))
+            {
+                ModelState.AddModelError(nameof(ImportFile), $"Instructor with ID {missingInstructorId} does not exist.");
+            }
+        }
+
+        if (!ModelState.IsValid)
+        {
+            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            await LoadPageDataAsync();
+            return Page();
+        }
+
+        var rowsWithIds = parsedRows.Where(r => r.Id.HasValue).ToList();
+        var termsToUpdate = new Dictionary<int, CourseTerm>();
+
+        if (rowsWithIds.Count > 0)
+        {
+            var termIds = rowsWithIds.Select(r => r.Id!.Value).ToHashSet();
+            termsToUpdate = await _context.CourseTerms
+                .Where(t => termIds.Contains(t.Id))
+                .ToDictionaryAsync(t => t.Id);
+
+            foreach (var missingTermId in termIds.Except(termsToUpdate.Keys))
+            {
+                ModelState.AddModelError(nameof(ImportFile), $"Course term with ID {missingTermId} does not exist.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                ErrorMessage = "Import failed. Please review the highlighted issues.";
+                await LoadPageDataAsync();
+                return Page();
+            }
+        }
+
+        var created = 0;
+        var updated = 0;
+
+        foreach (var row in parsedRows)
+        {
+            CourseTerm term;
+            if (row.Id.HasValue)
+            {
+                term = termsToUpdate[row.Id.Value];
+                if (term.SeatsTaken > row.Capacity)
+                {
+                    ModelState.AddModelError(nameof(ImportFile), $"Row {row.RowNumber}: Capacity {row.Capacity} is smaller than the current number of seats taken ({term.SeatsTaken}).");
+                    continue;
+                }
+
+                updated++;
+            }
+            else
+            {
+                term = new CourseTerm
+                {
+                    SeatsTaken = 0
+                };
+                _context.CourseTerms.Add(term);
+                created++;
+            }
+
+            term.CourseId = row.CourseId;
+            term.StartUtc = row.StartUtc;
+            term.EndUtc = row.EndUtc;
+            term.Capacity = row.Capacity;
+
+            if (row.IsActive.HasValue)
+            {
+                term.IsActive = row.IsActive.Value;
+            }
+
+            term.InstructorId = row.InstructorId;
+        }
+
+        if (!ModelState.IsValid)
+        {
+            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            await LoadPageDataAsync();
+            return Page();
+        }
+
+        await _context.SaveChangesAsync();
+
+        StatusMessage = $"Imported {created} new term(s) and updated {updated} existing term(s).";
+        return RedirectToPage(new { CourseId, OnlyActive });
+    }
+
+    private async Task LoadPageDataAsync()
     {
         var courseQuery = _context.Courses
             .AsNoTracking()
@@ -59,5 +424,280 @@ public class IndexModel : PageModel
         Terms = await termQuery
             .OrderByDescending(t => t.StartUtc)
             .ToListAsync();
+    }
+
+    private static Dictionary<string, int> ReadHeaderMap(ExcelWorksheet worksheet)
+    {
+        var headers = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var endColumn = worksheet.Dimension?.End.Column ?? 0;
+
+        for (var column = 1; column <= endColumn; column++)
+        {
+            var header = worksheet.Cells[1, column].GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(header))
+            {
+                headers[header.Trim()] = column;
+            }
+        }
+
+        return headers;
+    }
+
+    private static bool TryGetColumn(Dictionary<string, int> headerMap, string key, out int column)
+    {
+        return headerMap.TryGetValue(key, out column);
+    }
+
+    private static bool IsRowEmpty(ExcelWorksheet worksheet, int row)
+    {
+        var endColumn = worksheet.Dimension?.End.Column ?? 0;
+        for (var column = 1; column <= endColumn; column++)
+        {
+            var value = worksheet.Cells[row, column].Value;
+            if (value is string stringValue)
+            {
+                if (!string.IsNullOrWhiteSpace(stringValue))
+                {
+                    return false;
+                }
+            }
+            else if (value != null)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetInt(ExcelRange cell, out int value)
+    {
+        var success = TryGetNullableInt(cell, out var nullable);
+        if (success && nullable.HasValue)
+        {
+            value = nullable.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetNullableInt(ExcelRange cell, out int? value)
+    {
+        var raw = cell.Value;
+
+        if (raw == null)
+        {
+            value = null;
+            return true;
+        }
+
+        if (raw is string stringValue && string.IsNullOrWhiteSpace(stringValue))
+        {
+            value = null;
+            return true;
+        }
+
+        if (raw is int intValue)
+        {
+            value = intValue;
+            return true;
+        }
+
+        if (raw is long longValue)
+        {
+            value = Convert.ToInt32(longValue);
+            return true;
+        }
+
+        if (raw is double doubleValue)
+        {
+            if (Math.Abs(doubleValue % 1d) > double.Epsilon)
+            {
+                value = null;
+                return false;
+            }
+
+            value = Convert.ToInt32(Math.Round(doubleValue, MidpointRounding.AwayFromZero));
+            return true;
+        }
+
+        if (raw is decimal decimalValue)
+        {
+            if (decimalValue % 1m != 0m)
+            {
+                value = null;
+                return false;
+            }
+
+            value = (int)decimalValue;
+            return true;
+        }
+
+        if (raw is string stringNumber)
+        {
+            if (int.TryParse(stringNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ||
+                int.TryParse(stringNumber, NumberStyles.Integer, CultureInfo.CurrentCulture, out parsed))
+            {
+                value = parsed;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static bool TryGetDateTime(ExcelRange cell, out DateTime value)
+    {
+        var raw = cell.Value;
+
+        if (raw == null)
+        {
+            value = default;
+            return false;
+        }
+
+        if (raw is DateTime dateTime)
+        {
+            value = dateTime;
+            return true;
+        }
+
+        if (raw is double doubleValue)
+        {
+            value = DateTime.FromOADate(doubleValue);
+            return true;
+        }
+
+        if (raw is string stringValue)
+        {
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                value = default;
+                return false;
+            }
+
+            if (DateTime.TryParse(stringValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed) ||
+                DateTime.TryParse(stringValue, CultureInfo.CurrentCulture, DateTimeStyles.None, out parsed))
+            {
+                value = parsed;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetNullableBool(ExcelRange cell, out bool? value)
+    {
+        var raw = cell.Value;
+
+        if (raw == null)
+        {
+            value = null;
+            return true;
+        }
+
+        if (raw is string stringValue)
+        {
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                value = null;
+                return true;
+            }
+
+            var normalized = stringValue.Trim();
+
+            if (bool.TryParse(normalized, out var parsedBool))
+            {
+                value = parsedBool;
+                return true;
+            }
+
+            if (string.Equals(normalized, "1", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "ano", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "yes", StringComparison.OrdinalIgnoreCase))
+            {
+                value = true;
+                return true;
+            }
+
+            if (string.Equals(normalized, "0", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "ne", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(normalized, "no", StringComparison.OrdinalIgnoreCase))
+            {
+                value = false;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        if (raw is bool boolValue)
+        {
+            value = boolValue;
+            return true;
+        }
+
+        if (raw is double doubleValue)
+        {
+            if (Math.Abs(doubleValue) < double.Epsilon)
+            {
+                value = false;
+                return true;
+            }
+
+            if (Math.Abs(doubleValue - 1d) < double.Epsilon)
+            {
+                value = true;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+    }
+
+    private static string SanitizeForFileName(string input)
+    {
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var builder = new StringBuilder(input.Length);
+
+        foreach (var character in input)
+        {
+            builder.Append(invalidChars.Contains(character) ? '_' : character);
+        }
+
+        var sanitized = builder.ToString();
+        return string.IsNullOrWhiteSpace(sanitized) ? "course" : sanitized;
+    }
+
+    private sealed class CourseTermImportRow
+    {
+        public int RowNumber { get; init; }
+        public int? Id { get; init; }
+        public int CourseId { get; init; }
+        public DateTime StartUtc { get; init; }
+        public DateTime EndUtc { get; init; }
+        public int Capacity { get; init; }
+        public bool? IsActive { get; init; }
+        public int? InstructorId { get; init; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -18,6 +18,7 @@ using SysJaky_N.Middleware;
 using RazorLight;
 using Microsoft.Extensions.Hosting;
 using System.IO;
+using OfficeOpenXml;
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
@@ -25,6 +26,8 @@ Log.Logger = new LoggerConfiguration()
 
 try
 {
+    ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
     var builder = WebApplication.CreateBuilder(args);
 
     builder.Host.UseSerilog((context, services, configuration) =>

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Ixnas.AltchaNet" Version="1.1.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0" />
+    <PackageReference Include="EPPlus" Version="7.2.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add the EPPlus dependency and configure the license context on startup
- enable admins to export course term enrollments and import course terms from XLSX files
- expand the course term index page with upload UI, status messaging, and validation helpers

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c59ecb2c8321a920aca456cc4471