### PR TITLE
Add redirects for account dashboard and orders

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -255,6 +255,9 @@ try
         name: "default",
         pattern: "{controller}/{action=Index}/{id?}");
     app.MapControllers();
+    // Přesměrování na jednotné místo „Můj účet“
+    app.MapGet("/Account/Dashboard", () => Results.Redirect("/Account/Manage", true));
+    app.MapGet("/Orders", () => Results.Redirect("/Account/Manage#orders"));
     app.MapPost("/payment/webhook", async (HttpRequest request, PaymentService paymentService) =>
     {
         await paymentService.HandleWebhookAsync(request);


### PR DESCRIPTION
## Summary
- add minimal API redirects from /Account/Dashboard and /Orders to the consolidated account management page

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb5a557d883219eb0ef5254cb954a