### PR TITLE
Add modern hero and chip styling utilities

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -456,3 +456,65 @@ footer.app-footer a:focus {
     font-size: 1.5rem;
   }
 }
+/* Brand */
+:root{
+  --primary:#1ca8d7;
+  --primary-600:#168bb3;
+  --primary-50:#e6f6fc;
+
+  --accent:#fecc44;
+  --accent-600:#e6b73d;
+  --ink:#0f172a;
+}
+
+/* Hrdinské panely */
+.hero-edu{
+  background: linear-gradient(135deg, var(--primary) 0%, #199fcb 100%);
+  color:#fff;
+  border-radius:1rem;
+}
+.hero-consult{
+  background: linear-gradient(135deg, var(--accent) 0%, #f3c23f 100%);
+  color:var(--ink);
+  border-radius:1rem;
+}
+
+/* „Chip“ místo malých tlačítek */
+.chips{ gap:.5rem; display:flex; flex-wrap:wrap; }
+.chip{
+  display:inline-flex; align-items:center; gap:.5rem;
+  padding:.4rem .7rem; border-radius:999px;
+  border:1px solid rgba(0,0,0,.06); background:#fff; color:#111;
+  text-decoration:none; font-weight:600; font-size:.9rem;
+}
+.hero-edu .chip{ background:rgba(255,255,255,.15); color:#fff; border-color:rgba(255,255,255,.25); }
+.hero-edu .chip:hover{ background:rgba(255,255,255,.25); }
+.hero-consult .chip{ background:rgba(0,0,0,.06); color:#111; }
+.hero-consult .chip:hover{ background:rgba(0,0,0,.12); }
+
+/* Moderní karta + hover */
+.card-hover{ transition:transform .2s ease, box-shadow .2s ease; }
+.card-hover:hover{ transform:translateY(-3px); box-shadow:0 16px 32px rgba(17,24,39,.08); }
+
+/* Jemné seznamy s šipkou */
+.list-chevron .list-group-item{
+  display:flex; justify-content:space-between; align-items:center;
+  border:none; border-bottom:1px solid rgba(0,0,0,.06);
+}
+.list-chevron .list-group-item .chev{ opacity:.35; }
+
+/* „Ghost“ tlačítko */
+.btn-ghost{ background:transparent; border:1px solid rgba(0,0,0,.12); }
+.btn-ghost:hover{ background:rgba(0,0,0,.04); }
+
+/* Chip-badges na kartách */
+.badge-soft-primary{ background:rgba(28,168,215,.12); color:#168bb3; }
+.badge-soft-accent{ background:rgba(254,204,68,.25); color:#0f172a; }
+
+/* Focus ring přístupnost */
+:where(a,button,input,select,.chip):focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+
+/* Preferuje-li uživatel méně animací */
+@media (prefers-reduced-motion: reduce){
+  .card-hover{ transition:none; }
+}


### PR DESCRIPTION
## Summary
- append modern gradient hero panel styles for education and consulting sections
- add reusable chip, ghost button, and badge utility classes
- enhance accessibility focus rings and reduced motion handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb79468f4832189354ef6ab4d91d2