### PR TITLE
Refresh hero gradients and accent UI elements

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -13,10 +13,14 @@ html {
   --primary: #1ca8d7;
   --primary-dark: #168bb3;
   --primary-light: #33b6e0;
+  --primary-600: #168bb3;
+  --primary-50: #e6f6fc;
 
   --accent: #fecc44;
   --accent-dark: #e6b73d;
   --accent-ink: #0f172a;
+  --accent-600: #e6b73d;
+  --ink: #0f172a;
 
   /* Neutrály */
   --neutral-900: #0f172a;
@@ -92,7 +96,8 @@ a:focus {
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
-select:focus-visible {
+select:focus-visible,
+.chip:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -247,7 +252,12 @@ select:focus-visible {
   padding: clamp(4rem, 7vw, 6.5rem) 0 clamp(4rem, 8vw, 7.5rem);
   color: var(--neutral-100);
   overflow: hidden;
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 60%, var(--accent) 100%);
+}
+
+.hero,
+.gradient-hero {
+  background: radial-gradient(1200px 400px at 50% -100px, rgba(255, 255, 255, 0.15), transparent),
+              linear-gradient(135deg, #1ca8d7 0%, #1ca8d7 40%, #fecc44 140%);
 }
 
 .hero::after {
@@ -273,10 +283,13 @@ select:focus-visible {
   color: rgba(255, 255, 255, 0.85);
 }
 
+.underline-accent {
+  background: linear-gradient(transparent 65%, rgba(254, 204, 68, 0.65) 0);
+}
+
 .trust-stripe {
-  background: var(--neutral-100);
-  border: 1px solid var(--neutral-300);
-  box-shadow: 0 18px 36px rgba(12, 56, 87, 0.08);
+  background: linear-gradient(180deg, rgba(28, 168, 215, 0.06), rgba(28, 168, 215, 0.02));
+  border: 1px solid rgba(28, 168, 215, 0.15);
   color: var(--neutral-900);
 }
 
@@ -387,6 +400,41 @@ select:focus-visible {
   border-color: var(--primary);
 }
 
+.news-pill {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: #f3f4f6;
+  color: #111827;
+  text-decoration: none;
+}
+
+.news-pill:hover {
+  background: #e5e7eb;
+}
+
+.compare-bar {
+  position: sticky;
+  bottom: 0;
+  background: #fff;
+  border-top: 1px solid #e5e7eb;
+  padding: 0.5rem 0;
+  z-index: 1030;
+}
+
+.icon-list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.icon-list li {
+  margin: 0.25rem 0;
+}
+
+.icon-list i {
+  color: #1ca8d7;
+  margin-right: 0.35rem;
+}
+
 .feature-card:hover,
 .feature-card:focus-within {
   transform: translateY(-4px);
@@ -477,17 +525,6 @@ footer.app-footer a:focus {
     font-size: 1.5rem;
   }
 }
-/* Brand */
-:root{
-  --primary:#1ca8d7;
-  --primary-600:#168bb3;
-  --primary-50:#e6f6fc;
-
-  --accent:#fecc44;
-  --accent-600:#e6b73d;
-  --ink:#0f172a;
-}
-
 /* Hrdinské panely */
 .hero-edu{
   background: linear-gradient(135deg, var(--primary) 0%, #199fcb 100%);
@@ -503,15 +540,28 @@ footer.app-footer a:focus {
 /* „Chip“ místo malých tlačítek */
 .chips{ gap:.5rem; display:flex; flex-wrap:wrap; }
 .chip{
-  display:inline-flex; align-items:center; gap:.5rem;
+  display:inline-flex; align-items:center; gap:.4rem;
   padding:.4rem .7rem; border-radius:999px;
-  border:1px solid rgba(0,0,0,.06); background:#fff; color:#111;
-  text-decoration:none; font-weight:600; font-size:.9rem;
+  font-weight:600; font-size:.9rem;
+  border:1px solid rgba(15,23,42,.12);
+  background:rgba(255,255,255,.85);
+  color:var(--ink);
+  text-decoration:none;
+  cursor:pointer;
+  transition:background-color .2s ease, color .2s ease, box-shadow .2s ease;
 }
-.hero-edu .chip{ background:rgba(255,255,255,.15); color:#fff; border-color:rgba(255,255,255,.25); }
-.hero-edu .chip:hover{ background:rgba(255,255,255,.25); }
-.hero-consult .chip{ background:rgba(0,0,0,.06); color:#111; }
-.hero-consult .chip:hover{ background:rgba(0,0,0,.12); }
+.chip:hover,
+.chip:focus-visible{
+  background:rgba(255,255,255,1);
+  box-shadow:0 6px 14px rgba(15,23,42,.12);
+}
+.chip-light{ background:rgba(255,255,255,.9); color:#0f172a; }
+.hero-edu .chip{ background:rgba(255,255,255,.2); color:#fff; border-color:rgba(255,255,255,.4); }
+.hero-edu .chip:hover,
+.hero-edu .chip:focus-visible{ background:rgba(255,255,255,.3); }
+.hero-consult .chip{ background:rgba(15,23,42,.08); color:#111; border-color:rgba(15,23,42,.12); }
+.hero-consult .chip:hover,
+.hero-consult .chip:focus-visible{ background:rgba(15,23,42,.16); }
 
 /* Moderní karta + hover */
 .card-hover{ transition:transform .2s ease, box-shadow .2s ease; }
@@ -531,9 +581,6 @@ footer.app-footer a:focus {
 /* Chip-badges na kartách */
 .badge-soft-primary{ background:rgba(28,168,215,.12); color:#168bb3; }
 .badge-soft-accent{ background:rgba(254,204,68,.25); color:#0f172a; }
-
-/* Focus ring přístupnost */
-:where(a,button,input,select,.chip):focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
 
 /* Preferuje-li uživatel méně animací */
 @media (prefers-reduced-motion: reduce){


### PR DESCRIPTION
## Summary
- extend the global design tokens and focus-visible styling to cover interactive chips
- update hero and trust stripe backgrounds with the new accent underline helper for more dynamic visuals
- add reusable chip, pill, compare bar, and icon list treatments to support the refreshed UI patterns

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dbd87b58e083218b8cef4349a8ac74