### PR TITLE
Refactor persona and goal selects into shared tag helpers

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -12,24 +12,10 @@
 
         <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm">
             <div class="col-12 col-md-3">
-                <select name="persona" class="form-select" aria-label="Jsem">
-                    <option value="">Jsem…</option>
-                    <option>Jednotlivec</option>
-                    <option>HR / týmový leader</option>
-                    <option>Laboratoř</option>
-                    <option>Manažer kvality</option>
-                    <option>Auditor</option>
-                    <option>Začátečník v ISO</option>
-                </select>
+                <select name="persona" class="form-select" aria-label="Jsem" persona-options></select>
             </div>
             <div class="col-12 col-md-3">
-                <select name="goal" class="form-select" aria-label="Chci">
-                    <option value="">Chci…</option>
-                    <option>získat/obnovit certifikát</option>
-                    <option>rychle doplnit dovednost</option>
-                    <option>rekvalifikovat se</option>
-                    <option>školení pro celý tým</option>
-                </select>
+                <select name="goal" class="form-select" aria-label="Chci" goal-options></select>
             </div>
             <div class="col-12 col-md-4">
                 <div class="input-group">

--- a/Pages/Shared/_AdvisorOffcanvas.cshtml
+++ b/Pages/Shared/_AdvisorOffcanvas.cshtml
@@ -5,12 +5,8 @@
   </div>
   <div class="offcanvas-body">
     <form method="get" action="/Courses/Index" id="advisorForm" class="vstack gap-3">
-      <select name="persona" class="form-select">
-        <option value="">Jsem…</option><option>Jednotlivec</option><option>HR / týmový leader</option><option>Laboratoř</option><option>Manažer kvality</option><option>Auditor</option><option>Začátečník v ISO</option>
-      </select>
-      <select name="goal" class="form-select">
-        <option value="">Chci…</option><option>získat/obnovit certifikát</option><option>rychle doplnit dovednost</option><option>rekvalifikovat se</option><option>školení pro celý tým</option>
-      </select>
+      <select name="persona" class="form-select" persona-options></select>
+      <select name="goal" class="form-select" goal-options></select>
       <div class="input-group">
         <span class="input-group-text"><i class="bi bi-geo-alt"></i></span>
         <input class="form-control" name="City" placeholder="Město (volitelně)" />

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -2,3 +2,4 @@
 @using SysJaky_N.Models
 @namespace SysJaky_N.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, SysJaky_N

--- a/Program.cs
+++ b/Program.cs
@@ -139,6 +139,7 @@ try
     });
     builder.Services.Configure<PaymentGatewayOptions>(builder.Configuration.GetSection("PaymentGateway"));
     builder.Services.AddScoped<PaymentService>();
+    builder.Services.AddSingleton<ICourseSearchOptionProvider, CourseSearchOptionProvider>();
     builder.Services.AddSingleton<IConverter>(new SynchronizedConverter(new PdfTools()));
     builder.Services.AddSingleton<IRazorLightEngine>(sp =>
     {

--- a/Services/CourseSearchOptionProvider.cs
+++ b/Services/CourseSearchOptionProvider.cs
@@ -1,0 +1,44 @@
+using System.Collections.ObjectModel;
+
+namespace SysJaky_N.Services
+{
+    public interface ICourseSearchOptionProvider
+    {
+        IReadOnlyList<string> Personas { get; }
+
+        IReadOnlyList<string> Goals { get; }
+
+        string PersonaPlaceholder { get; }
+
+        string GoalPlaceholder { get; }
+    }
+
+    public class CourseSearchOptionProvider : ICourseSearchOptionProvider
+    {
+        private static readonly IReadOnlyList<string> _personas = new ReadOnlyCollection<string>(new[]
+        {
+            "Jednotlivec",
+            "HR / týmový leader",
+            "Laboratoř",
+            "Manažer kvality",
+            "Auditor",
+            "Začátečník v ISO"
+        });
+
+        private static readonly IReadOnlyList<string> _goals = new ReadOnlyCollection<string>(new[]
+        {
+            "získat/obnovit certifikát",
+            "rychle doplnit dovednost",
+            "rekvalifikovat se",
+            "školení pro celý tým"
+        });
+
+        public IReadOnlyList<string> Personas => _personas;
+
+        public IReadOnlyList<string> Goals => _goals;
+
+        public string PersonaPlaceholder => "Jsem…";
+
+        public string GoalPlaceholder => "Chci…";
+    }
+}

--- a/TagHelpers/PersonaGoalSelectTagHelpers.cs
+++ b/TagHelpers/PersonaGoalSelectTagHelpers.cs
@@ -1,0 +1,65 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using SysJaky_N.Services;
+
+namespace SysJaky_N.TagHelpers
+{
+    [HtmlTargetElement("select", Attributes = PersonaOptionsAttributeName)]
+    public class PersonaSelectTagHelper : TagHelper
+    {
+        private const string PersonaOptionsAttributeName = "persona-options";
+        private readonly ICourseSearchOptionProvider _optionsProvider;
+
+        public PersonaSelectTagHelper(ICourseSearchOptionProvider optionsProvider)
+        {
+            _optionsProvider = optionsProvider;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.TagMode = TagMode.StartTagAndEndTag;
+            var encoder = HtmlEncoder.Default;
+            var builder = new StringBuilder();
+
+            builder.AppendLine($"<option value=\"\">{encoder.Encode(_optionsProvider.PersonaPlaceholder)}</option>");
+
+            foreach (var persona in _optionsProvider.Personas)
+            {
+                var encodedValue = encoder.Encode(persona);
+                builder.AppendLine($"<option value=\"{encodedValue}\">{encodedValue}</option>");
+            }
+
+            output.Content.SetHtmlContent(builder.ToString());
+        }
+    }
+
+    [HtmlTargetElement("select", Attributes = GoalOptionsAttributeName)]
+    public class GoalSelectTagHelper : TagHelper
+    {
+        private const string GoalOptionsAttributeName = "goal-options";
+        private readonly ICourseSearchOptionProvider _optionsProvider;
+
+        public GoalSelectTagHelper(ICourseSearchOptionProvider optionsProvider)
+        {
+            _optionsProvider = optionsProvider;
+        }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            output.TagMode = TagMode.StartTagAndEndTag;
+            var encoder = HtmlEncoder.Default;
+            var builder = new StringBuilder();
+
+            builder.AppendLine($"<option value=\"\">{encoder.Encode(_optionsProvider.GoalPlaceholder)}</option>");
+
+            foreach (var goal in _optionsProvider.Goals)
+            {
+                var encodedValue = encoder.Encode(goal);
+                builder.AppendLine($"<option value=\"{encodedValue}\">{encodedValue}</option>");
+            }
+
+            output.Content.SetHtmlContent(builder.ToString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable options provider and tag helpers for persona and goal selects
- update the hero and advisor forms to consume the shared helpers so the markup stays aligned
- register the new services/tag helpers for Razor pages

## Testing
- `dotnet build` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdcd6bdb48321910169162cf71b74