### PR TITLE
Refactor admin Razor forms to shared partials

### DIFF
--- a/Pages/Admin/Articles/Create.cshtml
+++ b/Pages/Admin/Articles/Create.cshtml
@@ -7,18 +7,8 @@
 <h1>Create Article</h1>
 
 <form method="post">
-    <div class="form-group">
-        <label asp-for="Article.Title"></label>
-        <input asp-for="Article.Title" class="form-control" />
-        <span asp-validation-for="Article.Title" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Article.Content"></label>
-        <textarea asp-for="Article.Content" class="form-control"></textarea>
-        <span asp-validation-for="Article.Content" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to list</a>
+    <partial name="_ArticleForm" for="Article" />
+    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Back to list\" }" />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/Articles/Edit.cshtml
+++ b/Pages/Admin/Articles/Edit.cshtml
@@ -8,18 +8,8 @@
 
 <form method="post">
     <input type="hidden" asp-for="Article.Id" />
-    <div class="form-group">
-        <label asp-for="Article.Title"></label>
-        <input asp-for="Article.Title" class="form-control" />
-        <span asp-validation-for="Article.Title" class="text-danger"></span>
-    </div>
-    <div class="form-group">
-        <label asp-for="Article.Content"></label>
-        <textarea asp-for="Article.Content" class="form-control"></textarea>
-        <span asp-validation-for="Article.Content" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to list</a>
+    <partial name="_ArticleForm" for="Article" />
+    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Back to list\" }" />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/Articles/_ArticleForm.cshtml
+++ b/Pages/Admin/Articles/_ArticleForm.cshtml
@@ -1,0 +1,12 @@
+@model SysJaky_N.Models.Article
+
+<div class="form-group">
+    <label asp-for="Title"></label>
+    <input asp-for="Title" class="form-control" />
+    <span asp-validation-for="Title" class="text-danger"></span>
+</div>
+<div class="form-group">
+    <label asp-for="Content"></label>
+    <textarea asp-for="Content" class="form-control"></textarea>
+    <span asp-validation-for="Content" class="text-danger"></span>
+</div>

--- a/Pages/Admin/CourseBlocks/CourseBlockFormModel.cs
+++ b/Pages/Admin/CourseBlocks/CourseBlockFormModel.cs
@@ -1,0 +1,19 @@
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.CourseBlocks;
+
+public class CourseBlockFormModel
+{
+    public CourseBlockFormModel(CourseBlock courseBlock, IList<Course> availableCourses, ICollection<int> selectedCourseIds)
+    {
+        CourseBlock = courseBlock;
+        AvailableCourses = availableCourses;
+        SelectedCourseIds = selectedCourseIds;
+    }
+
+    public CourseBlock CourseBlock { get; }
+
+    public IList<Course> AvailableCourses { get; }
+
+    public ICollection<int> SelectedCourseIds { get; }
+}

--- a/Pages/Admin/CourseBlocks/Create.cshtml
+++ b/Pages/Admin/CourseBlocks/Create.cshtml
@@ -5,32 +5,8 @@
 }
 <h1>Create Course Block</h1>
 <form method="post">
-    <div class="mb-3">
-        <label asp-for="CourseBlock.Title" class="form-label"></label>
-        <input asp-for="CourseBlock.Title" class="form-control" />
-        <span asp-validation-for="CourseBlock.Title" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="CourseBlock.Description" class="form-label"></label>
-        <textarea asp-for="CourseBlock.Description" class="form-control"></textarea>
-        <span asp-validation-for="CourseBlock.Description" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="CourseBlock.Price" class="form-label"></label>
-        <input asp-for="CourseBlock.Price" class="form-control" />
-        <span asp-validation-for="CourseBlock.Price" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label>Modules</label>
-        @foreach (var course in Model.AvailableCourses)
-        {
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" value="@course.Id" name="SelectedCourseIds" />
-                <label class="form-check-label">@course.Title</label>
-            </div>
-        }
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
+    <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
+    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", ShowCancel = false }" />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseBlocks/Edit.cshtml
+++ b/Pages/Admin/CourseBlocks/Edit.cshtml
@@ -5,32 +5,8 @@
 }
 <h1>Edit Course Block</h1>
 <form method="post">
