### PR TITLE
Restructure admin navigation into dashboard entry

### DIFF
--- a/Authorization/ApplicationRoles.cs
+++ b/Authorization/ApplicationRoles.cs
@@ -10,6 +10,12 @@ public static class ApplicationRoles
     public const string CompanyManager = "CompanyManager";
     public const string StudentCustomer = "Student\\Customer";
 
+    public static IReadOnlyCollection<string> AdminDashboardRoles { get; } = new[]
+    {
+        Admin,
+        Editor
+    };
+
     public static IReadOnlyCollection<string> All { get; } = new[]
     {
         Admin,

--- a/Authorization/AuthorizationPolicies.cs
+++ b/Authorization/AuthorizationPolicies.cs
@@ -3,6 +3,7 @@ namespace SysJaky_N.Authorization;
 public static class AuthorizationPolicies
 {
     public const string AdminOnly = nameof(AdminOnly);
+    public const string AdminDashboardAccess = nameof(AdminDashboardAccess);
     public const string AdminOrInstructor = nameof(AdminOrInstructor);
     public const string EditorOnly = nameof(EditorOnly);
     public const string CompanyManagerOnly = nameof(CompanyManagerOnly);

--- a/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -1,11 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Authorization;
 using SysJaky_N.Data;
 
 namespace SysJaky_N.Pages.Admin.Dashboard;
 
-[Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+[Authorize(Policy = AuthorizationPolicies.AdminDashboardAccess)]
 public class IndexModel : PageModel
 {
     private readonly ApplicationDbContext _context;

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -52,13 +52,6 @@
     </div>
 </form>
 
-@if (User.IsInRole("Admin"))
-{
-    <p>
-        <a asp-page="Create">Create New</a>
-    </p>
-}
-
 <table class="table">
     <thead>
         <tr>
@@ -91,18 +84,10 @@
             <td>@item.Price</td>
             <td>@item.Date.ToString("d")</td>
             <td>
-                @if (User.IsInRole("Admin"))
-                {
-                    <a asp-page="Edit" asp-route-id="@item.Id">Edit</a> 
-                    <a asp-page="Delete" asp-route-id="@item.Id">Delete</a>
-                }
-                else
-                {
-                    <form method="post" asp-page-handler="AddToCart" style="display:inline">
-                        <input type="hidden" name="courseId" value="@item.Id" />
-                        <button type="submit" aria-label="Add @item.Title to cart">Add to cart</button>
-                    </form>
-                }
+                <form method="post" asp-page-handler="AddToCart" style="display:inline">
+                    <input type="hidden" name="courseId" value="@item.Id" />
+                    <button type="submit" aria-label="Add @item.Title to cart">Add to cart</button>
+                </form>
             </td>
         </tr>
     }

--- a/Pages/Orders/Index.cshtml
+++ b/Pages/Orders/Index.cshtml
@@ -26,10 +26,6 @@
             <td>@order.Total</td>
             <td>
                 <a asp-page="Details" asp-route-id="@order.Id">Details</a>
-                @if (User.IsInRole("Admin"))
-                {
-                    <text> | <a asp-page="Edit" asp-route-id="@order.Id">Change Status</a></text>
-                }
             </td>
         </tr>
     }

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,6 @@
-﻿<!DOCTYPE html>
+@using System.Linq
+@using SysJaky_N.Authorization
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -23,46 +25,55 @@
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
-                    <ul class="navbar-nav flex-grow-1">
+                    @{
+                        var currentPage = ViewContext.RouteData.Values["page"]?.ToString();
+                        var canAccessAdmin = ApplicationRoles.AdminDashboardRoles.Any(role => User.IsInRole(role));
+                    }
+                    <ul class="navbar-nav me-auto mb-2 mb-sm-0">
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Index" ? "page" : null)">Home</a>
+                            <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Privacy" ? "page" : null)">Privacy</a>
+                            <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">Privacy</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Courses/Index" ? "page" : null)">Courses</a>
+                            <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">Courses</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Articles/Index" ? "page" : null)">Articles</a>
+                            <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(currentPage == "/Articles/Index" ? "page" : null)">Articles</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Contact" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Contact" ? "page" : null)">Contact</a>
+                            <a class="nav-link" asp-area="" asp-page="/Contact" aria-current="@(currentPage == "/Contact" ? "page" : null)">Contact</a>
                         </li>
-                        @if (User.IsInRole("Admin"))
+                    </ul>
+                    <ul class="navbar-nav ms-auto align-items-center gap-2 mb-2 mb-sm-0">
+                        @if (canAccessAdmin)
                         {
                             <li class="nav-item">
-                                <a class="nav-link" asp-page="/Admin/Dashboard/Index">Admin</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-page="/Admin/Articles/Index" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Admin/Articles/Index" ? "page" : null)">Manage Articles</a>
+                                <a class="nav-link d-flex align-items-center gap-1" asp-page="/Admin/Dashboard/Index">
+                                    <i class="bi bi-speedometer2"></i>
+                                    <span>Admin Dashboard</span>
+                                </a>
                             </li>
                         }
-                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Cart" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Cart" ? "page" : null)">Cart</a>
-                        </li>
                         @if (!User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
-                                <a class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#authModal">Login / Register</a>
+                                <a class="btn btn-outline-light ms-sm-2" data-bs-toggle="modal" data-bs-target="#authModal">Login / Register</a>
                             </li>
                         }
                         else
                         {
                             <li class="nav-item">
-                                <a class="nav-link" asp-page="/Account/Manage" aria-current="@(ViewContext.RouteData.Values["page"]?.ToString() == "/Account/Manage" ? "page" : null)">@User.Identity?.Name</a>
+                                <a class="btn btn-outline-light ms-sm-2" asp-page="/Account/Manage">@User.Identity?.Name</a>
                             </li>
                         }
+                        <li class="nav-item">
+                            <a class="nav-link position-relative @(currentPage == "/Cart" ? "active" : null)" asp-area="" asp-page="/Cart" aria-label="Shopping cart">
+                                <i class="bi bi-cart fs-5"></i>
+                                <span class="visually-hidden">Cart</span>
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add an AdminDashboardRoles list and policy so the dashboard is reachable for configured roles
- simplify the public layout to expose a single Admin Dashboard link and cart icon while moving admin actions out of public pages
- adjust course and order listings to remove inline admin controls in favor of the dashboard

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68db8d8929a08321acb39533afbc5d30