### PR TITLE
Add sticky course results header with filter summary

### DIFF
--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -11,6 +11,24 @@
     <li class="nav-item"><a class="nav-link" asp-page="/Courses/Calendar">Kalendář</a></li>
 </ul>
 
+<div class="result-header sticky-top z-2 d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 py-2 bg-body border-bottom">
+    <div class="small text-muted">
+        @Model.TotalCount výsledků
+        @if (!string.IsNullOrWhiteSpace(Context.Request.Query["persona"]))
+        {
+            <span class="ms-2 badge bg-primary-subtle text-primary">@(Context.Request.Query["persona"])</span>
+        }
+        @if (!string.IsNullOrWhiteSpace(Context.Request.Query["goal"]))
+        {
+            <span class="ms-1 badge bg-warning">@((string)Context.Request.Query["goal"])</span>
+        }
+    </div>
+    <div class="d-flex gap-2">
+        <a class="btn btn-sm btn-outline-secondary" href="@Url.Page("/Courses/Index")">Zrušit filtry</a>
+        <a class="btn btn-sm btn-outline-primary d-lg-none" data-bs-toggle="offcanvas" href="#filters"><i class="bi bi-sliders"></i> Filtry</a>
+    </div>
+</div>
+
 @if (TempData["CartError"] is string cartError && !string.IsNullOrWhiteSpace(cartError))
 {
     <div class="alert alert-danger" role="alert">@cartError</div>


### PR DESCRIPTION
## Summary
- add a sticky results header above the course filters to show total matches and active persona/goal
- provide quick access buttons for resetting filters and opening the filter panel on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbcce4fe588321a0939852c3945c11