-    <div class="mb-3">
-        <label asp-for="CourseBlock.Title" class="form-label"></label>
-        <input asp-for="CourseBlock.Title" class="form-control" />
-        <span asp-validation-for="CourseBlock.Title" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="CourseBlock.Description" class="form-label"></label>
-        <textarea asp-for="CourseBlock.Description" class="form-control"></textarea>
-        <span asp-validation-for="CourseBlock.Description" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="CourseBlock.Price" class="form-label"></label>
-        <input asp-for="CourseBlock.Price" class="form-control" />
-        <span asp-validation-for="CourseBlock.Price" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label>Modules</label>
-        @foreach (var course in Model.AvailableCourses)
-        {
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" value="@course.Id" name="SelectedCourseIds" @(Model.SelectedCourseIds.Contains(course.Id) ? "checked" : string.Empty) />
-                <label class="form-check-label">@course.Title</label>
-            </div>
-        }
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
+    <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
+    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", ShowCancel = false }" />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseBlocks/_CourseBlockForm.cshtml
+++ b/Pages/Admin/CourseBlocks/_CourseBlockForm.cshtml
@@ -1,0 +1,29 @@
+@model SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel
+@using System.Linq
+
+<div class="mb-3">
+    <label asp-for="CourseBlock.Title" class="form-label"></label>
+    <input asp-for="CourseBlock.Title" class="form-control" />
+    <span asp-validation-for="CourseBlock.Title" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="CourseBlock.Description" class="form-label"></label>
+    <textarea asp-for="CourseBlock.Description" class="form-control"></textarea>
+    <span asp-validation-for="CourseBlock.Description" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="CourseBlock.Price" class="form-label"></label>
+    <input asp-for="CourseBlock.Price" class="form-control" />
+    <span asp-validation-for="CourseBlock.Price" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label>Modules</label>
+    @foreach (var course in Model.AvailableCourses)
+    {
+        var isChecked = Model.SelectedCourseIds?.Contains(course.Id) == true;
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" value="@course.Id" name="SelectedCourseIds" @(isChecked ? "checked" : null) />
+            <label class="form-check-label">@course.Title</label>
+        </div>
+    }
+</div>

--- a/Pages/Admin/CourseGroups/Create.cshtml
+++ b/Pages/Admin/CourseGroups/Create.cshtml
@@ -7,13 +7,8 @@
 <h1>Create Group</h1>
 
 <form method="post">
-    <div class="form-group">
-        <label asp-for="CourseGroup.Name"></label>
-        <input asp-for="CourseGroup.Name" class="form-control" />
-        <span asp-validation-for="CourseGroup.Name" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+    <partial name="_CourseGroupForm" for="CourseGroup" />
+    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Back to List\" }" />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseGroups/Edit.cshtml
+++ b/Pages/Admin/CourseGroups/Edit.cshtml
@@ -8,13 +8,8 @@
 
 <form method="post">
     <input type="hidden" asp-for="CourseGroup.Id" />
-    <div class="form-group">
-        <label asp-for="CourseGroup.Name"></label>
-        <input asp-for="CourseGroup.Name" class="form-control" />
-        <span asp-validation-for="CourseGroup.Name" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
+    <partial name="_CourseGroupForm" for="CourseGroup" />
+    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Back to List\" }" />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseGroups/_CourseGroupForm.cshtml
+++ b/Pages/Admin/CourseGroups/_CourseGroupForm.cshtml
@@ -1,0 +1,7 @@
+@model SysJaky_N.Models.CourseGroup
+
+<div class="form-group">
+    <label asp-for="Name"></label>
+    <input asp-for="Name" class="form-control" />
+    <span asp-validation-for="Name" class="text-danger"></span>
+</div>

