### PR TITLE
Add course term detail link and instructor attendance shortcut

### DIFF
--- a/Pages/Account/Manage.cshtml
+++ b/Pages/Account/Manage.cshtml
@@ -54,6 +54,7 @@
                     <th>Zahájení</th>
                     <th>Ukončení</th>
                     <th>Kalendář</th>
+                    <th>Detail</th>
                 </tr>
             </thead>
             <tbody>
@@ -71,6 +72,7 @@
                     <td>@term.StartUtc.ToLocalTime().ToString("g")</td>
                     <td>@term.EndUtc.ToLocalTime().ToString("g")</td>
                     <td><a href="/CourseTerms/ICS/@term.Id">Stáhnout .ics</a></td>
+                    <td><a class="btn btn-outline-secondary btn-sm" asp-page="/CourseTerms/Details" asp-route-id="@term.Id">Detail termínu</a></td>
                 </tr>
             }
             </tbody>

--- a/Pages/Admin/Dashboard/Index.cshtml
+++ b/Pages/Admin/Dashboard/Index.cshtml
@@ -36,6 +36,21 @@
     </div>
 </div>
 
+<div class="row mt-4">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-body">
+                <h3 class="card-title">Nástroje</h3>
+                <div class="d-flex flex-wrap gap-2">
+                    <a class="btn btn-outline-primary" asp-page="/Instructor/Attendance">
+                        <i class="bi bi-qr-code-scan"></i> Docházka (QR)
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
 @section Scripts {
     <script src="~/lib/chart.js/chart.js" asp-append-version="true"></script>
     <script>


### PR DESCRIPTION
## Summary
- add a detail column to the account course enrollment table linking to the term detail page
- surface a new instructor attendance (QR) shortcut in the admin dashboard tools card

## Testing
- `dotnet build` *(fails: command not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb6c501f88321a191fafb3afea350