### PR TITLE
Add trust stripe below hero section

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -52,6 +52,37 @@
     </div>
 </section>
 
+<section class="container-xl mb-4">
+    <div class="trust-stripe rounded-4 p-3">
+        <div class="row row-cols-2 row-cols-md-4 g-3 g-md-0 align-items-center text-center text-md-start">
+            <div class="col">
+                <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
+                    <i class="bi bi-star-fill"></i>
+                    <span>Hodnocení 4.8/5</span>
+                </div>
+            </div>
+            <div class="col">
+                <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
+                    <i class="bi bi-people"></i>
+                    <span>10 000+ absolventů</span>
+                </div>
+            </div>
+            <div class="col">
+                <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
+                    <i class="bi bi-shield-check"></i>
+                    <span>Garance spokojenosti / snadné storno</span>
+                </div>
+            </div>
+            <div class="col">
+                <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
+                    <i class="bi bi-patch-check"></i>
+                    <span>Certifikát v ceně vybraných kurzů</span>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
 <script>
     // Ulož volby pro pozdější předvyplnění (malý závazek = vyšší konverze)
     (function () {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -273,6 +273,27 @@ select:focus-visible {
   color: rgba(255, 255, 255, 0.85);
 }
 
+.trust-stripe {
+  background: var(--neutral-100);
+  border: 1px solid var(--neutral-300);
+  box-shadow: 0 18px 36px rgba(12, 56, 87, 0.08);
+  color: var(--neutral-900);
+}
+
+.trust-stripe .trust-item {
+  font-weight: 600;
+}
+
+.trust-stripe .bi {
+  font-size: 1.35rem;
+  color: var(--primary);
+}
+
+.trust-stripe .trust-item span {
+  display: inline-block;
+  line-height: 1.3;
+}
+
 .icon-circle {
   width: 4rem;
   height: 4rem;


### PR DESCRIPTION
## Summary
- add a trust stripe below the hero highlighting ratings, alumni count, guarantees, and certificates
- style the trust stripe for high contrast and responsive two-column layout on mobile

## Testing
- dotnet run *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbca2cdab88321a19f07fe0580a726