### PR TITLE
Refine UI styling with core color palette

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -5,36 +5,52 @@
     ViewData["Title"] = "Home page";
 }
 
-<section class="text-center py-5 bg-light">
-    <h1 class="display-4">@Localizer["HeroTitle"]</h1>
-    <p class="lead">@Localizer["HeroDescription"]</p>
+<section class="hero text-center">
+    <div class="container-xl">
+        <h1 class="display-4 mb-3">@Localizer["HeroTitle"]</h1>
+        <p class="lead mx-auto">@Localizer["HeroDescription"]</p>
+    </div>
 </section>
 
-<section class="py-5">
-    <h2 class="text-center mb-4">@Localizer["HowItWorksTitle"]</h2>
-    <div class="row text-center">
-        <div class="col-md-4">
-            <i class="bi bi-journal display-4 mb-3"></i>
-            <h3>@Localizer["StepSelectTitle"]</h3>
-            <p>@Localizer["StepSelectDescription"]</p>
-        </div>
-        <div class="col-md-4">
-            <i class="bi bi-person-check display-4 mb-3"></i>
-            <h3>@Localizer["StepRegisterTitle"]</h3>
-            <p>@Localizer["StepRegisterDescription"]</p>
-        </div>
-        <div class="col-md-4">
-            <i class="bi bi-credit-card display-4 mb-3"></i>
-            <h3>@Localizer["StepPayTitle"]</h3>
-            <p>@Localizer["StepPayDescription"]</p>
+<section class="app-section">
+    <div class="container-xl">
+        <h2 class="section-title text-center">@Localizer["HowItWorksTitle"]</h2>
+        <div class="row g-4 text-center">
+            <div class="col-md-4">
+                <div class="feature-card h-100 p-4">
+                    <div class="icon-circle mx-auto mb-3">
+                        <i class="bi bi-journal"></i>
+                    </div>
+                    <h3 class="h5">@Localizer["StepSelectTitle"]</h3>
+                    <p class="mb-0">@Localizer["StepSelectDescription"]</p>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="feature-card h-100 p-4">
+                    <div class="icon-circle mx-auto mb-3">
+                        <i class="bi bi-person-check"></i>
+                    </div>
+                    <h3 class="h5">@Localizer["StepRegisterTitle"]</h3>
+                    <p class="mb-0">@Localizer["StepRegisterDescription"]</p>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="feature-card h-100 p-4">
+                    <div class="icon-circle mx-auto mb-3">
+                        <i class="bi bi-credit-card"></i>
+                    </div>
+                    <h3 class="h5">@Localizer["StepPayTitle"]</h3>
+                    <p class="mb-0">@Localizer["StepPayDescription"]</p>
+                </div>
+            </div>
         </div>
     </div>
 </section>
 
-<section class="py-5 bg-white">
-    <div class="container">
-        <h2 class="text-center mb-4">Why Choose Our Platform?</h2>
-        <p class="text-center">Our courses are crafted by experts and delivered in an accessible format that helps you learn quickly and effectively.</p>
+<section class="app-section app-section-alt">
+    <div class="container-xl text-center">
+        <h2 class="section-title mb-3">Why Choose Our Platform?</h2>
+        <p class="mx-auto app-section-description">Our courses are crafted by experts and delivered in an accessible format that helps you learn quickly and effectively.</p>
     </div>
 </section>
 

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -14,22 +14,22 @@
     <link rel="stylesheet" href="~/lib/altcha/altcha.min.css" />
     @await RenderSectionAsync("Head", required: false)
 </head>
-<body>
+<body class="app-body">
     <a class="visually-hidden-focusable" href="#main-content">Přeskočit na obsah</a>
