### PR TITLE
Adjust courses layout and CTA styling

### DIFF
--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -179,19 +179,28 @@
         </section>
     </div>
     <div class="col-lg-4">
-        <div class="p-3 border rounded-3">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-                <strong>Cena</strong>
-                <div class="fs-5 fw-bold">@Model.Course.Price.ToString("C")</div>
+        <aside class="course-cta-card" aria-labelledby="course-cta-title">
+            <div class="course-cta-card__price">
+                <strong id="course-cta-title">Cena kurzu</strong>
+                <div class="fs-4 fw-bold text-primary">@Model.Course.Price.ToString("C")</div>
             </div>
             <div class="d-grid gap-2">
                 <form method="post">
-                    <button type="submit" class="btn btn-primary">Přihlásit se</button>
+                    <button type="submit" class="btn btn-primary d-flex align-items-center justify-content-center gap-2">
+                        <i class="bi bi-cart-plus"></i>
+                        <span>Přihlásit se</span>
+                    </button>
                 </form>
-                <a class="btn btn-secondary" href="/Courses/ICS/@Model.Course.Id">Přidat do kalendáře</a>
-                <a class="btn btn-outline-secondary" asp-page="/Contact">Firemní poptávka</a>
+                <a class="btn btn-secondary d-flex align-items-center justify-content-center gap-2" href="/Courses/ICS/@Model.Course.Id">
+                    <i class="bi bi-calendar-plus"></i>
+                    <span>Přidat do kalendáře</span>
+                </a>
+                <a class="btn btn-outline-secondary d-flex align-items-center justify-content-center gap-2" asp-page="/Contact">
+                    <i class="bi bi-building"></i>
+                    <span>Firemní poptávka</span>
+                </a>
             </div>
-        </div>
+        </aside>
 
         @if (User.Identity?.IsAuthenticated ?? false)
         {

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -53,12 +53,10 @@
     </div>
 </form>
 
-<div class="row g-3">
+<div class="courses-grid">
     @foreach (var c in Model.Courses)
     {
-        <div class="col-12 col-md-6 col-lg-4">
-            @await Html.PartialAsync("/Pages/Shared/Components/_CourseCard.cshtml", c)
-        </div>
+        @await Html.PartialAsync("/Pages/Shared/Components/_CourseCard.cshtml", c)
     }
 </div>
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -293,6 +293,79 @@ select:focus-visible {
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
+.courses-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 768px) {
+  .courses-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .courses-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.feature-card .btn {
+  font-weight: 600;
+  border-radius: 0.75rem;
+}
+
+.feature-card .btn-primary {
+  box-shadow: 0 10px 25px rgba(30, 136, 184, 0.28);
+}
+
+.feature-card .btn-outline-secondary {
+  color: var(--primary-dark);
+  border-color: rgba(30, 136, 184, 0.45);
+}
+
+.feature-card .btn-outline-secondary:hover,
+.feature-card .btn-outline-secondary:focus {
+  color: #fff;
+  background-color: var(--primary);
+  border-color: var(--primary);
+}
+
+.course-cta-card {
+  background: linear-gradient(135deg, rgba(30, 136, 184, 0.08), rgba(30, 136, 184, 0.02));
+  border: 1px solid rgba(30, 136, 184, 0.25);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  box-shadow: 0 18px 36px rgba(12, 56, 87, 0.12);
+}
+
+.course-cta-card__price {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.course-cta-card .btn {
+  border-radius: 0.85rem;
+  padding-block: 0.75rem;
+}
+
+.course-cta-card .btn-outline-secondary {
+  color: var(--primary-dark);
+  border-color: rgba(30, 136, 184, 0.45);
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.course-cta-card .btn-outline-secondary:hover,
+.course-cta-card .btn-outline-secondary:focus {
+  color: #fff;
+  background-color: var(--primary);
+  border-color: var(--primary);
+}
+
 .feature-card:hover,
 .feature-card:focus-within {
   transform: translateY(-4px);


### PR DESCRIPTION
## Summary
- switch the courses index listing to a CSS grid that steps through 1/2/3 columns at 360/768/1200px
- refresh course card call-to-action styling for better contrast and readability
- redesign the course details sidebar into a highlighted pricing card with three clear CTAs

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbaac2354c8321989316cdc881e999