### PR TITLE
Add offcanvas filters and desktop sidebar for courses

### DIFF
--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -34,65 +34,34 @@
     <div class="alert alert-danger" role="alert">@cartError</div>
 }
 
-<form method="get" class="mb-4" role="search" aria-label="Filtry kurzů">
-    <div class="row g-2">
-        <div class="col-sm-6 col-lg-3">
-            <input type="text" asp-for="SearchString" placeholder="Co se chcete naučit? Zadejte kurz, nástroj nebo dovednost" class="form-control" aria-label="Hledání kurzů" />
-        </div>
-        <div class="col-sm-6 col-lg-3">
-            <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-select" aria-label="Skupina kurzů">
-                <option value="">Všechny skupiny</option>
-            </select>
-        </div>
-        <div class="col-sm-6 col-lg-3">
-            <select asp-for="Level" asp-items="Model.LevelOptions" class="form-select" aria-label="Úroveň">
-                <option value="">Všechny úrovně</option>
-            </select>
-        </div>
-        <div class="col-sm-6 col-lg-3">
-            <select asp-for="Mode" asp-items="Model.ModeOptions" class="form-select" aria-label="Forma">
-                <option value="">Všechny formy</option>
-            </select>
-        </div>
-        <div class="col-sm-6 col-lg-3">
-            <div class="input-group">
-                <span class="input-group-text" id="minDurationLabel">Min. délka</span>
-                <input type="number" asp-for="MinDuration" class="form-control" min="0" aria-labelledby="minDurationLabel" />
-            </div>
-        </div>
-        <div class="col-sm-6 col-lg-3">
-            <div class="input-group">
-                <span class="input-group-text" id="maxDurationLabel">Max. délka</span>
-                <input type="number" asp-for="MaxDuration" class="form-control" min="0" aria-labelledby="maxDurationLabel" />
-            </div>
-        </div>
-        <div class="col-12 col-lg-6">
-            <label class="form-label">Štítky</label>
-            <select asp-for="SelectedTagIds" asp-items="Model.TagOptions" class="form-select" multiple size="4" aria-label="Štítky"></select>
-        </div>
-        <div class="col-12 text-end">
-            <button type="submit" class="btn btn-primary">Vyhledat kurzy</button>
-        </div>
-    </div>
-</form>
+@await Html.PartialAsync("/Pages/Courses/_Filters.cshtml", Model)
 
-<div class="courses-grid">
-    @foreach (var c in Model.Courses)
-    {
-        @await Html.PartialAsync("/Pages/Shared/Components/_CourseCard.cshtml", c)
-    }
+<div class="row g-3">
+    <aside class="col-lg-3 d-none d-lg-block">
+        <div class="feature-card p-3">
+            @await Html.PartialAsync("/Pages/Courses/_FiltersForm.cshtml", Model)
+        </div>
+    </aside>
+    <main class="col-lg-9">
+        <div class="courses-grid">
+            @foreach (var c in Model.Courses)
+            {
+                @await Html.PartialAsync("/Pages/Shared/Components/_CourseCard.cshtml", c)
+            }
+        </div>
+
+        @if (Model.TotalPages > 1)
+        {
+            <nav class="mt-3" aria-label="Stránkování kurzů">
+                <ul class="pagination">
+                    <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
+                        <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">Předchozí</a>
+                    </li>
+                    <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
+                        <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">Další</a>
+                    </li>
+                </ul>
+            </nav>
+        }
+    </main>
 </div>
-
-@if (Model.TotalPages > 1)
-{
-    <nav class="mt-3" aria-label="Stránkování kurzů">
-        <ul class="pagination">
-            <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">Předchozí</a>
-            </li>
-            <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">Další</a>
-            </li>
-        </ul>
-    </nav>
-}

--- a/Pages/Courses/_Filters.cshtml
+++ b/Pages/Courses/_Filters.cshtml
@@ -1,0 +1,11 @@
+@model SysJaky_N.Pages.Courses.IndexModel
+
+<div class="offcanvas offcanvas-lg offcanvas-start d-lg-none" tabindex="-1" id="filters" aria-labelledby="filtersLabel">
+    <div class="offcanvas-header d-lg-none">
+        <h5 id="filtersLabel">Filtry</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Zavřít"></button>
+    </div>
+    <div class="offcanvas-body">
+        @await Html.PartialAsync("/Pages/Courses/_FiltersForm.cshtml", Model)
+    </div>
+</div>

--- a/Pages/Courses/_FiltersForm.cshtml
+++ b/Pages/Courses/_FiltersForm.cshtml
@@ -1,0 +1,43 @@
+@model SysJaky_N.Pages.Courses.IndexModel
+
+<form method="get" class="mb-0" role="search" aria-label="Filtry kurzů">
+    <div class="row g-2">
+        <div class="col-sm-6 col-lg-12">
+            <input type="text" asp-for="SearchString" placeholder="Co se chcete naučit? Zadejte kurz, nástroj nebo dovednost" class="form-control" aria-label="Hledání kurzů" />
+        </div>
+        <div class="col-sm-6 col-lg-12">
+            <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-select" aria-label="Skupina kurzů">
+                <option value="">Všechny skupiny</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-12">
+            <select asp-for="Level" asp-items="Model.LevelOptions" class="form-select" aria-label="Úroveň">
+                <option value="">Všechny úrovně</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-12">
+            <select asp-for="Mode" asp-items="Model.ModeOptions" class="form-select" aria-label="Forma">
+                <option value="">Všechny formy</option>
+            </select>
+        </div>
+        <div class="col-sm-6 col-lg-6">
+            <div class="input-group">
+                <span class="input-group-text" id="minDurationLabel">Min. délka</span>
+                <input type="number" asp-for="MinDuration" class="form-control" min="0" aria-labelledby="minDurationLabel" />
+            </div>
+        </div>
+        <div class="col-sm-6 col-lg-6">
+            <div class="input-group">
+                <span class="input-group-text" id="maxDurationLabel">Max. délka</span>
+                <input type="number" asp-for="MaxDuration" class="form-control" min="0" aria-labelledby="maxDurationLabel" />
+            </div>
+        </div>
+        <div class="col-12">
+            <label class="form-label">Štítky</label>
+            <select asp-for="SelectedTagIds" asp-items="Model.TagOptions" class="form-select" multiple size="4" aria-label="Štítky"></select>
+        </div>
+        <div class="col-12 text-end">
+            <button type="submit" class="btn btn-primary">Vyhledat kurzy</button>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- add a reusable filters form partial for the courses page
- introduce a mobile offcanvas wrapper for filters
- restructure the courses index into a desktop sidebar/main layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbcda839d88321a1956768a478932a