### PR TITLE
Fix course mode serialization for course JSON-LD metadata

### DIFF
--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -47,7 +47,7 @@
             {
                 ["@type"] = "CourseInstance",
                 ["startDate"] = Model.Course.Date.ToString("yyyy-MM-dd"),
-                ["courseMode"] = Model.Course.Mode ?? string.Empty,
+                ["courseMode"] = Model.Course.Mode.ToString(),
                 ["offers"] = new System.Text.Json.Nodes.JsonObject
                 {
                     ["@type"] = "Offer",


### PR DESCRIPTION
## Summary
- convert the course mode enum to a string when emitting JSON-LD metadata to resolve the CS0019 build error

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbad8603e0832188f37c3bbae093b3