### PR TITLE
Allow dev BrowserLink connections in CSP

### DIFF
--- a/Middleware/ContentSecurityPolicyMiddleware.cs
+++ b/Middleware/ContentSecurityPolicyMiddleware.cs
@@ -1,27 +1,40 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 
 namespace SysJaky_N.Middleware;
 
 public class ContentSecurityPolicyMiddleware
 {
     private const string HeaderName = "Content-Security-Policy";
-    private const string PolicyValue =
-        "default-src 'self'; " +
-        "script-src 'self' 'unsafe-inline'; " +
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
-        "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net data:; " +
-        "img-src 'self' data:; " +
-        "connect-src 'self'; " +
-        "form-action 'self'; " +
-        "frame-ancestors 'self'; " +
-        "object-src 'none';";
 
     private readonly RequestDelegate _next;
+    private readonly string _policyValue;
 
-    public ContentSecurityPolicyMiddleware(RequestDelegate next)
+    public ContentSecurityPolicyMiddleware(RequestDelegate next, IHostEnvironment environment)
     {
         _next = next;
+        _policyValue = BuildPolicyValue(environment);
+    }
+
+    private static string BuildPolicyValue(IHostEnvironment environment)
+    {
+        var connectSources = "'self'";
+        if (environment.IsDevelopment())
+        {
+            connectSources += " http://localhost:* https://localhost:* ws://localhost:* wss://localhost:*";
+        }
+
+        return
+            "default-src 'self'; " +
+            "script-src 'self' 'unsafe-inline'; " +
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
+            "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net data:; " +
+            "img-src 'self' data:; " +
+            $"connect-src {connectSources}; " +
+            "form-action 'self'; " +
+            "frame-ancestors 'self'; " +
+            "object-src 'none';";
     }
 
     public Task InvokeAsync(HttpContext context)
@@ -30,7 +43,7 @@ public class ContentSecurityPolicyMiddleware
         {
             if (!context.Response.Headers.ContainsKey(HeaderName))
             {
-                context.Response.Headers[HeaderName] = PolicyValue;
+                context.Response.Headers[HeaderName] = _policyValue;
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
## Summary
- update the content security policy middleware to build its policy string dynamically
- allow localhost http/https/ws connections during development so BrowserLink can negotiate successfully

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca94d24c9c8321ba560780e5996a00