### PR TITLE
Adjust feature card hover styling

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -285,9 +285,9 @@ select:focus-visible {
 
 .feature-card:hover,
 .feature-card:focus-within {
-  transform: translateY(-6px);
+  transform: translateY(-4px);
   border-color: var(--accent);
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 16px 36px rgba(12, 56, 87, 0.12);
 }
 
 .card,


### PR DESCRIPTION
## Summary
- align the feature card hover effect with the soft UI spec by reducing lift and matching the shadow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba737740883218143913963c51dda