--- a/Pages/Admin/CourseTerms/CourseTermFormModel.cs
+++ b/Pages/Admin/CourseTerms/CourseTermFormModel.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace SysJaky_N.Pages.Admin.CourseTerms;
+
+public class CourseTermFormModel
+{
+    public CourseTermFormModel(CourseTermInputModel input, IEnumerable<SelectListItem> courseOptions, IEnumerable<SelectListItem> instructorOptions)
+    {
+        Input = input;
+        CourseOptions = courseOptions;
+        InstructorOptions = instructorOptions;
+    }
+
+    public CourseTermInputModel Input { get; }
+
+    public IEnumerable<SelectListItem> CourseOptions { get; }
+
+    public IEnumerable<SelectListItem> InstructorOptions { get; }
+}

--- a/Pages/Admin/CourseTerms/Create.cshtml
+++ b/Pages/Admin/CourseTerms/Create.cshtml
@@ -9,47 +9,10 @@
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="Input.CourseId" class="form-label"></label>
-        <select asp-for="Input.CourseId" class="form-select" asp-items="Model.CourseOptions"></select>
-        <span asp-validation-for="Input.CourseId" class="text-danger"></span>
-    </div>
+    <partial name="_CourseTermForm" model="new SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel(Model.Input, Model.CourseOptions, Model.InstructorOptions)" />
 
-    <div class="row g-3">
-        <div class="col-md-6">
-            <label asp-for="Input.StartUtc" class="form-label"></label>
-            <input asp-for="Input.StartUtc" type="datetime-local" class="form-control" />
-            <span asp-validation-for="Input.StartUtc" class="text-danger"></span>
-        </div>
-        <div class="col-md-6">
-            <label asp-for="Input.EndUtc" class="form-label"></label>
-            <input asp-for="Input.EndUtc" type="datetime-local" class="form-control" />
-            <span asp-validation-for="Input.EndUtc" class="text-danger"></span>
-        </div>
-    </div>
-
-    <div class="row g-3 mt-1">
-        <div class="col-md-4">
-            <label asp-for="Input.Capacity" class="form-label"></label>
-            <input asp-for="Input.Capacity" class="form-control" type="number" min="1" />
-            <span asp-validation-for="Input.Capacity" class="text-danger"></span>
-        </div>
-        <div class="col-md-4">
-            <label asp-for="Input.InstructorId" class="form-label"></label>
-            <select asp-for="Input.InstructorId" class="form-select" asp-items="Model.InstructorOptions"></select>
-            <span asp-validation-for="Input.InstructorId" class="text-danger"></span>
-        </div>
-        <div class="col-md-4 d-flex align-items-center">
-            <div class="form-check mt-3">
-                <input class="form-check-input" asp-for="Input.IsActive" />
-                <label class="form-check-label" asp-for="Input.IsActive"></label>
-            </div>
-        </div>
-    </div>
-
-    <div class="mt-4 d-flex gap-2">
-        <button type="submit" class="btn btn-primary">Create</button>
-        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Cancel\" }" />
     </div>
 </form>
 

--- a/Pages/Admin/CourseTerms/Edit.cshtml
+++ b/Pages/Admin/CourseTerms/Edit.cshtml
@@ -9,50 +9,17 @@
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="Input.CourseId" class="form-label"></label>
-        <select asp-for="Input.CourseId" class="form-select" asp-items="Model.CourseOptions"></select>
-        <span asp-validation-for="Input.CourseId" class="text-danger"></span>
-    </div>
-
-    <div class="row g-3">
-        <div class="col-md-6">
-            <label asp-for="Input.StartUtc" class="form-label"></label>
-            <input asp-for="Input.StartUtc" type="datetime-local" class="form-control" />
-            <span asp-validation-for="Input.StartUtc" class="text-danger"></span>
-        </div>
-        <div class="col-md-6">
-            <label asp-for="Input.EndUtc" class="form-label"></label>
-            <input asp-for="Input.EndUtc" type="datetime-local" class="form-control" />
-            <span asp-validation-for="Input.EndUtc" class="text-danger"></span>
-        </div>
-    </div>
+    <partial name="_CourseTermForm" model="new SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel(Model.Input, Model.CourseOptions, Model.InstructorOptions)" />
 
     <div class="row g-3 mt-1">
