### PR TITLE
Add admin course group navigation entry

### DIFF
--- a/Pages/Admin/CourseGroups/Create.cshtml
+++ b/Pages/Admin/CourseGroups/Create.cshtml
@@ -1,19 +1,18 @@
-@page "{id:int}"
-@model SysJaky_N.Pages.CourseGroups.EditModel
+@page
+@model SysJaky_N.Pages.Admin.CourseGroups.CreateModel
 @{
-    ViewData["Title"] = "Edit Group";
+    ViewData["Title"] = "Create Group";
 }
 
-<h1>Edit Group</h1>
+<h1>Create Group</h1>
 
 <form method="post">
-    <input type="hidden" asp-for="CourseGroup.Id" />
     <div class="form-group">
         <label asp-for="CourseGroup.Name"></label>
         <input asp-for="CourseGroup.Name" class="form-control" />
         <span asp-validation-for="CourseGroup.Name" class="text-danger"></span>
     </div>
-    <button type="submit" class="btn btn-primary">Save</button>
+    <button type="submit" class="btn btn-primary">Create</button>
     <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </form>
 

--- a/Pages/Admin/CourseGroups/Create.cshtml.cs
+++ b/Pages/Admin/CourseGroups/Create.cshtml.cs
@@ -1,18 +1,17 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
 
-namespace SysJaky_N.Pages.CourseGroups;
+namespace SysJaky_N.Pages.Admin.CourseGroups;
 
 [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
-public class EditModel : PageModel
+public class CreateModel : PageModel
 {
     private readonly ApplicationDbContext _context;
 
-    public EditModel(ApplicationDbContext context)
+    public CreateModel(ApplicationDbContext context)
     {
         _context = context;
     }
@@ -20,15 +19,8 @@ public class EditModel : PageModel
     [BindProperty]
     public CourseGroup CourseGroup { get; set; } = new();
 
-    public async Task<IActionResult> OnGetAsync(int id)
+    public void OnGet()
     {
-        var group = await _context.CourseGroups.FindAsync(id);
-        if (group == null)
-        {
-            return NotFound();
-        }
-        CourseGroup = group;
-        return Page();
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -38,7 +30,7 @@ public class EditModel : PageModel
             return Page();
         }
 
-        _context.Attach(CourseGroup).State = EntityState.Modified;
+        _context.CourseGroups.Add(CourseGroup);
         await _context.SaveChangesAsync();
         return RedirectToPage("Index");
     }

--- a/Pages/Admin/CourseGroups/Delete.cshtml
+++ b/Pages/Admin/CourseGroups/Delete.cshtml
@@ -1,5 +1,5 @@
 @page "{id:int}"
-@model SysJaky_N.Pages.CourseGroups.DeleteModel
+@model SysJaky_N.Pages.Admin.CourseGroups.DeleteModel
 @{
     ViewData["Title"] = "Delete Group";
 }

--- a/Pages/Admin/CourseGroups/Delete.cshtml.cs
+++ b/Pages/Admin/CourseGroups/Delete.cshtml.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
 
-namespace SysJaky_N.Pages.CourseGroups;
+namespace SysJaky_N.Pages.Admin.CourseGroups;
 
 [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
 public class DeleteModel : PageModel

--- a/Pages/Admin/CourseGroups/Edit.cshtml
+++ b/Pages/Admin/CourseGroups/Edit.cshtml
@@ -1,18 +1,19 @@
-@page
-@model SysJaky_N.Pages.CourseGroups.CreateModel
+@page "{id:int}"
+@model SysJaky_N.Pages.Admin.CourseGroups.EditModel
 @{
-    ViewData["Title"] = "Create Group";
+    ViewData["Title"] = "Edit Group";
 }
 
-<h1>Create Group</h1>
+<h1>Edit Group</h1>
 
 <form method="post">
+    <input type="hidden" asp-for="CourseGroup.Id" />
     <div class="form-group">
         <label asp-for="CourseGroup.Name"></label>
         <input asp-for="CourseGroup.Name" class="form-control" />
         <span asp-validation-for="CourseGroup.Name" class="text-danger"></span>
     </div>
-    <button type="submit" class="btn btn-primary">Create</button>
+    <button type="submit" class="btn btn-primary">Save</button>
     <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </form>
 

--- a/Pages/Admin/CourseGroups/Edit.cshtml.cs
+++ b/Pages/Admin/CourseGroups/Edit.cshtml.cs
@@ -1,17 +1,18 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
 
-namespace SysJaky_N.Pages.CourseGroups;
+namespace SysJaky_N.Pages.Admin.CourseGroups;
 
 [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
-public class CreateModel : PageModel
+public class EditModel : PageModel
 {
     private readonly ApplicationDbContext _context;
 
-    public CreateModel(ApplicationDbContext context)
+    public EditModel(ApplicationDbContext context)
     {
         _context = context;
     }
@@ -19,8 +20,15 @@ public class CreateModel : PageModel
     [BindProperty]
     public CourseGroup CourseGroup { get; set; } = new();
 
-    public void OnGet()
+    public async Task<IActionResult> OnGetAsync(int id)
     {
+        var group = await _context.CourseGroups.FindAsync(id);
+        if (group == null)
+        {
+            return NotFound();
+        }
+        CourseGroup = group;
+        return Page();
     }
 
     public async Task<IActionResult> OnPostAsync()
@@ -30,7 +38,7 @@ public class CreateModel : PageModel
             return Page();
         }
 
-        _context.CourseGroups.Add(CourseGroup);
+        _context.Attach(CourseGroup).State = EntityState.Modified;
         await _context.SaveChangesAsync();
         return RedirectToPage("Index");
     }

--- a/Pages/Admin/CourseGroups/Index.cshtml
+++ b/Pages/Admin/CourseGroups/Index.cshtml
@@ -1,5 +1,5 @@
 @page
-@model SysJaky_N.Pages.CourseGroups.IndexModel
+@model SysJaky_N.Pages.Admin.CourseGroups.IndexModel
 @{
     ViewData["Title"] = "Course Groups";
 }

--- a/Pages/Admin/CourseGroups/Index.cshtml.cs
+++ b/Pages/Admin/CourseGroups/Index.cshtml.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
 
-namespace SysJaky_N.Pages.CourseGroups;
+namespace SysJaky_N.Pages.Admin.CourseGroups;
 
 [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
 public class IndexModel : PageModel

--- a/Pages/Admin/_Layout.cshtml
+++ b/Pages/Admin/_Layout.cshtml
@@ -33,6 +33,9 @@
                             <a class="nav-link @ActiveClass("/Admin/Courses")" asp-page="/Admin/Courses/Index">Courses</a>
                         </li>
                         <li class="nav-item" role="presentation">
+                            <a class="nav-link @ActiveClass("/Admin/CourseGroups")" asp-page="/Admin/CourseGroups/Index">Skupiny kurzů</a>
+                        </li>
+                        <li class="nav-item" role="presentation">
                             <a class="nav-link @ActiveClass("/Admin/CourseTerms")" asp-page="/Admin/CourseTerms/Index">Course Terms</a>
                         </li>
                         <li class="nav-item" role="presentation">


### PR DESCRIPTION
## Summary
- add a Course Groups link to the admin navigation menu
- relocate the CourseGroups Razor pages under the Admin area and update their namespaces

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb5c5943c8321b940ed46bb312377