### PR TITLE
Add upcoming course term availability table

### DIFF
--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -166,6 +166,52 @@
             </section>
         }
 
+        @if (Model.Terms.Any())
+        {
+            <section class="mb-4">
+                <h2 class="h5">Nejbližší termíny</h2>
+                <div class="table-responsive">
+                    <table class="table align-middle">
+                        <thead><tr><th>Datum</th><th>Místo</th><th>Dostupnost</th><th class="text-end"></th></tr></thead>
+                        <tbody>
+                            @foreach (var term in Model.Terms)
+                            {
+                                var scarce = term.SeatsLeft <= 3 && term.SeatsLeft > 0;
+                                var seatsLabel = term.SeatsLeft switch
+                                {
+                                    1 => "místo",
+                                    2 or 3 or 4 => "místa",
+                                    _ => "míst"
+                                };
+                                <tr>
+                                    <td>@term.StartsAt.ToString("d")</td>
+                                    <td>@(term.IsOnline ? "Online" : term.Location)</td>
+                                    <td>
+                                        @if (term.SeatsLeft == 0)
+                                        {
+                                            <span class="badge bg-secondary">Obsazeno</span>
+                                        }
+                                        else if (scarce)
+                                        {
+                                            <span class="badge bg-warning text-dark">Poslední @term.SeatsLeft @seatsLabel</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="badge bg-success">Volno</span>
+                                        }
+                                    </td>
+                                    <td class="text-end">
+                                        <a class="btn btn-outline-secondary btn-sm" asp-page="/CourseTerms/Details" asp-route-id="@term.Id">Detail</a>
+                                        <a class="btn btn-secondary btn-sm" href="/CourseTerms/ICS/@term.Id">.ics</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        }
+
         <section class="mb-4">
             <h2 class="h5 mb-3">Co se naučíte</h2>
             <ul class="list-unstyled mb-0">

--- a/Services/ICacheService.cs
+++ b/Services/ICacheService.cs
@@ -10,7 +10,8 @@ public record CourseDetailCacheEntry(
     Course Course,
     CourseBlock? CourseBlock,
     IReadOnlyList<CourseReview> Reviews,
-    IReadOnlyList<Lesson> Lessons);
+    IReadOnlyList<Lesson> Lessons,
+    IReadOnlyList<CourseTerm> Terms);
 
 public interface ICacheService
 {


### PR DESCRIPTION
## Summary
- load and cache active upcoming course terms for the course detail page
- render a table of upcoming terms with availability badges and calendar download links

## Testing
- Not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dbd7759294832192263c4af1fc07cd