### PR TITLE
Align site styles with brand palette

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -9,18 +9,32 @@ html {
 }
 
 :root {
-  --primary: #1E88B8;
-  --primary-dark: #166d92;
-  --primary-light: #3aa0cc;
-  --accent: #F3C04D;
-  --accent-dark: #dca437;
+  /* Firemní brand */
+  --primary: #1ca8d7;
+  --primary-dark: #168bb3;
+  --primary-light: #33b6e0;
+
+  --accent: #fecc44;
+  --accent-dark: #e6b73d;
+  --accent-ink: #0f172a;
+
+  /* Neutrály */
+  --neutral-900: #0f172a;
+  --neutral-700: #334155;
+  --neutral-500: #64748b;
+  --neutral-300: #e2e8f0;
   --neutral-100: #ffffff;
-  --neutral-200: #f7f7f9;
-  --neutral-300: #e7e9ee;
-  --neutral-400: #ccd2d9;
-  --neutral-500: #5c6b77;
-  --neutral-700: #2d3a45;
-  --shadow-soft: 0 24px 48px rgba(30, 136, 184, 0.12);
+
+  /* Legacy scale & efekty */
+  --neutral-200: #f8fafc;
+  --neutral-400: #cbd5e1;
+  --shadow-soft: 0 24px 48px rgba(28, 168, 215, 0.12);
+
+  /* Bootstrap CSS variables (override) */
+  --bs-primary: var(--primary);
+  --bs-secondary: var(--accent);
+  --bs-link-color: var(--primary);
+  --bs-link-hover-color: var(--primary-dark);
 }
 
 html {
@@ -76,7 +90,9 @@ a:focus {
 }
 
 a:focus-visible,
-button:focus-visible {
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -135,7 +151,7 @@ button:focus-visible {
   color: var(--neutral-100);
   background-color: var(--primary);
   border-color: var(--primary);
-  box-shadow: 0 10px 20px rgba(30, 136, 184, 0.35);
+  box-shadow: 0 10px 20px rgba(28, 168, 215, 0.35);
 }
 
 .btn-primary:hover,
@@ -143,6 +159,19 @@ button:focus-visible {
   color: var(--neutral-100);
   background-color: var(--primary-dark);
   border-color: var(--primary-dark);
+}
+
+.btn-secondary {
+  color: var(--accent-ink);
+  background-color: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 10px 20px rgba(254, 204, 68, 0.35);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background-color: var(--accent-dark);
+  border-color: var(--accent-dark);
 }
 
 .btn-outline-light {
@@ -156,6 +185,16 @@ button:focus-visible {
   color: var(--primary-dark);
   background-color: var(--accent);
   border-color: var(--accent);
+}
+
+.badge-soft-primary {
+  background: color-mix(in oklab, var(--primary) 15%, white);
+  color: var(--primary-dark);
+}
+
+.badge-soft-accent {
+  background: color-mix(in oklab, var(--accent) 25%, white);
+  color: var(--accent-ink);
 }
 
 .app-content {


### PR DESCRIPTION
## Summary
- align root CSS variables with the corporate palette and override Bootstrap link colors
- update primary and secondary buttons, badges, and focus outlines for improved accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba2c02ab48321af89d7bf0c6f48af