### PR TITLE
Fix Razor partial models and add course list count

### DIFF
--- a/Pages/Admin/Articles/Create.cshtml
+++ b/Pages/Admin/Articles/Create.cshtml
@@ -8,7 +8,7 @@
 
 <form method="post">
     <partial name="_ArticleForm" for="Article" />
-    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Back to list\" }" />
+    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to list" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/Articles/Edit.cshtml
+++ b/Pages/Admin/Articles/Edit.cshtml
@@ -9,7 +9,7 @@
 <form method="post">
     <input type="hidden" asp-for="Article.Id" />
     <partial name="_ArticleForm" for="Article" />
-    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Back to list\" }" />
+    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to list" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseBlocks/Create.cshtml
+++ b/Pages/Admin/CourseBlocks/Create.cshtml
@@ -6,7 +6,7 @@
 <h1>Create Course Block</h1>
 <form method="post">
     <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
-    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", ShowCancel = false }" />
+    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", ShowCancel = false }' />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseBlocks/Edit.cshtml
+++ b/Pages/Admin/CourseBlocks/Edit.cshtml
@@ -6,7 +6,7 @@
 <h1>Edit Course Block</h1>
 <form method="post">
     <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
-    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", ShowCancel = false }" />
+    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", ShowCancel = false }' />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseGroups/Create.cshtml
+++ b/Pages/Admin/CourseGroups/Create.cshtml
@@ -8,7 +8,7 @@
 
 <form method="post">
     <partial name="_CourseGroupForm" for="CourseGroup" />
-    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Back to List\" }" />
+    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to List" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseGroups/Edit.cshtml
+++ b/Pages/Admin/CourseGroups/Edit.cshtml
@@ -9,7 +9,7 @@
 <form method="post">
     <input type="hidden" asp-for="CourseGroup.Id" />
     <partial name="_CourseGroupForm" for="CourseGroup" />
-    <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Back to List\" }" />
+    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to List" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseTerms/Create.cshtml
+++ b/Pages/Admin/CourseTerms/Create.cshtml
@@ -12,7 +12,7 @@
     <partial name="_CourseTermForm" model="new SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel(Model.Input, Model.CourseOptions, Model.InstructorOptions)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Cancel\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/CourseTerms/Edit.cshtml
+++ b/Pages/Admin/CourseTerms/Edit.cshtml
@@ -19,7 +19,7 @@
     </div>
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save changes\", CancelText = \"Cancel\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Instructors/Create.cshtml
+++ b/Pages/Admin/Instructors/Create.cshtml
@@ -12,7 +12,7 @@
     <partial name="_InstructorForm" for="Instructor" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Cancel\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Instructors/Edit.cshtml
+++ b/Pages/Admin/Instructors/Edit.cshtml
@@ -13,7 +13,7 @@
     <partial name="_InstructorForm" for="Instructor" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save changes\", CancelText = \"Cancel\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/PriceSchedules/Create.cshtml
+++ b/Pages/Admin/PriceSchedules/Create.cshtml
@@ -12,7 +12,7 @@
     <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Cancel\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/PriceSchedules/Edit.cshtml
+++ b/Pages/Admin/PriceSchedules/Edit.cshtml
@@ -13,7 +13,7 @@
     <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Cancel\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Vouchers/Create.cshtml
+++ b/Pages/Admin/Vouchers/Create.cshtml
@@ -13,7 +13,7 @@
     <partial name="_VoucherForm" model="new SysJaky_N.Pages.Admin.Vouchers.VoucherFormModel(Model.Voucher, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Create\", CancelText = \"Back to List\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to List" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Vouchers/Edit.cshtml
+++ b/Pages/Admin/Vouchers/Edit.cshtml
@@ -19,7 +19,7 @@
     </div>
 
     <div class="mt-4">
-        <partial name="_FormActions" model="new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = \"Save\", CancelText = \"Back to List\" }" />
+        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to List" }' />
     </div>
 </form>
 

--- a/Pages/Courses/Create.cshtml
+++ b/Pages/Courses/Create.cshtml
@@ -1,5 +1,6 @@
 @page
 @model SysJaky_N.Pages.Courses.CreateModel
+@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Mvc.Rendering
 @using SysJaky_N.Pages.Courses
 @{
@@ -16,18 +17,20 @@
     backLink.Attributes["href"] = Url.Page("Index");
     backLink.InnerHtml.Append("Back to List");
     actions.AppendHtml(backLink);
-}
 
