### PR TITLE
Refactor course editor workflow with shared partial

### DIFF
--- a/Pages/Courses/CourseFormModel.cs
+++ b/Pages/Courses/CourseFormModel.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Courses;
+
+public class CourseFormModel
+{
+    public Course Course { get; set; } = new();
+
+    public SelectList CourseGroups { get; set; } = default!;
+
+    public IFormFile? CoverImage { get; set; }
+
+    public IHtmlContent? ActionButtons { get; set; }
+}

--- a/Pages/Courses/Create.cshtml
+++ b/Pages/Courses/Create.cshtml
@@ -1,75 +1,33 @@
 @page
 @model SysJaky_N.Pages.Courses.CreateModel
+@using Microsoft.AspNetCore.Mvc.Rendering
+@using SysJaky_N.Pages.Courses
 @{
     ViewData["Title"] = "Create Course";
+    var actions = new HtmlContentBuilder();
+    var submitButton = new TagBuilder("button");
+    submitButton.Attributes["type"] = "submit";
+    submitButton.AddCssClass("btn btn-primary");
+    submitButton.InnerHtml.Append("Create");
+    actions.AppendHtml(submitButton);
+
+    var backLink = new TagBuilder("a");
+    backLink.AddCssClass("btn btn-secondary");
+    backLink.Attributes["href"] = Url.Page("Index");
+    backLink.InnerHtml.Append("Back to List");
+    actions.AppendHtml(backLink);
 }
 
 <h1>Create Course</h1>
 
 <form method="post" enctype="multipart/form-data">
