### PR TITLE
Add curated recommendations and fast-start sections to home page

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -98,6 +98,61 @@
     })();
 </script>
 
+<section class="container-xl">
+  <div class="row g-3 align-items-stretch">
+    <div class="col-lg-8">
+      <div class="feature-card h-100 p-3">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h2 class="h5 mb-0">Doporučeno pro vás</h2>
+          <a class="btn btn-sm btn-outline-secondary" href="/Courses/Index">Zobrazit vše</a>
+        </div>
+        <div class="row g-3">
+          @foreach (var c in Model.PicksForPersona)
+          {
+            <div class="col-12 col-md-6">
+              @await Html.PartialAsync("/Pages/Shared/Components/_CourseCard.cshtml", c)
+            </div>
+          }
+          @if (!Model.PicksForPersona.Any())
+          {
+            <div class="col-12 text-muted">Vyberte nahoře „Jsem… / Chci…“, nebo použijte vyhledávání.</div>
+          }
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-4">
+      <div class="feature-card h-100 p-3">
+        <h2 class="h6">Co startuje nejdřív</h2>
+        <ul class="list-unstyled small mb-3">
+          @foreach (var c in Model.FastSoonest)
+          {
+            <li class="mb-2">
+              <a asp-page="/Courses/Details" asp-route-id="@c.Id">@c.Title</a>
+              <span class="text-muted">— @c.Date.ToString("d")</span>
+            </li>
+          }
+        </ul>
+        <a class="btn btn-outline-primary btn-sm" href="/Courses/Calendar"><i class="bi bi-calendar3"></i> Kalendář termínů</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="row g-3 mt-1">
+    <div class="col-12">
+      <div class="feature-card p-3">
+        <h2 class="h6 mb-2">Novinky</h2>
+        <div class="d-flex flex-wrap gap-3">
+          @foreach (var a in Model.FreshNews)
+          {
+            <a class="news-pill" asp-page="/Articles/Details" asp-route-id="@a.Id">@a.Title</a>
+          }
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="app-section">
     <div class="container-xl">
         <h2 class="section-title text-center">@Localizer["HowItWorksTitle"]</h2>

--- a/Pages/Index.cshtml.cs
+++ b/Pages/Index.cshtml.cs
@@ -1,20 +1,84 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
 
 namespace SysJaky_N.Pages
 {
     public class IndexModel : PageModel
     {
         private readonly ILogger<IndexModel> _logger;
+        private readonly ApplicationDbContext _context;
 
-        public IndexModel(ILogger<IndexModel> logger)
+        public IndexModel(ILogger<IndexModel> logger, ApplicationDbContext context)
         {
             _logger = logger;
+            _context = context;
         }
 
-        public void OnGet()
-        {
+        public IList<Course> PicksForPersona { get; set; } = new List<Course>();
+        public IList<Course> FastSoonest { get; set; } = new List<Course>();
+        public IList<Article> FreshNews { get; set; } = new List<Article>();
 
+        public async Task OnGetAsync(string? persona, string? goal)
+        {
+            var today = DateTime.Today;
+
+            FastSoonest = await _context.Courses
+                .AsNoTracking()
+                .Where(c => c.IsActive && c.Date >= today)
+                .OrderBy(c => c.Date)
+                .ThenBy(c => c.Title)
+                .Take(6)
+                .ToListAsync();
+
+            IQueryable<Course> baseQuery = _context.Courses
+                .AsNoTracking()
+                .Where(c => c.IsActive);
+
+            if (!string.IsNullOrWhiteSpace(persona))
+            {
+                var personaPattern = $"%{persona.Trim()}%";
+                baseQuery = baseQuery.Where(c =>
+                    (c.CourseGroup != null && EF.Functions.Like(c.CourseGroup.Name, personaPattern)) ||
+                    c.CourseTags.Any(ct => EF.Functions.Like(ct.Tag.Name, personaPattern)));
+            }
+
+            if (!string.IsNullOrWhiteSpace(goal))
+            {
+                var goalPattern = $"%{goal.Trim()}%";
+                baseQuery = baseQuery.Where(c =>
+                    (!string.IsNullOrEmpty(c.Description) && EF.Functions.Like(c.Description, goalPattern)) ||
+                    c.CourseTags.Any(ct => EF.Functions.Like(ct.Tag.Name, goalPattern)));
+            }
+
+            var recommended = await baseQuery
+                .GroupJoin(
+                    _context.CourseReviews.AsNoTracking().Where(r => r.IsPublic),
+                    course => course.Id,
+                    review => review.CourseId,
+                    (course, reviews) => new
+                    {
+                        Course = course,
+                        AverageRating = reviews.Select(r => (double?)r.Rating).Average() ?? 0d,
+                        ReviewCount = reviews.Count()
+                    })
+                .OrderByDescending(x => x.AverageRating)
+                .ThenByDescending(x => x.ReviewCount)
+                .ThenBy(x => x.Course.Date)
+                .Take(6)
+                .ToListAsync();
+
+            PicksForPersona = recommended
+                .Select(x => x.Course)
+                .ToList();
+
+            FreshNews = await _context.Articles
+                .AsNoTracking()
+                .OrderByDescending(a => a.CreatedAt)
+                .Take(6)
+                .ToListAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add asynchronous data loading on the home page for persona picks, fast upcoming courses, and fresh news
- surface curated course and article sections on the landing page under the trust stripe

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbcb71f0988321a0e029519f8f586e