-<h1>Create Course</h1>
-
-<form method="post" enctype="multipart/form-data">
-    <partial name="Courses/Shared/_CourseForm" model="new CourseFormModel
+    var formModel = new CourseFormModel
     {
         Course = Model.Course,
         CourseGroups = Model.CourseGroups,
         CoverImage = Model.CoverImage,
         ActionButtons = actions
-    }" />
+    };
+}
+
+<h1>Create Course</h1>
+
+<form method="post" enctype="multipart/form-data">
+    <partial name="Courses/Shared/_CourseForm" model="formModel" />
 </form>
 
 @section Scripts {

--- a/Pages/Courses/Edit.cshtml
+++ b/Pages/Courses/Edit.cshtml
@@ -1,5 +1,6 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Courses.EditModel
+@using Microsoft.AspNetCore.Html
 @using Microsoft.AspNetCore.Mvc.Rendering
 @using SysJaky_N.Pages.Courses
 @{
@@ -16,6 +17,14 @@
     backLink.Attributes["href"] = Url.Page("Index");
     backLink.InnerHtml.Append("Back to List");
     actions.AppendHtml(backLink);
+
+    var formModel = new CourseFormModel
+    {
+        Course = Model.Course,
+        CourseGroups = Model.CourseGroups,
+        CoverImage = Model.CoverImage,
+        ActionButtons = actions
+    };
 }
 
 <h1>Edit Course</h1>
@@ -29,13 +38,7 @@
         </div>
     }
 
-    <partial name="Courses/Shared/_CourseForm" model="new CourseFormModel
-    {
-        Course = Model.Course,
-        CourseGroups = Model.CourseGroups,
-        CoverImage = Model.CoverImage,
-        ActionButtons = actions
-    }" />
+    <partial name="Courses/Shared/_CourseForm" model="formModel" />
 </form>
 
 @section Scripts {

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -16,13 +16,13 @@
 <div class="result-header sticky-top z-2 d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 py-2 bg-body border-bottom">
     <div class="small text-muted">
         @Localizer["ResultCount", Model.TotalCount]
-        @if (!string.IsNullOrWhiteSpace(Context.Request.Query["persona"]))
+        @if (!string.IsNullOrWhiteSpace(HttpContext.Request.Query["persona"]))
         {
-            <span class="ms-2 badge bg-primary-subtle text-primary">@(Context.Request.Query["persona"])</span>
+            <span class="ms-2 badge bg-primary-subtle text-primary">@(HttpContext.Request.Query["persona"])</span>
         }
-        @if (!string.IsNullOrWhiteSpace(Context.Request.Query["goal"]))
+        @if (!string.IsNullOrWhiteSpace(HttpContext.Request.Query["goal"]))
         {
-            <span class="ms-1 badge bg-warning">@((string)Context.Request.Query["goal"])</span>
+            <span class="ms-1 badge bg-warning">@((string)HttpContext.Request.Query["goal"])</span>
         }
     </div>
     <div class="d-flex gap-2">

--- a/Pages/Courses/Index.cshtml.cs
+++ b/Pages/Courses/Index.cshtml.cs
@@ -57,6 +57,8 @@ public class IndexModel : PageModel
 
     public int TotalPages { get; set; }
 
+    public int TotalCount { get; set; }
+
     public async Task OnGetAsync()
     {
         const int pageSize = 10;
@@ -176,10 +178,11 @@ public class IndexModel : PageModel
                 .Take(pageSize)
                 .ToListAsync();
 
-            return new CourseListCacheEntry(courses, totalPages);
+            return new CourseListCacheEntry(courses, totalPages, count);
         });
 
         TotalPages = cacheEntry.TotalPages;
+        TotalCount = cacheEntry.TotalCount;
         Courses = cacheEntry.Courses.ToList();
     }
 

--- a/Services/ICacheService.cs
+++ b/Services/ICacheService.cs
@@ -4,7 +4,7 @@ using SysJaky_N.Models;
 
 namespace SysJaky_N.Services;
 
-public record CourseListCacheEntry(IReadOnlyList<Course> Courses, int TotalPages);
+public record CourseListCacheEntry(IReadOnlyList<Course> Courses, int TotalPages, int TotalCount);
 
 public record CourseDetailCacheEntry(
     Course Course,


### PR DESCRIPTION
## Summary
- clean up `_FormActions` partial usage across admin Razor pages to remove escaped quotes
- reuse a prepared `CourseFormModel` with `HtmlContentBuilder` support on course create/edit pages
- include total course count in the cached course list and surface it on the index view

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc96130c8321bbd4b046784819c6