-        <div class="col-md-4">
-            <label asp-for="Input.Capacity" class="form-label"></label>
-            <input asp-for="Input.Capacity" class="form-control" type="number" min="1" />
-            <span asp-validation-for="Input.Capacity" class="text-danger"></span>
-        </div>
-        <div class="col-md-4">
-            <label asp-for="Input.InstructorId" class="form-label"></label>
-            <select asp-for="Input.InstructorId" class="form-select" asp-items="Model.InstructorOptions"></select>
-            <span asp-validation-for="Input.InstructorId" class="text-danger"></span>
-        </div>
         <div class="col-md-4">
             <label class="form-label">Seats taken</label>
             <input class="form-control" value="@Model.SeatsTaken" readonly />
         </div>
     </div>
 
-    <div class="form-check mt-3">
-        <input class="form-check-input" asp-for="Input.IsActive" />
-        <label class="form-check-label" asp-for="Input.IsActive"></label>
-    </div>
-
-    <div class="mt-4 d-flex gap-2">
-        <button type="submit" class="btn btn-primary">Save changes</button>
-        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save changes\", CancelText = \"Cancel\" }" />
     </div>
 </form>
 

--- a/Pages/Admin/CourseTerms/_CourseTermForm.cshtml
+++ b/Pages/Admin/CourseTerms/_CourseTermForm.cshtml
@@ -1,0 +1,39 @@
+@model SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel
+
+<div class="mb-3">
+    <label asp-for="Input.CourseId" class="form-label"></label>
+    <select asp-for="Input.CourseId" class="form-select" asp-items="Model.CourseOptions"></select>
+    <span asp-validation-for="Input.CourseId" class="text-danger"></span>
+</div>
+
+<div class="row g-3">
+    <div class="col-md-6">
+        <label asp-for="Input.StartUtc" class="form-label"></label>
+        <input asp-for="Input.StartUtc" type="datetime-local" class="form-control" />
+        <span asp-validation-for="Input.StartUtc" class="text-danger"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="Input.EndUtc" class="form-label"></label>
+        <input asp-for="Input.EndUtc" type="datetime-local" class="form-control" />
+        <span asp-validation-for="Input.EndUtc" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="row g-3 mt-1">
+    <div class="col-md-4">
+        <label asp-for="Input.Capacity" class="form-label"></label>
+        <input asp-for="Input.Capacity" class="form-control" type="number" min="1" />
+        <span asp-validation-for="Input.Capacity" class="text-danger"></span>
+    </div>
+    <div class="col-md-4">
+        <label asp-for="Input.InstructorId" class="form-label"></label>
+        <select asp-for="Input.InstructorId" class="form-select" asp-items="Model.InstructorOptions"></select>
+        <span asp-validation-for="Input.InstructorId" class="text-danger"></span>
+    </div>
+    <div class="col-md-4 d-flex align-items-center">
+        <div class="form-check mt-3">
+            <input class="form-check-input" asp-for="Input.IsActive" />
+            <label class="form-check-label" asp-for="Input.IsActive"></label>
+        </div>
+    </div>
+</div>

--- a/Pages/Admin/Instructors/Create.cshtml
+++ b/Pages/Admin/Instructors/Create.cshtml
@@ -9,34 +9,10 @@
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="Instructor.FullName" class="form-label"></label>
-        <input asp-for="Instructor.FullName" class="form-control" />
-        <span asp-validation-for="Instructor.FullName" class="text-danger"></span>
-    </div>
+    <partial name="_InstructorForm" for="Instructor" />
 