-    <div class="form-group">
-        <label asp-for="Course.Title"></label>
-        <input asp-for="Course.Title" class="form-control" />
-        <span asp-validation-for="Course.Title" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Description"></label>
-        <textarea asp-for="Course.Description" class="form-control"></textarea>
-        <span asp-validation-for="Course.Description" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.MetaTitle"></label>
-        <input asp-for="Course.MetaTitle" class="form-control" />
-        <span asp-validation-for="Course.MetaTitle" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.MetaDescription"></label>
-        <textarea asp-for="Course.MetaDescription" class="form-control"></textarea>
-        <span asp-validation-for="Course.MetaDescription" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.OpenGraphImage"></label>
-        <input asp-for="Course.OpenGraphImage" class="form-control" />
-        <span asp-validation-for="Course.OpenGraphImage" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.CourseGroupId"></label>
-        <select asp-for="Course.CourseGroupId" asp-items="Model.CourseGroups" class="form-control">
-            <option value="">-- Select Group --</option>
-        </select>
-        <span asp-validation-for="Course.CourseGroupId" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Price"></label>
-        <input asp-for="Course.Price" class="form-control" />
-        <span asp-validation-for="Course.Price" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Date"></label>
-        <input asp-for="Course.Date" class="form-control" />
-        <span asp-validation-for="Course.Date" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="CoverImage"></label>
-        <input asp-for="CoverImage" type="file" class="form-control" accept="image/jpeg" />
-        <span asp-validation-for="CoverImage" class="text-danger"></span>
-        <label asp-for="Course.Level"></label>
-        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseLevel>()"></select>
-        <span asp-validation-for="Course.Level" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Mode"></label>
-        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseMode>()"></select>
-        <span asp-validation-for="Course.Mode" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Duration"></label>
-        <input asp-for="Course.Duration" class="form-control" min="0" />
-        <span asp-validation-for="Course.Duration" class="text-danger"></span>
-
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+    <partial name="Courses/Shared/_CourseForm" model="new CourseFormModel
+    {
+        Course = Model.Course,
+        CourseGroups = Model.CourseGroups,
+        CoverImage = Model.CoverImage,
+        ActionButtons = actions
+    }" />
 </form>
 
 @section Scripts {

--- a/Pages/Courses/Edit.cshtml
+++ b/Pages/Courses/Edit.cshtml
@@ -1,83 +1,41 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Courses.EditModel
+@using Microsoft.AspNetCore.Mvc.Rendering
+@using SysJaky_N.Pages.Courses
 @{
     ViewData["Title"] = "Edit Course";
+    var actions = new HtmlContentBuilder();
+    var submitButton = new TagBuilder("button");
+    submitButton.Attributes["type"] = "submit";
+    submitButton.AddCssClass("btn btn-primary");
+    submitButton.InnerHtml.Append("Save");
+    actions.AppendHtml(submitButton);
+
+    var backLink = new TagBuilder("a");
+    backLink.AddCssClass("btn btn-secondary");
+    backLink.Attributes["href"] = Url.Page("Index");
+    backLink.InnerHtml.Append("Back to List");
+    actions.AppendHtml(backLink);
 }
 
 <h1>Edit Course</h1>
 
 <form method="post" enctype="multipart/form-data">
     <input type="hidden" asp-for="Course.Id" />
-    <div class="form-group">
-        <label asp-for="Course.Title"></label>
-        <input asp-for="Course.Title" class="form-control" />
-        <span asp-validation-for="Course.Title" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Description"></label>
-        <textarea asp-for="Course.Description" class="form-control"></textarea>
-        <span asp-validation-for="Course.Description" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.MetaTitle"></label>
-        <input asp-for="Course.MetaTitle" class="form-control" />
-        <span asp-validation-for="Course.MetaTitle" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.MetaDescription"></label>
-        <textarea asp-for="Course.MetaDescription" class="form-control"></textarea>
-        <span asp-validation-for="Course.MetaDescription" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.OpenGraphImage"></label>
-        <input asp-for="Course.OpenGraphImage" class="form-control" />
-        <span asp-validation-for="Course.OpenGraphImage" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.CourseGroupId"></label>
-        <select asp-for="Course.CourseGroupId" asp-items="Model.CourseGroups" class="form-control">
-            <option value="">-- Select Group --</option>
-        </select>
-        <span asp-validation-for="Course.CourseGroupId" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Price"></label>
-        <input asp-for="Course.Price" class="form-control" />
-        <span asp-validation-for="Course.Price" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Date"></label>
-        <input asp-for="Course.Date" class="form-control" />
-        <span asp-validation-for="Course.Date" class="text-danger"></span>
-    </div>
     @if (!string.IsNullOrEmpty(Model.Course.CoverImageUrl))
     {
         <div class="mb-3">
             <img src="@Model.Course.CoverImageUrl" alt="Cover for @Model.Course.Title" class="img-fluid rounded" style="max-width: 240px;" />
         </div>
     }
-    <div class="form-group">
-        <label asp-for="CoverImage"></label>
-        <input asp-for="CoverImage" type="file" class="form-control" accept="image/jpeg" />
-        <span asp-validation-for="CoverImage" class="text-danger"></span>
 
-    <div class="form-group">
-        <label asp-for="Course.Level"></label>
-        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseLevel>()"></select>
-        <span asp-validation-for="Course.Level" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Mode"></label>
-        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<SysJaky_N.Models.CourseMode>()"></select>
-        <span asp-validation-for="Course.Mode" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Course.Duration"></label>
-        <input asp-for="Course.Duration" class="form-control" min="0" />
-        <span asp-validation-for="Course.Duration" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+    <partial name="Courses/Shared/_CourseForm" model="new CourseFormModel
+    {
+        Course = Model.Course,
+        CourseGroups = Model.CourseGroups,
+        CoverImage = Model.CoverImage,
+        ActionButtons = actions
+    }" />
 </form>
 
 @section Scripts {

--- a/Pages/Courses/Shared/_CourseForm.cshtml
+++ b/Pages/Courses/Shared/_CourseForm.cshtml
@@ -1,0 +1,77 @@
+@model SysJaky_N.Pages.Courses.CourseFormModel
+@using SysJaky_N.Models
+
+<div class="mb-3">
+    <label asp-for="Course.Title" class="form-label"></label>
+    <input asp-for="Course.Title" class="form-control" />
+    <span asp-validation-for="Course.Title" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="Course.Description" class="form-label"></label>
+    <textarea asp-for="Course.Description" class="form-control" rows="4"></textarea>
+    <span asp-validation-for="Course.Description" class="text-danger"></span>
+</div>
+<div class="row g-3">
+    <div class="col-md-6">
+        <label asp-for="Course.MetaTitle" class="form-label"></label>
+        <input asp-for="Course.MetaTitle" class="form-control" />
+        <span asp-validation-for="Course.MetaTitle" class="text-danger"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="Course.MetaDescription" class="form-label"></label>
+        <textarea asp-for="Course.MetaDescription" class="form-control" rows="2"></textarea>
+        <span asp-validation-for="Course.MetaDescription" class="text-danger"></span>
+    </div>
+</div>
+<div class="mb-3">
+    <label asp-for="Course.OpenGraphImage" class="form-label"></label>
+    <input asp-for="Course.OpenGraphImage" class="form-control" />
+    <span asp-validation-for="Course.OpenGraphImage" class="text-danger"></span>
+</div>
+<div class="row g-3">
+    <div class="col-md-6">
+        <label asp-for="Course.CourseGroupId" class="form-label"></label>
+        <select asp-for="Course.CourseGroupId" asp-items="Model.CourseGroups" class="form-select">
+            <option value="">-- Select Group --</option>
+        </select>
+        <span asp-validation-for="Course.CourseGroupId" class="text-danger"></span>
+    </div>
+    <div class="col-md-3">
+        <label asp-for="Course.Price" class="form-label"></label>
+        <input asp-for="Course.Price" class="form-control" />
+        <span asp-validation-for="Course.Price" class="text-danger"></span>
+    </div>
+    <div class="col-md-3">
+        <label asp-for="Course.Date" class="form-label"></label>
+        <input asp-for="Course.Date" class="form-control" />
+        <span asp-validation-for="Course.Date" class="text-danger"></span>
+    </div>
+</div>
+<div class="mb-3">
+    <label asp-for="CoverImage" class="form-label"></label>
+    <input asp-for="CoverImage" type="file" class="form-control" accept="image/jpeg" />
+    <span asp-validation-for="CoverImage" class="text-danger"></span>
+</div>
+<div class="row g-3">
+    <div class="col-md-4">
+        <label asp-for="Course.Level" class="form-label"></label>
+        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<CourseLevel>()"></select>
+        <span asp-validation-for="Course.Level" class="text-danger"></span>
+    </div>
+    <div class="col-md-4">
+        <label asp-for="Course.Mode" class="form-label"></label>
+        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<CourseMode>()"></select>
+        <span asp-validation-for="Course.Mode" class="text-danger"></span>
+    </div>
+    <div class="col-md-4">
+        <label asp-for="Course.Duration" class="form-label"></label>
+        <input asp-for="Course.Duration" class="form-control" min="0" />
+        <span asp-validation-for="Course.Duration" class="text-danger"></span>
+    </div>
+</div>
+@if (Model.ActionButtons is not null)
+{
+    <div class="d-flex gap-2 mt-4">
+        @Model.ActionButtons
+    </div>
+}

--- a/Program.cs
+++ b/Program.cs
@@ -134,6 +134,7 @@ try
     builder.Services.Configure<CourseReviewRequestOptions>(builder.Configuration.GetSection("CourseReviews"));
     builder.Services.AddScoped<IAuditService, AuditService>();
     builder.Services.AddScoped<ICourseMediaStorage, LocalCourseMediaStorage>();
+    builder.Services.AddScoped<ICourseEditor, CourseEditor>();
     builder.Services.AddScoped<CartService>();
     builder.Services.Configure<CertificateOptions>(builder.Configuration.GetSection("Certificates"));
     builder.Services.AddScoped<CertificateService>();

--- a/Services/CourseEditor.cs
+++ b/Services/CourseEditor.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace SysJaky_N.Services;
+
+public sealed class CourseEditor : ICourseEditor
+{
+    private readonly ICourseMediaStorage _courseMediaStorage;
+    private readonly ICacheService _cacheService;
+
+    public CourseEditor(ICourseMediaStorage courseMediaStorage, ICacheService cacheService)
+    {
+        _courseMediaStorage = courseMediaStorage;
+        _cacheService = cacheService;
+    }
+
+    public bool ValidateCoverImage(IFormFile? coverImage, ModelStateDictionary modelState, string fieldName)
+    {
+        var isValid = true;
+
+        if (coverImage is { Length: > 0 } && !string.Equals(coverImage.ContentType, "image/jpeg", StringComparison.OrdinalIgnoreCase))
+        {
+            modelState.AddModelError(fieldName, "Nahrajte prosím obálku ve formátu JPEG.");
+            isValid = false;
+        }
+        else if (coverImage is { Length: 0 })
+        {
+            modelState.AddModelError(fieldName, "Soubor s obálkou je prázdný.");
+            isValid = false;
+        }
+
+        return isValid;
+    }
+
+    public async Task<CourseCoverImageResult> SaveCoverImageAsync(
+        int courseId,
+        IFormFile? coverImage,
+        CancellationToken cancellationToken)
+    {
+        if (coverImage is not { Length: > 0 })
+        {
+            return CourseCoverImageResult.NoChange;
+        }
+
+        try
+        {
+            await using var imageStream = coverImage.OpenReadStream();
+            var coverUrl = await _courseMediaStorage.SaveCoverImageAsync(
+                courseId,
+                imageStream,
+                coverImage.ContentType,
+                cancellationToken);
+            return CourseCoverImageResult.Success(coverUrl);
+        }
+        catch (Exception ex) when (ex is IOException or InvalidOperationException)
+        {
+            return CourseCoverImageResult.Failure("Nepodařilo se uložit obálku kurzu. Zkontrolujte prosím soubor a zkuste to znovu.");
+        }
+    }
+
+    public void InvalidateCourseCache(int courseId)
+    {
+        _cacheService.InvalidateCourseList();
+        _cacheService.InvalidateCourseDetail(courseId);
+    }
+}
+
+public sealed record CourseCoverImageResult(bool Succeeded, string? CoverImageUrl, string? ErrorMessage)
+{
+    public static CourseCoverImageResult Success(string coverImageUrl) => new(true, coverImageUrl, null);
+
+    public static CourseCoverImageResult Failure(string errorMessage) => new(false, null, errorMessage);
+
+    public static CourseCoverImageResult NoChange { get; } = new(true, null, null);
+}

--- a/Services/ICourseEditor.cs
+++ b/Services/ICourseEditor.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace SysJaky_N.Services;
+
+public interface ICourseEditor
+{
+    bool ValidateCoverImage(IFormFile? coverImage, ModelStateDictionary modelState, string fieldName);
+
+    Task<CourseCoverImageResult> SaveCoverImageAsync(
+        int courseId,
+        IFormFile? coverImage,
+        CancellationToken cancellationToken);
+
+    void InvalidateCourseCache(int courseId);
+}

--- a/SysJaky_N.Tests/CourseEditorTests.cs
+++ b/SysJaky_N.Tests/CourseEditorTests.cs
@@ -1,0 +1,89 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Moq;
+using SysJaky_N.Services;
+using Xunit;
+
+namespace SysJaky_N.Tests;
+
+public class CourseEditorTests
+{
+    [Fact]
+    public void ValidateCoverImage_AddsError_ForNonJpeg()
+    {
+        var mediaStorage = new Mock<ICourseMediaStorage>();
+        var cacheService = new Mock<ICacheService>();
+        var editor = new CourseEditor(mediaStorage.Object, cacheService.Object);
+        var modelState = new ModelStateDictionary();
+
+        var formFile = CreateFormFile("image/png");
+
+        var result = editor.ValidateCoverImage(formFile, modelState, "CoverImage");
+
+        Assert.False(result);
+        Assert.True(modelState.ContainsKey("CoverImage"));
+        Assert.Single(modelState["CoverImage"].Errors);
+    }
+
+    [Fact]
+    public async Task SaveCoverImageAsync_ReturnsFailure_WhenStorageThrows()
+    {
+        var mediaStorage = new Mock<ICourseMediaStorage>();
+        var cacheService = new Mock<ICacheService>();
+        mediaStorage
+            .Setup(s => s.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("failed"));
+        var editor = new CourseEditor(mediaStorage.Object, cacheService.Object);
+
+        var formFile = CreateFormFile("image/jpeg");
+
+        var result = await editor.SaveCoverImageAsync(1, formFile, CancellationToken.None);
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task SaveCoverImageAsync_ReturnsCoverUrl_OnSuccess()
+    {
+        var mediaStorage = new Mock<ICourseMediaStorage>();
+        var cacheService = new Mock<ICacheService>();
+        mediaStorage
+            .Setup(s => s.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("/covers/course-1.jpg");
+        var editor = new CourseEditor(mediaStorage.Object, cacheService.Object);
+
+        var formFile = CreateFormFile("image/jpeg");
+
+        var result = await editor.SaveCoverImageAsync(1, formFile, CancellationToken.None);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("/covers/course-1.jpg", result.CoverImageUrl);
+    }
+
+    [Fact]
+    public void InvalidateCourseCache_CallsCacheService()
+    {
+        var mediaStorage = new Mock<ICourseMediaStorage>();
+        var cacheService = new Mock<ICacheService>();
+        var editor = new CourseEditor(mediaStorage.Object, cacheService.Object);
+
+        editor.InvalidateCourseCache(5);
+
+        cacheService.Verify(s => s.InvalidateCourseList(), Times.Once);
+        cacheService.Verify(s => s.InvalidateCourseDetail(5), Times.Once);
+    }
+
+    private static IFormFile CreateFormFile(string contentType)
+    {
+        var stream = new MemoryStream(new byte[] { 1, 2, 3 });
+        var file = new FormFile(stream, 0, stream.Length, "CoverImage", "cover.jpg")
+        {
+            ContentType = contentType
+        };
+        return file;
+    }
+}

--- a/SysJaky_N.Tests/CoursePageModelTests.cs
+++ b/SysJaky_N.Tests/CoursePageModelTests.cs
@@ -1,0 +1,316 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+using SysJaky_N.Pages.Courses;
+using SysJaky_N.Services;
+using Xunit;
+
+namespace SysJaky_N.Tests;
+
+public class CoursePageModelTests
+{
+    [Fact]
+    public async Task CreateModel_ReturnsPage_WhenValidationFails()
+    {
+        await using var fixture = await CourseFixture.CreateAsync();
+        fixture.Context.CourseGroups.Add(new CourseGroup { Name = "Group" });
+        await fixture.Context.SaveChangesAsync();
+        var courseGroupId = fixture.Context.CourseGroups.Select(g => g.Id).First();
+
+        var auditService = new Mock<IAuditService>();
+        var editor = new Mock<ICourseEditor>();
+        editor
+            .Setup(e => e.ValidateCoverImage(It.IsAny<IFormFile?>(), It.IsAny<ModelStateDictionary>(), It.IsAny<string>()))
+            .Callback<IFormFile?, ModelStateDictionary, string>((_, state, field) => state.AddModelError(field, "error"))
+            .Returns(false);
+
+        var model = new CreateModel(fixture.Context, auditService.Object, editor.Object)
+        {
+            Course = new Course
+            {
+                Title = "New Course",
+                Description = "Desc",
+                Date = DateTime.UtcNow,
+                CourseGroupId = courseGroupId
+            }
+        };
+        model.PageContext = new PageContext(new ActionContext
+        {
+            HttpContext = new DefaultHttpContext()
+        });
+
+        var result = await model.OnPostAsync();
+
+        Assert.IsType<PageResult>(result);
+        Assert.True(model.ModelState.ContainsKey("CoverImage"));
+        editor.Verify(e => e.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<IFormFile?>(), It.IsAny<CancellationToken>()), Times.Never);
+        editor.Verify(e => e.InvalidateCourseCache(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateModel_ReturnsPage_WhenCoverSaveFails()
+    {
+        await using var fixture = await CourseFixture.CreateAsync();
+        fixture.Context.CourseGroups.Add(new CourseGroup { Name = "Group" });
+        await fixture.Context.SaveChangesAsync();
+        var courseGroupId = fixture.Context.CourseGroups.Select(g => g.Id).First();
+
+        var auditService = new Mock<IAuditService>();
+        var editor = new Mock<ICourseEditor>();
+        editor
+            .Setup(e => e.ValidateCoverImage(It.IsAny<IFormFile?>(), It.IsAny<ModelStateDictionary>(), It.IsAny<string>()))
+            .Returns(true);
+        editor
+            .Setup(e => e.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<IFormFile?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CourseCoverImageResult.Failure("cover error"));
+
+        var model = new CreateModel(fixture.Context, auditService.Object, editor.Object)
+        {
+            Course = new Course
+            {
+                Title = "New Course",
+                Description = "Desc",
+                Date = DateTime.UtcNow,
+                CourseGroupId = courseGroupId
+            },
+            CoverImage = CreateFormFile()
+        };
+        var httpContext = new DefaultHttpContext();
+        model.PageContext = new PageContext(new ActionContext
+        {
+            HttpContext = httpContext
+        });
+
+        var result = await model.OnPostAsync();
+
+        Assert.IsType<PageResult>(result);
+        Assert.Equal(0, model.Course.Id);
+        Assert.True(model.ModelState.ContainsKey("CoverImage"));
+        editor.Verify(e => e.InvalidateCourseCache(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateModel_Redirects_OnSuccess()
+    {
+        await using var fixture = await CourseFixture.CreateAsync();
+        fixture.Context.CourseGroups.Add(new CourseGroup { Name = "Group" });
+        await fixture.Context.SaveChangesAsync();
+        var courseGroupId = fixture.Context.CourseGroups.Select(g => g.Id).First();
+
+        var auditService = new Mock<IAuditService>();
+        auditService.Setup(a => a.LogAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        var editor = new Mock<ICourseEditor>();
+        editor
+            .Setup(e => e.ValidateCoverImage(It.IsAny<IFormFile?>(), It.IsAny<ModelStateDictionary>(), It.IsAny<string>()))
+            .Returns(true);
+        editor
+            .Setup(e => e.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<IFormFile?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CourseCoverImageResult.Success("/covers/course-1.jpg"));
+
+        var model = new CreateModel(fixture.Context, auditService.Object, editor.Object)
+        {
+            Course = new Course
+            {
+                Title = "New Course",
+                Description = "Desc",
+                Date = DateTime.UtcNow,
+                CourseGroupId = courseGroupId
+            },
+            CoverImage = CreateFormFile()
+        };
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "user-1") }))
+        };
+        model.PageContext = new PageContext(new ActionContext
+        {
+            HttpContext = httpContext
+        });
+
+        var result = await model.OnPostAsync();
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("Index", redirect.PageName);
+        Assert.Single(fixture.Context.Courses);
+        Assert.Equal("/covers/course-1.jpg", fixture.Context.Courses.Single().CoverImageUrl);
+        editor.Verify(e => e.InvalidateCourseCache(It.IsAny<int>()), Times.Once);
+        auditService.Verify(a => a.LogAsync("user-1", "CourseCreated", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EditModel_ReturnsPage_WhenCoverSaveFails()
+    {
+        await using var fixture = await CourseFixture.CreateAsync();
+        var course = new Course
+        {
+            Title = "Existing",
+            Description = "Desc",
+            Date = DateTime.UtcNow,
+            CoverImageUrl = "/covers/old.jpg",
+            Level = CourseLevel.Beginner,
+            Mode = CourseMode.SelfPaced,
+            Duration = 10
+        };
+        fixture.Context.Courses.Add(course);
+        await fixture.Context.SaveChangesAsync();
+
+        var auditService = new Mock<IAuditService>();
+        var editor = new Mock<ICourseEditor>();
+        editor
+            .Setup(e => e.ValidateCoverImage(It.IsAny<IFormFile?>(), It.IsAny<ModelStateDictionary>(), It.IsAny<string>()))
+            .Returns(true);
+        editor
+            .Setup(e => e.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<IFormFile?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CourseCoverImageResult.Failure("cover error"));
+
+        var model = new EditModel(fixture.Context, auditService.Object, editor.Object)
+        {
+            Course = new Course
+            {
+                Id = course.Id,
+                Title = "Updated",
+                Description = "Desc",
+                Date = course.Date,
+                Level = CourseLevel.Advanced,
+                Mode = CourseMode.InstructorLed,
+                Duration = 20
+            },
+            CoverImage = CreateFormFile()
+        };
+        model.PageContext = new PageContext(new ActionContext
+        {
+            HttpContext = new DefaultHttpContext()
+        });
+
+        var result = await model.OnPostAsync();
+
+        Assert.IsType<PageResult>(result);
+        Assert.Equal("/covers/old.jpg", model.Course.CoverImageUrl);
+        Assert.True(model.ModelState.ContainsKey("CoverImage"));
+    }
+
+    [Fact]
+    public async Task EditModel_Redirects_OnSuccess()
+    {
+        await using var fixture = await CourseFixture.CreateAsync();
+        var course = new Course
+        {
+            Title = "Existing",
+            Description = "Desc",
+            Date = DateTime.UtcNow,
+            CoverImageUrl = "/covers/old.jpg",
+            Level = CourseLevel.Beginner,
+            Mode = CourseMode.SelfPaced,
+            Duration = 10
+        };
+        fixture.Context.Courses.Add(course);
+        await fixture.Context.SaveChangesAsync();
+
+        var auditService = new Mock<IAuditService>();
+        auditService.Setup(a => a.LogAsync(It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        var editor = new Mock<ICourseEditor>();
+        editor
+            .Setup(e => e.ValidateCoverImage(It.IsAny<IFormFile?>(), It.IsAny<ModelStateDictionary>(), It.IsAny<string>()))
+            .Returns(true);
+        editor
+            .Setup(e => e.SaveCoverImageAsync(It.IsAny<int>(), It.IsAny<IFormFile?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CourseCoverImageResult.Success("/covers/new.jpg"));
+
+        var model = new EditModel(fixture.Context, auditService.Object, editor.Object)
+        {
+            Course = new Course
+            {
+                Id = course.Id,
+                Title = "Updated",
+                Description = "Updated desc",
+                MetaTitle = "Meta",
+                MetaDescription = "Meta desc",
+                OpenGraphImage = "/og.jpg",
+                CourseGroupId = null,
+                Price = 10,
+                Date = course.Date,
+                Level = CourseLevel.Advanced,
+                Mode = CourseMode.InstructorLed,
+                Duration = 20
+            },
+            CoverImage = CreateFormFile()
+        };
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "user-1") }))
+        };
+        model.PageContext = new PageContext(new ActionContext
+        {
+            HttpContext = httpContext
+        });
+
+        var result = await model.OnPostAsync();
+
+        var redirect = Assert.IsType<RedirectToPageResult>(result);
+        Assert.Equal("Index", redirect.PageName);
+        var updatedCourse = fixture.Context.Courses.Single();
+        Assert.Equal("Updated", updatedCourse.Title);
+        Assert.Equal("Updated desc", updatedCourse.Description);
+        Assert.Equal("/covers/new.jpg", updatedCourse.CoverImageUrl);
+        Assert.Equal(CourseLevel.Advanced, updatedCourse.Level);
+        Assert.Equal(CourseMode.InstructorLed, updatedCourse.Mode);
+        Assert.Equal(20, updatedCourse.Duration);
+        editor.Verify(e => e.InvalidateCourseCache(course.Id), Times.Once);
+        auditService.Verify(a => a.LogAsync("user-1", "CourseEdited", It.IsAny<string>()), Times.Once);
+    }
+
+    private static IFormFile CreateFormFile()
+    {
+        var stream = new MemoryStream(new byte[] { 1, 2, 3, 4 });
+        return new FormFile(stream, 0, stream.Length, "CoverImage", "cover.jpg")
+        {
+            ContentType = "image/jpeg"
+        };
+    }
+
+    private sealed class CourseFixture : IAsyncDisposable
+    {
+        public ApplicationDbContext Context { get; }
+        private readonly SqliteConnection _connection;
+
+        private CourseFixture(ApplicationDbContext context, SqliteConnection connection)
+        {
+            Context = context;
+            _connection = connection;
+        }
+
+        public static async Task<CourseFixture> CreateAsync()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            await connection.OpenAsync();
+
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseSqlite(connection)
+                .Options;
+
+            var context = new ApplicationDbContext(options);
+            await context.Database.EnsureCreatedAsync();
+            return new CourseFixture(context, connection);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Context.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/SysJaky_N.Tests/SysJaky_N.Tests.csproj
+++ b/SysJaky_N.Tests/SysJaky_N.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SysJaky_N\SysJaky_N.csproj" />
+  </ItemGroup>
+</Project>

--- a/SysJaky_N.sln
+++ b/SysJaky_N.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.13.36105.23 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SysJaky_N", "SysJaky_N.csproj", "{0F00B5CC-7387-4BBD-BC19-D3115079631E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SysJaky_N.Tests", "SysJaky_N.Tests\SysJaky_N.Tests.csproj", "{EE62090C-B158-43DC-9BBF-CD28A39FB686}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0F00B5CC-7387-4BBD-BC19-D3115079631E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F00B5CC-7387-4BBD-BC19-D3115079631E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0F00B5CC-7387-4BBD-BC19-D3115079631E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0F00B5CC-7387-4BBD-BC19-D3115079631E}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {0F00B5CC-7387-4BBD-BC19-D3115079631E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0F00B5CC-7387-4BBD-BC19-D3115079631E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0F00B5CC-7387-4BBD-BC19-D3115079631E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0F00B5CC-7387-4BBD-BC19-D3115079631E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {EE62090C-B158-43DC-9BBF-CD28A39FB686}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {EE62090C-B158-43DC-9BBF-CD28A39FB686}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {EE62090C-B158-43DC-9BBF-CD28A39FB686}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {EE62090C-B158-43DC-9BBF-CD28A39FB686}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a shared course form partial and view-model used by the create and edit Razor pages
- extract cover image validation, storage, and cache invalidation into a reusable CourseEditor service
- register the new service and add unit/integration tests for the course editing flows

## Testing
- dotnet test *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb9a73804832190652a7d39c94875