### PR TITLE
Add popover to course card for upcoming dates

### DIFF
--- a/Models/Course.cs
+++ b/Models/Course.cs
@@ -60,6 +60,8 @@ public class Course
     public ICollection<Lesson> Lessons { get; set; } = new List<Lesson>();
 
     public ICollection<CourseTag> CourseTags { get; set; } = new List<CourseTag>();
+
+    public string? PopoverHtml { get; set; }
 }
 
 public enum CourseType

--- a/Pages/Shared/Components/_CourseCard.cshtml
+++ b/Pages/Shared/Components/_CourseCard.cshtml
@@ -16,7 +16,18 @@
   </div>
   <div class="d-flex justify-content-between align-items-end mt-3">
     <div class="small text-muted">
-      <i class="bi bi-calendar2 me-2"></i>@Model.Date.ToShortDateString()
+      <div class="d-flex align-items-center">
+        <i class="bi bi-calendar2 me-2"></i>
+        <small class="text-muted">
+          @Model.Date.ToString("d")
+          @if (!string.IsNullOrWhiteSpace(Model.PopoverHtml))
+          {
+            <a tabindex="0" role="button" class="ms-1 text-decoration-dotted" data-bs-toggle="popover" data-bs-html="true" data-bs-content="@Model.PopoverHtml">
+              <i class="bi bi-info-circle"></i>
+            </a>
+          }
+        </small>
+      </div>
       <div class="fw-semibold">@Model.Price.ToString("C")</div>
     </div>
     <div class="d-flex gap-2">

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -2,3 +2,11 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+document.addEventListener('DOMContentLoaded', () => {
+    if (window.bootstrap && typeof window.bootstrap.Popover === 'function') {
+        document.querySelectorAll('[data-bs-toggle="popover"]').forEach((element) => {
+            new window.bootstrap.Popover(element);
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- add a popover trigger next to the course date to display upcoming sessions
- expose an optional `PopoverHtml` property on the course model for server-provided markup
- initialize Bootstrap popovers on DOM ready when the Bootstrap library is available

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbd2f0fd5083219e386ae338ab33ee