### PR TITLE
Fix localization resources and Razor view engine imports

### DIFF
--- a/Pages/Admin/Orders/Details.cshtml.cs
+++ b/Pages/Admin/Orders/Details.cshtml.cs
@@ -1,5 +1,6 @@
 using DinkToPdf.Contracts;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Configuration;

--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -138,7 +138,7 @@
             var audienceFor = new List<string> { levelSummary, modePreference };
             if (Model.Course.CourseGroup is not null)
             {
-                audienceFor.Add($"Členy vzdělávacího bloku „{Model.Course.CourseGroup.Title}“ hledající navazující obsah.");
+                audienceFor.Add($"Členy vzdělávacího bloku „{Model.Course.CourseGroup.Name}“ hledající navazující obsah.");
             }
 
             var audienceNotFor = new List<string> { levelLimitation, modeLimitation };

--- a/Pages/Orders/Details.cshtml.cs
+++ b/Pages/Orders/Details.cshtml.cs
@@ -1,5 +1,6 @@
 using DinkToPdf.Contracts;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Configuration;

--- a/Resources/SharedResources.cs
+++ b/Resources/SharedResources.cs
@@ -1,8 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Resources;
+
 namespace SysJaky_N.Resources;
 
 /// <summary>
-/// Marker class for shared localization resources.
+/// Provides strongly-typed accessors for shared localization resources.
 /// </summary>
-public class SharedResources
+[SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Wrapper around localized resources")]
+public static class SharedResources
 {
+    private static readonly ResourceManager ResourceManager = new(
+        "SysJaky_N.Resources.SharedResources",
+        typeof(SharedResources).GetTypeInfo().Assembly);
+
+    private static string GetString(string name) => ResourceManager.GetString(name) ?? string.Empty;
+
+    public static string FieldRequired => GetString(nameof(FieldRequired));
+    public static string StringLength => GetString(nameof(StringLength));
+    public static string EmailAddressInvalid => GetString(nameof(EmailAddressInvalid));
+    public static string ContactNameLabel => GetString(nameof(ContactNameLabel));
+    public static string ContactEmailLabel => GetString(nameof(ContactEmailLabel));
+    public static string ContactMessageLabel => GetString(nameof(ContactMessageLabel));
 }


### PR DESCRIPTION
## Summary
- provide strongly-typed accessors in `SharedResources` so data annotations can resolve localization strings
- add Razor view engine namespaces to order details page models
- align the course details view with the `CourseGroup` model by using the `Name` property

## Testing
- not run (dotnet CLI not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbda42c4208321be3a04282516b015