-    <div class="row g-3">
-        <div class="col-md-6">
-            <label asp-for="Instructor.Email" class="form-label"></label>
-            <input asp-for="Instructor.Email" class="form-control" />
-            <span asp-validation-for="Instructor.Email" class="text-danger"></span>
-        </div>
-        <div class="col-md-6">
-            <label asp-for="Instructor.PhoneNumber" class="form-label"></label>
-            <input asp-for="Instructor.PhoneNumber" class="form-control" />
-            <span asp-validation-for="Instructor.PhoneNumber" class="text-danger"></span>
-        </div>
-    </div>
-
-    <div class="mb-3 mt-3">
-        <label asp-for="Instructor.Bio" class="form-label"></label>
-        <textarea asp-for="Instructor.Bio" class="form-control" rows="5"></textarea>
-        <span asp-validation-for="Instructor.Bio" class="text-danger"></span>
-    </div>
-
-    <div class="d-flex gap-2">
-        <button type="submit" class="btn btn-primary">Create</button>
-        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Cancel\" }" />
     </div>
 </form>
 

--- a/Pages/Admin/Instructors/Edit.cshtml
+++ b/Pages/Admin/Instructors/Edit.cshtml
@@ -10,34 +10,10 @@
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <input type="hidden" asp-for="Instructor.Id" />
 
-    <div class="mb-3">
-        <label asp-for="Instructor.FullName" class="form-label"></label>
-        <input asp-for="Instructor.FullName" class="form-control" />
-        <span asp-validation-for="Instructor.FullName" class="text-danger"></span>
-    </div>
+    <partial name="_InstructorForm" for="Instructor" />
 
-    <div class="row g-3">
-        <div class="col-md-6">
-            <label asp-for="Instructor.Email" class="form-label"></label>
-            <input asp-for="Instructor.Email" class="form-control" />
-            <span asp-validation-for="Instructor.Email" class="text-danger"></span>
-        </div>
-        <div class="col-md-6">
-            <label asp-for="Instructor.PhoneNumber" class="form-label"></label>
-            <input asp-for="Instructor.PhoneNumber" class="form-control" />
-            <span asp-validation-for="Instructor.PhoneNumber" class="text-danger"></span>
-        </div>
-    </div>
-
-    <div class="mb-3 mt-3">
-        <label asp-for="Instructor.Bio" class="form-label"></label>
-        <textarea asp-for="Instructor.Bio" class="form-control" rows="5"></textarea>
-        <span asp-validation-for="Instructor.Bio" class="text-danger"></span>
-    </div>
-
-    <div class="d-flex gap-2">
-        <button type="submit" class="btn btn-primary">Save changes</button>
-        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save changes\", CancelText = \"Cancel\" }" />
     </div>
 </form>
 

--- a/Pages/Admin/Instructors/_InstructorForm.cshtml
+++ b/Pages/Admin/Instructors/_InstructorForm.cshtml
@@ -1,0 +1,26 @@
+@model SysJaky_N.Models.Instructor
+
+<div class="mb-3">
+    <label asp-for="FullName" class="form-label"></label>
+    <input asp-for="FullName" class="form-control" />
+    <span asp-validation-for="FullName" class="text-danger"></span>
+</div>
+
+<div class="row g-3">
+    <div class="col-md-6">
+        <label asp-for="Email" class="form-label"></label>
+        <input asp-for="Email" class="form-control" />
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="PhoneNumber" class="form-label"></label>
+        <input asp-for="PhoneNumber" class="form-control" />
+        <span asp-validation-for="PhoneNumber" class="text-danger"></span>
+    </div>
+</div>
+
+<div class="mb-3 mt-3">
+    <label asp-for="Bio" class="form-label"></label>
+    <textarea asp-for="Bio" class="form-control" rows="5"></textarea>
+    <span asp-validation-for="Bio" class="text-danger"></span>
+</div>

