### PR TITLE
Add course comparison selection and page

### DIFF
--- a/Pages/Courses/Compare.cshtml
+++ b/Pages/Courses/Compare.cshtml
@@ -1,0 +1,40 @@
+@page
+@model SysJaky_N.Pages.Courses.CompareModel
+@{
+    ViewData["Title"] = "Porovnání kurzů";
+}
+
+<h1 class="h4 mb-3">Porovnání kurzů</h1>
+
+@if (Model.Courses.Count == 0)
+{
+    <div class="alert alert-info">Vyberte alespoň dva kurzy k porovnání.</div>
+}
+else
+{
+    <div class="table-responsive feature-card p-3">
+        <table class="table align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Název</th>
+                    <th scope="col">Délka</th>
+                    <th scope="col">Úroveň</th>
+                    <th scope="col">Forma</th>
+                    <th scope="col">Cena</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var course in Model.Courses)
+                {
+                    <tr>
+                        <td>@course.Title</td>
+                        <td>@course.Duration min</td>
+                        <td>@course.Level</td>
+                        <td>@course.Mode</td>
+                        <td>@course.Price.ToString("C")</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}

--- a/Pages/Courses/Compare.cshtml.cs
+++ b/Pages/Courses/Compare.cshtml.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Pages.Courses;
+
+public class CompareModel : PageModel
+{
+    private readonly ApplicationDbContext _context;
+
+    public CompareModel(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public IList<Course> Courses { get; private set; } = new List<Course>();
+
+    public async Task<IActionResult> OnGetAsync(string? ids)
+    {
+        var requestedIds = ParseCourseIds(ids);
+        if (requestedIds.Count == 0)
+        {
+            Courses = new List<Course>();
+            return Page();
+        }
+
+        var idSet = new HashSet<int>(requestedIds);
+        var courses = await _context.Courses
+            .AsNoTracking()
+            .Where(c => idSet.Contains(c.Id))
+            .ToListAsync();
+
+        var courseById = courses.ToDictionary(c => c.Id);
+        Courses = requestedIds
+            .Where(courseById.ContainsKey)
+            .Select(id => courseById[id])
+            .ToList();
+
+        return Page();
+    }
+
+    private static List<int> ParseCourseIds(string? ids)
+    {
+        var result = new List<int>();
+        if (string.IsNullOrWhiteSpace(ids))
+        {
+            return result;
+        }
+
+        var seen = new HashSet<int>();
+        foreach (var part in ids.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (result.Count >= 3)
+            {
+                break;
+            }
+
+            if (int.TryParse(part, out var value) && seen.Add(value))
+            {
+                result.Add(value);
+            }
+        }
+
+        return result;
+    }
+}

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -29,6 +29,49 @@
     </div>
 </div>
 
+<div id="cmpBar" class="compare-bar d-none">
+    <div class="container-xl d-flex justify-content-between align-items-center">
+        <div class="small" id="cmpCount">0 vybráno</div>
+        <a id="cmpGo" class="btn btn-primary btn-sm disabled" aria-disabled="true">Porovnat</a>
+    </div>
+</div>
+<script>
+    const bar = document.getElementById('cmpBar');
+    const btn = document.getElementById('cmpGo');
+    const cnt = document.getElementById('cmpCount');
+    const sel = new Set();
+
+    document.querySelectorAll('.cmp-check').forEach(ch => {
+        ch.addEventListener('change', () => {
+            if (ch.checked) {
+                sel.add(ch.value);
+            } else {
+                sel.delete(ch.value);
+            }
+
+            const selected = sel.size;
+            cnt.textContent = `${selected} vybráno`;
+
+            if (selected > 1 && selected <= 3) {
+                bar.classList.remove('d-none');
+                btn.classList.remove('disabled');
+                btn.removeAttribute('aria-disabled');
+                btn.href = '/Courses/Compare?ids=' + Array.from(sel).join(',');
+            } else {
+                btn.classList.add('disabled');
+                btn.setAttribute('aria-disabled', 'true');
+                btn.removeAttribute('href');
+
+                if (selected === 0) {
+                    bar.classList.add('d-none');
+                } else {
+                    bar.classList.remove('d-none');
+                }
+            }
+        });
+    });
+</script>
+
 @if (TempData["CartError"] is string cartError && !string.IsNullOrWhiteSpace(cartError))
 {
     <div class="alert alert-danger" role="alert">@cartError</div>

--- a/Pages/Shared/Components/_CourseCard.cshtml
+++ b/Pages/Shared/Components/_CourseCard.cshtml
@@ -30,12 +30,18 @@
       </div>
       <div class="fw-semibold">@Model.Price.ToString("C")</div>
     </div>
-    <div class="d-flex gap-2">
-      <a class="btn btn-outline-secondary" asp-page="/Courses/Details" asp-route-id="@Model.Id">Detail</a>
-      <form method="post" asp-page="/Courses/Index" asp-page-handler="AddToCart" class="d-inline">
-        <input type="hidden" name="courseId" value="@Model.Id" />
-        <button type="submit" class="btn btn-primary" aria-label="Přihlásit se na @Model.Title">Přihlásit se</button>
-      </form>
+    <div class="d-flex flex-column align-items-end gap-2">
+      <div class="form-check form-check-inline">
+        <input class="form-check-input cmp-check" type="checkbox" value="@Model.Id" id="cmp_@Model.Id">
+        <label class="form-check-label small" for="cmp_@Model.Id">Porovnat</label>
+      </div>
+      <div class="d-flex gap-2">
+        <a class="btn btn-outline-secondary" asp-page="/Courses/Details" asp-route-id="@Model.Id">Detail</a>
+        <form method="post" asp-page="/Courses/Index" asp-page-handler="AddToCart" class="d-inline">
+          <input type="hidden" name="courseId" value="@Model.Id" />
+          <button type="submit" class="btn btn-primary" aria-label="Přihlásit se na @Model.Title">Přihlásit se</button>
+        </form>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add a dedicated course comparison page to display key course attributes side-by-side
- extend course cards with compare checkboxes and surface a sticky compare bar on the listing page
- load and order selected courses safely based on the requested identifiers

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd401bbd88321b140af9dbd632629