-    <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-primary border-bottom box-shadow mb-3" role="navigation">
-            <div class="container">
+    <header class="app-header">
+        <nav class="navbar navbar-expand-lg navbar-toggleable-lg navbar-dark app-navbar" role="navigation">
+            <div class="container-xl">
                 <a class="navbar-brand" asp-area="" asp-page="/Index">SysJaky_N</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                <div class="navbar-collapse collapse d-lg-inline-flex justify-content-between">
                     @{
                         var currentPage = ViewContext.RouteData.Values["page"]?.ToString();
                         var canAccessAdmin = ApplicationRoles.AdminDashboardRoles.Any(role => User.IsInRole(role));
                     }
-                    <ul class="navbar-nav me-auto mb-2 mb-sm-0">
+                    <ul class="navbar-nav me-auto mb-2 mb-lg-0 gap-lg-1">
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">Home</a>
                         </li>
@@ -46,7 +46,7 @@
                             <a class="nav-link" asp-area="" asp-page="/Contact" aria-current="@(currentPage == "/Contact" ? "page" : null)">Contact</a>
                         </li>
                     </ul>
-                    <ul class="navbar-nav ms-auto align-items-center gap-2 mb-2 mb-sm-0">
+                    <ul class="navbar-nav ms-auto align-items-center gap-3 mb-2 mb-lg-0">
                         @if (canAccessAdmin)
                         {
                             <li class="nav-item">
@@ -59,13 +59,13 @@
                         @if (!User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
-                                <a class="btn btn-outline-light ms-sm-2" data-bs-toggle="modal" data-bs-target="#authModal">Login / Register</a>
+                                <a class="btn btn-outline-light" data-bs-toggle="modal" data-bs-target="#authModal">Login / Register</a>
                             </li>
                         }
                         else
                         {
                             <li class="nav-item">
-                                <a class="btn btn-outline-light ms-sm-2" asp-page="/Account/Manage">@User.Identity?.Name</a>
+                                <a class="btn btn-outline-light" asp-page="/Account/Manage">@User.Identity?.Name</a>
                             </li>
                         }
                         <li class="nav-item">
@@ -79,14 +79,14 @@
             </div>
         </nav>
     </header>
-    <div class="container">
-        <main id="main-content" role="main" class="pb-3">
+    <div class="app-content container-xl px-3 px-md-4">
+        <main id="main-content" role="main" class="app-main">
             @RenderBody()
         </main>
     </div>
 
-    <footer class="border-top footer text-muted">
-        <div class="container">
+    <footer class="footer app-footer text-muted mt-5">
+        <div class="container-xl">
             &copy; 2025 - SysJaky_N - <a asp-area="" asp-page="/Privacy">Privacy</a>
         </div>
     </footer>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -10,11 +10,35 @@ html {
 
 :root {
   --primary: #1E88B8;
+  --primary-dark: #166d92;
+  --primary-light: #3aa0cc;
   --accent: #F3C04D;
-  --secondary: #5C6B77;
-  --text: #2D3A45;
-  --box-bg: #F7F7F9;
-  --box-border: #E7E9EE;
+  --accent-dark: #dca437;
+  --neutral-100: #ffffff;
+  --neutral-200: #f7f7f9;
+  --neutral-300: #e7e9ee;
+  --neutral-400: #ccd2d9;
+  --neutral-500: #5c6b77;
+  --neutral-700: #2d3a45;
+  --shadow-soft: 0 24px 48px rgba(30, 136, 184, 0.12);
+}
+
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  background: linear-gradient(180deg, rgba(30, 136, 184, 0.12) 0%, rgba(255, 255, 255, 0) 35%), var(--neutral-200);
+  color: var(--neutral-700);
+}
+
+.app-body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .visually-hidden-focusable:not(:focus):not(:focus-within) {
@@ -29,7 +53,8 @@ html {
   border: 0;
 }
 
-.visually-hidden-focusable:focus, .visually-hidden-focusable:focus-within {
+.visually-hidden-focusable:focus,
+.visually-hidden-focusable:focus-within {
   position: static;
   width: auto;
   height: auto;
@@ -39,103 +64,273 @@ html {
   white-space: normal;
 }
 
-.btn:focus,
-.btn:active:focus,
-.btn-link.nav-link:focus,
-.form-control:focus,
-.form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem #fff, 0 0 0 0.25rem rgba(30, 136, 184, 0.4);
-}
-
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-body {
-  margin-bottom: 60px;
-  font-family: 'Roboto', sans-serif;
-  background-color: var(--box-bg);
-  color: var(--text);
-}
-
 a {
   color: var(--primary);
+  text-decoration: none;
+  transition: color 0.25s ease, background-color 0.25s ease, box-shadow 0.25s ease;
 }
 
 a:hover,
 a:focus {
-  color: var(--secondary);
-  background-color: var(--accent);
+  color: var(--primary-dark);
 }
 
 a:focus-visible,
 button:focus-visible {
-  outline: 2px solid var(--primary);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
-.bg-primary {
-  background-color: var(--primary) !important;
+.app-header {
+  background: var(--neutral-100);
+  box-shadow: 0 8px 20px rgba(12, 56, 87, 0.08);
 }
 
-.navbar-dark .nav-link {
+.app-navbar {
+  background: linear-gradient(120deg, var(--primary) 0%, var(--primary-dark) 55%, var(--primary-light) 100%);
+  padding-block: 1rem;
+}
+
+.navbar-brand {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.app-navbar .navbar-brand {
+  color: var(--neutral-100);
+}
+
+.app-navbar .navbar-brand:hover,
+.app-navbar .navbar-brand:focus {
   color: var(--accent);
 }
 
-.navbar-dark .nav-link:hover,
-.navbar-dark .nav-link:focus {
-  color: #fff;
+.app-navbar .nav-link {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+}
+
+.app-navbar .nav-link:hover,
+.app-navbar .nav-link:focus {
+  color: var(--neutral-100);
+  background-color: rgba(243, 192, 77, 0.2);
+}
+
+.app-navbar .nav-link.active,
+.app-navbar .nav-link[aria-current="page"] {
+  background-color: var(--accent);
+  color: var(--primary-dark);
+  box-shadow: 0 10px 22px rgba(243, 192, 77, 0.3);
+}
+
+.btn {
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.5rem 1.5rem;
 }
 
 .btn-primary {
-  color: #fff;
+  color: var(--neutral-100);
   background-color: var(--primary);
   border-color: var(--primary);
+  box-shadow: 0 10px 20px rgba(30, 136, 184, 0.35);
 }
 
 .btn-primary:hover,
 .btn-primary:focus {
-  color: var(--text);
+  color: var(--neutral-100);
+  background-color: var(--primary-dark);
+  border-color: var(--primary-dark);
+}
+
+.btn-outline-light {
+  color: var(--neutral-100);
+  border-color: rgba(255, 255, 255, 0.7);
+  background-color: transparent;
+}
+
+.btn-outline-light:hover,
+.btn-outline-light:focus {
+  color: var(--primary-dark);
   background-color: var(--accent);
   border-color: var(--accent);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+.app-content {
+  flex: 1 0 auto;
+  width: 100%;
+}
+
+.app-main {
+  background: var(--neutral-100);
+  border-radius: 1.75rem;
+  border: 1px solid var(--neutral-300);
+  box-shadow: 0 24px 48px rgba(12, 56, 87, 0.08);
+  padding: clamp(2.25rem, 4vw, 3.5rem);
+  margin-block: clamp(2rem, 5vw, 3.5rem);
+}
+
+.app-section {
+  padding: clamp(3rem, 6vw, 5rem) 0;
+}
+
+.section-title {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  font-weight: 700;
   color: var(--primary);
+  margin-bottom: 2.5rem;
+}
+
+.app-section-description {
+  max-width: 52ch;
+  color: var(--neutral-500);
+}
+
+.app-section-alt {
+  background: linear-gradient(180deg, rgba(30, 136, 184, 0.08) 0%, rgba(255, 255, 255, 0) 75%);
+  border-radius: 1.75rem;
+}
+
+.hero {
+  position: relative;
+  padding: clamp(4rem, 7vw, 6.5rem) 0 clamp(4rem, 8vw, 7.5rem);
+  color: var(--neutral-100);
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 60%, var(--accent) 100%);
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 55%),
+              radial-gradient(circle at bottom left, rgba(243, 192, 77, 0.25), transparent 60%);
+  pointer-events: none;
+}
+
+.hero .container-xl {
+  position: relative;
+  z-index: 1;
+}
+
+.hero .display-4 {
+  font-weight: 700;
+}
+
+.hero .lead {
+  max-width: 60ch;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.icon-circle {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 1.75rem;
+  color: var(--primary-dark);
+  background: radial-gradient(circle at 30% 30%, rgba(243, 192, 77, 0.85), rgba(255, 221, 135, 0.7));
+  box-shadow: 0 12px 25px rgba(243, 192, 77, 0.25);
+}
+
+.feature-card {
+  background: var(--neutral-100);
+  border: 1px solid var(--neutral-300);
+  border-radius: 1.5rem;
+  box-shadow: 0 12px 32px rgba(12, 56, 87, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.feature-card:hover,
+.feature-card:focus-within {
+  transform: translateY(-6px);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-soft);
 }
 
 .card,
 .modal-content {
-  background-color: var(--box-bg);
-  border-color: var(--box-border);
-  color: var(--text);
+  background-color: var(--neutral-100);
+  border: 1px solid var(--neutral-300);
+  border-radius: 1.25rem;
+  color: var(--neutral-700);
+  box-shadow: 0 20px 40px rgba(12, 56, 87, 0.1);
 }
 
 .form-control,
 .form-select {
-  border-color: var(--box-border);
-  color: var(--text);
-  background-color: #fff;
+  border-radius: 0.75rem;
+  border-color: var(--neutral-300);
+  color: var(--neutral-700);
+  background-color: var(--neutral-100);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .form-control:focus,
 .form-select:focus {
   border-color: var(--primary);
-  box-shadow: 0 0 0 0.25rem rgba(30, 136, 184, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(30, 136, 184, 0.2);
 }
 
-footer.footer {
-  background-color: var(--box-bg);
-  border-top: 1px solid var(--box-border);
-  color: var(--secondary);
+.table {
+  background: var(--neutral-100);
+  border-radius: 1rem;
+  overflow: hidden;
 }
 
-footer.footer a {
+.table thead {
+  background: rgba(30, 136, 184, 0.08);
+  color: var(--primary-dark);
+}
+
+.table-striped > tbody > tr:nth-of-type(odd) > * {
+  background-color: rgba(30, 136, 184, 0.03);
+}
+
+footer.app-footer {
+  background: var(--neutral-100);
+  border-top: 1px solid var(--neutral-300);
+  color: var(--neutral-500);
+  padding: 2.5rem 0;
+}
+
+footer.app-footer a {
   color: var(--primary);
+  font-weight: 600;
+}
+
+footer.app-footer a:hover,
+footer.app-footer a:focus {
+  color: var(--primary-dark);
+}
+
+@media (max-width: 991.98px) {
+  .app-navbar .nav-link {
+    border-radius: 0.75rem;
+    text-align: center;
+  }
+
+  .app-main {
+    margin-block: 1.5rem 2.5rem;
+    padding: clamp(1.75rem, 6vw, 2.75rem);
+  }
+}
+
+@media (max-width: 575.98px) {
+  .hero {
+    text-align: left;
+  }
+
+  .hero .lead {
+    margin: 0;
+  }
+
+  .icon-circle {
+    width: 3.5rem;
+    height: 3.5rem;
+    font-size: 1.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- restyle the shared layout shell and navigation with the blue and yellow brand colors
- refresh the home page hero and feature sections with structured cards and icon treatments
- expand the global stylesheet with palette variables and consistent component styling using neutral tones

## Testing
- not run (dotnet CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db9452ad3883218500d3e86acb851d