--- a/Pages/Admin/PriceSchedules/Create.cshtml
+++ b/Pages/Admin/PriceSchedules/Create.cshtml
@@ -9,29 +9,11 @@
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.CourseId" class="form-label"></label>
-        <select asp-for="PriceSchedule.CourseId" class="form-select" asp-items="Model.Courses"></select>
-        <span asp-validation-for="PriceSchedule.CourseId" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.FromUtc" class="form-label"></label>
-        <input asp-for="PriceSchedule.FromUtc" class="form-control" type="datetime-local" />
-        <span asp-validation-for="PriceSchedule.FromUtc" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.ToUtc" class="form-label"></label>
-        <input asp-for="PriceSchedule.ToUtc" class="form-control" type="datetime-local" />
-        <span asp-validation-for="PriceSchedule.ToUtc" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.NewPriceExcl" class="form-label"></label>
-        <input asp-for="PriceSchedule.NewPriceExcl" class="form-control" type="number" step="0.01" min="0.01" />
-        <span asp-validation-for="PriceSchedule.NewPriceExcl" class="text-danger"></span>
-    </div>
+    <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
-    <button type="submit" class="btn btn-primary">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Cancel\" }" />
+    </div>
 </form>
 
 @section Scripts {

--- a/Pages/Admin/PriceSchedules/Edit.cshtml
+++ b/Pages/Admin/PriceSchedules/Edit.cshtml
@@ -10,29 +10,11 @@
     <input type="hidden" asp-for="PriceSchedule.Id" />
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.CourseId" class="form-label"></label>
-        <select asp-for="PriceSchedule.CourseId" class="form-select" asp-items="Model.Courses"></select>
-        <span asp-validation-for="PriceSchedule.CourseId" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.FromUtc" class="form-label"></label>
-        <input asp-for="PriceSchedule.FromUtc" class="form-control" type="datetime-local" />
-        <span asp-validation-for="PriceSchedule.FromUtc" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.ToUtc" class="form-label"></label>
-        <input asp-for="PriceSchedule.ToUtc" class="form-control" type="datetime-local" />
-        <span asp-validation-for="PriceSchedule.ToUtc" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="PriceSchedule.NewPriceExcl" class="form-label"></label>
-        <input asp-for="PriceSchedule.NewPriceExcl" class="form-control" type="number" step="0.01" min="0.01" />
-        <span asp-validation-for="PriceSchedule.NewPriceExcl" class="text-danger"></span>
-    </div>
+    <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Cancel\" }" />
+    </div>
 </form>
 
 @section Scripts {

--- a/Pages/Admin/PriceSchedules/PriceScheduleFormModel.cs
+++ b/Pages/Admin/PriceSchedules/PriceScheduleFormModel.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.PriceSchedules;
+
+public class PriceScheduleFormModel
+{
+    public PriceScheduleFormModel(PriceSchedule priceSchedule, IEnumerable<SelectListItem> courses)
+    {
+        PriceSchedule = priceSchedule;
+        Courses = courses;
+    }
+
+    public PriceSchedule PriceSchedule { get; }
+
+    public IEnumerable<SelectListItem> Courses { get; }
+}

--- a/Pages/Admin/PriceSchedules/_PriceScheduleForm.cshtml
+++ b/Pages/Admin/PriceSchedules/_PriceScheduleForm.cshtml
@@ -1,0 +1,22 @@
+@model SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel
+
+<div class="mb-3">
+    <label asp-for="PriceSchedule.CourseId" class="form-label"></label>
+    <select asp-for="PriceSchedule.CourseId" class="form-select" asp-items="Model.Courses"></select>
+    <span asp-validation-for="PriceSchedule.CourseId" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="PriceSchedule.FromUtc" class="form-label"></label>
+    <input asp-for="PriceSchedule.FromUtc" class="form-control" type="datetime-local" />
+    <span asp-validation-for="PriceSchedule.FromUtc" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="PriceSchedule.ToUtc" class="form-label"></label>
+    <input asp-for="PriceSchedule.ToUtc" class="form-control" type="datetime-local" />
+    <span asp-validation-for="PriceSchedule.ToUtc" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="PriceSchedule.NewPriceExcl" class="form-label"></label>
+    <input asp-for="PriceSchedule.NewPriceExcl" class="form-control" type="number" step="0.01" min="0.01" />
+    <span asp-validation-for="PriceSchedule.NewPriceExcl" class="text-danger"></span>
+</div>

--- a/Pages/Admin/Shared/FormActionsModel.cs
+++ b/Pages/Admin/Shared/FormActionsModel.cs
@@ -1,0 +1,16 @@
+namespace SysJaky_N.Pages.Admin.Shared;
+
+public class FormActionsModel
+{
+    public string SubmitText { get; set; } = "Save";
+
+    public string SubmitCssClass { get; set; } = "btn btn-primary";
+
+    public string CancelPage { get; set; } = "Index";
+
+    public string CancelText { get; set; } = "Cancel";
+
+    public string CancelCssClass { get; set; } = "btn btn-secondary";
+
+    public bool ShowCancel { get; set; } = true;
+}

--- a/Pages/Admin/Shared/_FormActions.cshtml
+++ b/Pages/Admin/Shared/_FormActions.cshtml
@@ -1,0 +1,9 @@
+@model SysJaky_N.Pages.Admin.Shared.FormActionsModel
+
+<div class="d-flex gap-2">
+    <button type="submit" class="@Model.SubmitCssClass">@Model.SubmitText</button>
+    @if (Model.ShowCancel)
+    {
+        <a asp-page="@Model.CancelPage" class="@Model.CancelCssClass">@Model.CancelText</a>
+    }
+</div>

--- a/Pages/Admin/Vouchers/Create.cshtml
+++ b/Pages/Admin/Vouchers/Create.cshtml
@@ -10,38 +10,11 @@
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
-    <div class="mb-3">
-        <label asp-for="Voucher.Code" class="form-label"></label>
-        <input asp-for="Voucher.Code" class="form-control" />
-        <span asp-validation-for="Voucher.Code" class="text-danger"></span>
+    <partial name="_VoucherForm" model="new SysJaky_N.Pages.Admin.Vouchers.VoucherFormModel(Model.Voucher, Model.Courses)" />
+
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Back to List\" }" />
     </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.Type" class="form-label"></label>
-        <select asp-for="Voucher.Type" class="form-select" asp-items="Html.GetEnumSelectList<VoucherType>()"></select>
-        <span asp-validation-for="Voucher.Type" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.Value" class="form-label"></label>
-        <input asp-for="Voucher.Value" class="form-control" type="number" step="0.01" min="0" />
-        <span asp-validation-for="Voucher.Value" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.ExpiresUtc" class="form-label"></label>
-        <input asp-for="Voucher.ExpiresUtc" class="form-control" type="datetime-local" />
-        <span asp-validation-for="Voucher.ExpiresUtc" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.MaxRedemptions" class="form-label"></label>
-        <input asp-for="Voucher.MaxRedemptions" class="form-control" type="number" min="1" />
-        <span asp-validation-for="Voucher.MaxRedemptions" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.AppliesToCourseId" class="form-label"></label>
-        <select asp-for="Voucher.AppliesToCourseId" class="form-select" asp-items="Model.Courses"></select>
-        <span asp-validation-for="Voucher.AppliesToCourseId" class="text-danger"></span>
-    </div>
-    <button type="submit" class="btn btn-primary">Create</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </form>
 
 @section Scripts {

--- a/Pages/Admin/Vouchers/Edit.cshtml
+++ b/Pages/Admin/Vouchers/Edit.cshtml
@@ -10,42 +10,17 @@
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
     <input type="hidden" asp-for="Voucher.Id" />
-    <div class="mb-3">
-        <label asp-for="Voucher.Code" class="form-label"></label>
-        <input asp-for="Voucher.Code" class="form-control" />
-        <span asp-validation-for="Voucher.Code" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.Type" class="form-label"></label>
-        <select asp-for="Voucher.Type" class="form-select" asp-items="Html.GetEnumSelectList<VoucherType>()"></select>
-        <span asp-validation-for="Voucher.Type" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.Value" class="form-label"></label>
-        <input asp-for="Voucher.Value" class="form-control" type="number" step="0.01" min="0" />
-        <span asp-validation-for="Voucher.Value" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.ExpiresUtc" class="form-label"></label>
-        <input asp-for="Voucher.ExpiresUtc" class="form-control" type="datetime-local" />
-        <span asp-validation-for="Voucher.ExpiresUtc" class="text-danger"></span>
-    </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.MaxRedemptions" class="form-label"></label>
-        <input asp-for="Voucher.MaxRedemptions" class="form-control" type="number" min="1" />
-        <span asp-validation-for="Voucher.MaxRedemptions" class="text-danger"></span>
-    </div>
+
+    <partial name="_VoucherForm" model="new SysJaky_N.Pages.Admin.Vouchers.VoucherFormModel(Model.Voucher, Model.Courses)" />
+
     <div class="mb-3">
         <label asp-for="Voucher.UsedCount" class="form-label"></label>
         <input class="form-control" value="@Model.Voucher.UsedCount" readonly />
     </div>
-    <div class="mb-3">
-        <label asp-for="Voucher.AppliesToCourseId" class="form-label"></label>
-        <select asp-for="Voucher.AppliesToCourseId" class="form-select" asp-items="Model.Courses"></select>
-        <span asp-validation-for="Voucher.AppliesToCourseId" class="text-danger"></span>
+
+    <div class="mt-4">
+        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Back to List\" }" />
     </div>
-    <button type="submit" class="btn btn-primary">Save</button>
-    <a asp-page="Index" class="btn btn-secondary">Back to List</a>
 </form>
 
 @section Scripts {

--- a/Pages/Admin/Vouchers/VoucherFormModel.cs
+++ b/Pages/Admin/Vouchers/VoucherFormModel.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc.Rendering;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Admin.Vouchers;
+
+public class VoucherFormModel
+{
+    public VoucherFormModel(Voucher voucher, IEnumerable<SelectListItem> courses)
+    {
+        Voucher = voucher;
+        Courses = courses;
+    }
+
+    public Voucher Voucher { get; }
+
+    public IEnumerable<SelectListItem> Courses { get; }
+}

--- a/Pages/Admin/Vouchers/_VoucherForm.cshtml
+++ b/Pages/Admin/Vouchers/_VoucherForm.cshtml
@@ -1,0 +1,33 @@
+@model SysJaky_N.Pages.Admin.Vouchers.VoucherFormModel
+@using SysJaky_N.Models
+
+<div class="mb-3">
+    <label asp-for="Voucher.Code" class="form-label"></label>
+    <input asp-for="Voucher.Code" class="form-control" />
+    <span asp-validation-for="Voucher.Code" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="Voucher.Type" class="form-label"></label>
+    <select asp-for="Voucher.Type" class="form-select" asp-items="Html.GetEnumSelectList<VoucherType>()"></select>
+    <span asp-validation-for="Voucher.Type" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="Voucher.Value" class="form-label"></label>
+    <input asp-for="Voucher.Value" class="form-control" type="number" step="0.01" min="0" />
+    <span asp-validation-for="Voucher.Value" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="Voucher.ExpiresUtc" class="form-label"></label>
+    <input asp-for="Voucher.ExpiresUtc" class="form-control" type="datetime-local" />
+    <span asp-validation-for="Voucher.ExpiresUtc" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="Voucher.MaxRedemptions" class="form-label"></label>
+    <input asp-for="Voucher.MaxRedemptions" class="form-control" type="number" min="1" />
+    <span asp-validation-for="Voucher.MaxRedemptions" class="text-danger"></span>
+</div>
+<div class="mb-3">
+    <label asp-for="Voucher.AppliesToCourseId" class="form-label"></label>
+    <select asp-for="Voucher.AppliesToCourseId" class="form-select" asp-items="Model.Courses"></select>
+    <span asp-validation-for="Voucher.AppliesToCourseId" class="text-danger"></span>
+</div>


### PR DESCRIPTION
## Summary
- extract shared Razor partials for admin CourseBlocks, CourseGroups, CourseTerms, PriceSchedules, Vouchers, Instructors, and Articles forms
- add a reusable form action partial for consistent submit and cancel controls across admin pages
- update the create and edit pages to render the new partials while keeping hidden identifiers and read-only fields intact

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb9b797e4832184ce9951b764a5b8