### PR TITLE
Add advisor offcanvas for course selection guidance

### DIFF
--- a/Pages/Shared/_AdvisorOffcanvas.cshtml
+++ b/Pages/Shared/_AdvisorOffcanvas.cshtml
@@ -1,0 +1,22 @@
+<div class="offcanvas offcanvas-end" tabindex="-1" id="advisor" aria-labelledby="advisorLabel">
+  <div class="offcanvas-header">
+    <h5 id="advisorLabel">Najdeme vhodné školení</h5>
+    <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
+  </div>
+  <div class="offcanvas-body">
+    <form method="get" action="/Courses/Index" id="advisorForm" class="vstack gap-3">
+      <select name="persona" class="form-select">
+        <option value="">Jsem…</option><option>Jednotlivec</option><option>HR / týmový leader</option><option>Laboratoř</option><option>Manažer kvality</option><option>Auditor</option><option>Začátečník v ISO</option>
+      </select>
+      <select name="goal" class="form-select">
+        <option value="">Chci…</option><option>získat/obnovit certifikát</option><option>rychle doplnit dovednost</option><option>rekvalifikovat se</option><option>školení pro celý tým</option>
+      </select>
+      <div class="input-group">
+        <span class="input-group-text"><i class="bi bi-geo-alt"></i></span>
+        <input class="form-control" name="City" placeholder="Město (volitelně)" />
+      </div>
+      <div class="d-grid"><button class="btn btn-primary">Zobrazit návrhy</button></div>
+      <div class="text-muted small">Tip: Vaši volbu si zapamatujeme pro příště.</div>
+    </form>
+  </div>
+</div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -56,6 +56,11 @@
                                 </a>
                             </li>
                         }
+                        <li class="nav-item">
+                            <a class="btn btn-outline-light ms-2" data-bs-toggle="offcanvas" href="#advisor" role="button">
+                                <i class="bi bi-magic"></i> Poradit s výběrem
+                            </a>
+                        </li>
                         @if (!User.Identity.IsAuthenticated)
                         {
                             <li class="nav-item">
@@ -105,6 +110,8 @@
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     <script type="module" src='@Url.Content("~/lib/altcha/altcha.min.js")'></script>
+
+    @await Html.PartialAsync("/Pages/Shared/_AdvisorOffcanvas.cshtml")
 
     @if (!User.Identity.IsAuthenticated)
     {


### PR DESCRIPTION
## Summary
- add a header button that opens a new advisor offcanvas for course recommendations
- create a reusable partial with persona, goal, and location inputs and include it in the layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbcc76a7ac832199ef266be5ffa414