### PR TITLE
Refactor account forms into reusable localized partials

### DIFF
--- a/Models/ViewModels/AuthFormOptions.cs
+++ b/Models/ViewModels/AuthFormOptions.cs
@@ -1,0 +1,59 @@
+using SysJaky_N.Pages.Account;
+
+namespace SysJaky_N.Models.ViewModels;
+
+public abstract class AuthFormOptionsBase<TInput>
+    where TInput : class, new()
+{
+    public TInput Input { get; set; } = new();
+    public string Method { get; set; } = "post";
+    public string? FormId { get; set; }
+    public string? FormCssClass { get; set; }
+    public string? AspPage { get; set; }
+    public string? AspPageHandler { get; set; }
+    public string? Action { get; set; }
+    public bool IncludeAntiforgery { get; set; } = true;
+    public string? HeadingLocalizationKey { get; set; }
+    public string HeadingTagName { get; set; } = "h1";
+    public string? HeadingId { get; set; }
+    public string? ValidationSummaryCssClass { get; set; } = "text-danger";
+    public string AltchaChallengeUrl { get; set; } = "~/altcha/challenge?d=2";
+    public string AltchaVerifyUrl { get; set; } = "~/altcha/verify";
+    public string AltchaWorkerUrl { get; set; } = "~/lib/altcha/altcha.worker.js";
+    public bool UseAbsoluteWorkerUrl { get; set; } = true;
+    public string? AltchaWorkerVersionSuffix { get; set; } = "?v=5";
+    public string AltchaWorkers { get; set; } = "1";
+    public string AltchaMaxNumber { get; set; } = "500000";
+    public bool EnableRefetchOnExpire { get; set; } = true;
+    public string AltchaWidgetName { get; set; } = "altcha";
+    public string? AltchaId { get; set; }
+}
+
+public class LoginFormOptions : AuthFormOptionsBase<LoginModel.InputModel>
+{
+    public string EmailLabelKey { get; set; } = "EmailLabel";
+    public string PasswordLabelKey { get; set; } = "PasswordLabel";
+    public string RememberMeLabelKey { get; set; } = "RememberMe";
+    public string SubmitButtonKey { get; set; } = "LoginTitle";
+    public string EnableJavascriptKey { get; set; } = "EnableJavascript";
+    public string? EmailInputId { get; set; }
+    public string? PasswordInputId { get; set; }
+    public string? RememberMeInputId { get; set; }
+    public bool ShowRememberMe { get; set; } = true;
+}
+
+public class RegisterFormOptions : AuthFormOptionsBase<RegisterModel.InputModel>
+{
+    public string EmailLabelKey { get; set; } = "EmailLabel";
+    public string PasswordLabelKey { get; set; } = "PasswordLabel";
+    public string ConfirmPasswordLabelKey { get; set; } = "ConfirmPasswordLabel";
+    public string ReferralCodeLabelKey { get; set; } = "ReferralCodeLabel";
+    public string SubmitButtonKey { get; set; } = "RegisterTitle";
+    public string EnableJavascriptKey { get; set; } = "EnableJavascript";
+    public string? EmailInputId { get; set; }
+    public string? PasswordInputId { get; set; }
+    public string? ConfirmPasswordInputId { get; set; }
+    public string? ReferralCodeInputId { get; set; }
+    public bool IncludeConfirmPassword { get; set; }
+    public bool IncludeReferralCode { get; set; }
+}

--- a/Pages/Account/Login.cshtml
+++ b/Pages/Account/Login.cshtml
@@ -1,31 +1,31 @@
 @page
 @model SysJaky_N.Pages.Account.LoginModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 
-<h1>Login</h1>
+@{
+    ViewData["Title"] = Localizer["LoginTitle"];
+    var loginFormOptions = new LoginFormOptions
+    {
+        Input = Model.Input,
+        FormId = "account-login-form",
+        FormCssClass = "card card-body p-4 auth-form",
+        HeadingLocalizationKey = "LoginTitle",
+        HeadingTagName = "h1",
+        ValidationSummaryCssClass = "text-danger",
+        EmailInputId = "account-login-email",
+        PasswordInputId = "account-login-password",
+        RememberMeInputId = "account-login-remember",
+        AltchaId = "account-login-altcha",
+        AltchaChallengeUrl = "~/altcha/challenge",
+        AltchaWorkerVersionSuffix = string.Empty,
+        UseAbsoluteWorkerUrl = false,
+        AltchaWorkers = "1",
+        AltchaMaxNumber = "500000",
+        EnableRefetchOnExpire = true
+    };
+}
 
-<form method="post">
-    <div asp-validation-summary="All"></div>
-    <div>
-        <label asp-for="Input.Email"></label>
-        <input asp-for="Input.Email" />
-        <span asp-validation-for="Input.Email"></span>
-    </div>
-    <div>
-        <label asp-for="Input.Password"></label>
-        <input asp-for="Input.Password" type="password" />
-        <span asp-validation-for="Input.Password"></span>
-    </div>
-    <div>
-        <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
-        <noscript>Prosím povolte JavaScript.</noscript>
-        <span asp-validation-for="Input.Captcha"></span>
-    </div>
-    <div>
-        <input asp-for="Input.RememberMe" />
-        <label asp-for="Input.RememberMe">Remember me</label>
-    </div>
-    <button type="submit">Login</button>
-</form>
+<partial name="~/Pages/Shared/Account/_LoginForm.cshtml" model="loginFormOptions" />
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/Pages/Account/Register.cshtml
+++ b/Pages/Account/Register.cshtml
@@ -1,32 +1,34 @@
 @page
 @model SysJaky_N.Pages.Account.RegisterModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 
-<h1>Register</h1>
+@{
+    ViewData["Title"] = Localizer["RegisterTitle"];
+    var registerFormOptions = new RegisterFormOptions
+    {
+        Input = Model.Input,
+        FormId = "account-register-form",
+        FormCssClass = "card card-body p-4 auth-form",
+        HeadingLocalizationKey = "RegisterTitle",
+        HeadingTagName = "h1",
+        ValidationSummaryCssClass = "text-danger",
+        EmailInputId = "account-register-email",
+        PasswordInputId = "account-register-password",
+        ConfirmPasswordInputId = "account-register-confirm",
+        ReferralCodeInputId = "account-register-referral",
+        AltchaId = "account-register-altcha",
+        AltchaChallengeUrl = "~/altcha/challenge",
+        AltchaWorkerVersionSuffix = string.Empty,
+        UseAbsoluteWorkerUrl = false,
+        AltchaWorkers = "1",
+        AltchaMaxNumber = "500000",
+        IncludeConfirmPassword = true,
+        IncludeReferralCode = true,
+        EnableRefetchOnExpire = true
+    };
+}
 
-<form method="post">
-    <div asp-validation-summary="All"></div>
-    <div>
-        <label asp-for="Input.Email"></label>
-        <input asp-for="Input.Email" />
-        <span asp-validation-for="Input.Email"></span>
-    </div>
-    <div>
-        <label asp-for="Input.Password"></label>
-        <input asp-for="Input.Password" type="password" />
-        <span asp-validation-for="Input.Password"></span>
-    </div>
-    <div>
-        <label asp-for="Input.ReferralCode"></label>
-        <input asp-for="Input.ReferralCode" />
-        <span asp-validation-for="Input.ReferralCode"></span>
-    </div>
-    <div>
-        <altcha-widget name="altcha" challengeurl="@Url.Content("~/altcha/challenge")" verifyurl="@Url.Content("~/altcha/verify")" workerurl="@Url.Content("~/lib/altcha/altcha.worker.js")" refetchonexpire></altcha-widget>
-        <noscript>Prosím povolte JavaScript.</noscript>
-        <span asp-validation-for="Input.Captcha"></span>
-    </div>
-    <button type="submit">Register</button>
-</form>
+<partial name="~/Pages/Shared/Account/_RegisterForm.cshtml" model="registerFormOptions" />
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />

--- a/Pages/Account/Register.cshtml.cs
+++ b/Pages/Account/Register.cshtml.cs
@@ -40,6 +40,11 @@ public class RegisterModel : PageModel
         [StringLength(100, MinimumLength = 6)]
         [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Password must contain upper and lower case letters and numbers.")]
         public string Password { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare(nameof(Password))]
+        public string ConfirmPassword { get; set; } = string.Empty;
         public string Captcha { get; set; } = string.Empty;
 
         [Display(Name = "Referral code")]

--- a/Pages/Shared/Account/_LoginForm.cshtml
+++ b/Pages/Shared/Account/_LoginForm.cshtml
@@ -1,0 +1,82 @@
+@using System
+@model SysJaky_N.Models.ViewModels.LoginFormOptions
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+@{
+    var formId = Model.FormId ?? "login-form";
+    var emailId = Model.EmailInputId ?? $"{formId}-email";
+    var passwordId = Model.PasswordInputId ?? $"{formId}-password";
+    var rememberId = Model.RememberMeInputId ?? $"{formId}-remember";
+    var altchaId = Model.AltchaId ?? $"{formId}-altcha";
+    var headingTag = string.IsNullOrWhiteSpace(Model.HeadingTagName) ? "h1" : Model.HeadingTagName;
+    var workerUrl = Model.UseAbsoluteWorkerUrl
+        ? $"{Context.Request.Scheme}://{Context.Request.Host}{Url.Content(Model.AltchaWorkerUrl)}{(string.IsNullOrEmpty(Model.AltchaWorkerVersionSuffix) ? string.Empty : Model.AltchaWorkerVersionSuffix)}"
+        : Url.Content(Model.AltchaWorkerUrl);
+    var method = string.IsNullOrWhiteSpace(Model.Method) ? "post" : Model.Method;
+}
+
+@if (!string.IsNullOrWhiteSpace(Model.HeadingLocalizationKey))
+{
+    var headingContent = Localizer[Model.HeadingLocalizationKey];
+    if (headingTag.Equals("h1", StringComparison.OrdinalIgnoreCase))
+    {
+        <h1 id="@Model.HeadingId">@headingContent</h1>
+    }
+    else if (headingTag.Equals("h2", StringComparison.OrdinalIgnoreCase))
+    {
+        <h2 id="@Model.HeadingId">@headingContent</h2>
+    }
+    else if (headingTag.Equals("h3", StringComparison.OrdinalIgnoreCase))
+    {
+        <h3 id="@Model.HeadingId">@headingContent</h3>
+    }
+    else
+    {
+        <div id="@Model.HeadingId" class="@headingTag">@headingContent</div>
+    }
+}
+
+<form method="@method"
+      id="@formId"
+      class="@Model.FormCssClass"
+      asp-page="@(string.IsNullOrEmpty(Model.AspPage) ? null : Model.AspPage)"
+      asp-page-handler="@(string.IsNullOrEmpty(Model.AspPageHandler) ? null : Model.AspPageHandler)"
+      action="@(string.IsNullOrEmpty(Model.Action) ? null : Model.Action)"
+      asp-antiforgery="@Model.IncludeAntiforgery">
+    <div asp-validation-summary="All" class="@Model.ValidationSummaryCssClass"></div>
+
+    <div class="mb-3">
+        <label class="form-label" for="@emailId">@Localizer[Model.EmailLabelKey]</label>
+        <input class="form-control" asp-for="Input.Email" id="@emailId" autocomplete="email" />
+        <span class="text-danger" asp-validation-for="Input.Email"></span>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label" for="@passwordId">@Localizer[Model.PasswordLabelKey]</label>
+        <input class="form-control" asp-for="Input.Password" id="@passwordId" autocomplete="current-password" />
+        <span class="text-danger" asp-validation-for="Input.Password"></span>
+    </div>
+
+    <div class="mb-3">
+        <altcha-widget id="@altchaId"
+                       name="@Model.AltchaWidgetName"
+                       challengeurl='@Url.Content(Model.AltchaChallengeUrl)'
+                       verifyurl='@Url.Content(Model.AltchaVerifyUrl)'
+                       workerurl='@workerUrl'
+                       workers='@Model.AltchaWorkers'
+                       maxnumber='@Model.AltchaMaxNumber'
+                       @(Model.EnableRefetchOnExpire ? "refetchonexpire" : null)>
+        </altcha-widget>
+        <noscript>@Localizer[Model.EnableJavascriptKey]</noscript>
+        <span class="text-danger" asp-validation-for="Input.Captcha"></span>
+    </div>
+
+    @if (Model.ShowRememberMe)
+    {
+        <div class="mb-3 form-check">
+            <input class="form-check-input" asp-for="Input.RememberMe" id="@rememberId" />
+            <label class="form-check-label" for="@rememberId">@Localizer[Model.RememberMeLabelKey]</label>
+        </div>
+    }
+
+    <button type="submit" class="btn btn-primary">@Localizer[Model.SubmitButtonKey]</button>
+</form>

--- a/Pages/Shared/Account/_RegisterForm.cshtml
+++ b/Pages/Shared/Account/_RegisterForm.cshtml
@@ -1,0 +1,93 @@
+@using System
+@model SysJaky_N.Models.ViewModels.RegisterFormOptions
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+@{
+    var formId = Model.FormId ?? "register-form";
+    var emailId = Model.EmailInputId ?? $"{formId}-email";
+    var passwordId = Model.PasswordInputId ?? $"{formId}-password";
+    var confirmId = Model.ConfirmPasswordInputId ?? $"{formId}-confirm";
+    var referralId = Model.ReferralCodeInputId ?? $"{formId}-referral";
+    var altchaId = Model.AltchaId ?? $"{formId}-altcha";
+    var headingTag = string.IsNullOrWhiteSpace(Model.HeadingTagName) ? "h1" : Model.HeadingTagName;
+    var workerUrl = Model.UseAbsoluteWorkerUrl
+        ? $"{Context.Request.Scheme}://{Context.Request.Host}{Url.Content(Model.AltchaWorkerUrl)}{(string.IsNullOrEmpty(Model.AltchaWorkerVersionSuffix) ? string.Empty : Model.AltchaWorkerVersionSuffix)}"
+        : Url.Content(Model.AltchaWorkerUrl);
+    var method = string.IsNullOrWhiteSpace(Model.Method) ? "post" : Model.Method;
+}
+
+@if (!string.IsNullOrWhiteSpace(Model.HeadingLocalizationKey))
+{
+    var headingContent = Localizer[Model.HeadingLocalizationKey];
+    if (headingTag.Equals("h1", StringComparison.OrdinalIgnoreCase))
+    {
+        <h1 id="@Model.HeadingId">@headingContent</h1>
+    }
+    else if (headingTag.Equals("h2", StringComparison.OrdinalIgnoreCase))
+    {
+        <h2 id="@Model.HeadingId">@headingContent</h2>
+    }
+    else if (headingTag.Equals("h3", StringComparison.OrdinalIgnoreCase))
+    {
+        <h3 id="@Model.HeadingId">@headingContent</h3>
+    }
+    else
+    {
+        <div id="@Model.HeadingId" class="@headingTag">@headingContent</div>
+    }
+}
+
+<form method="@method"
+      id="@formId"
+      class="@Model.FormCssClass"
+      asp-page="@(string.IsNullOrEmpty(Model.AspPage) ? null : Model.AspPage)"
+      asp-page-handler="@(string.IsNullOrEmpty(Model.AspPageHandler) ? null : Model.AspPageHandler)"
+      action="@(string.IsNullOrEmpty(Model.Action) ? null : Model.Action)"
+      asp-antiforgery="@Model.IncludeAntiforgery">
+    <div asp-validation-summary="All" class="@Model.ValidationSummaryCssClass"></div>
+
+    <div class="mb-3">
+        <label class="form-label" for="@emailId">@Localizer[Model.EmailLabelKey]</label>
+        <input class="form-control" asp-for="Input.Email" id="@emailId" autocomplete="email" />
+        <span class="text-danger" asp-validation-for="Input.Email"></span>
+    </div>
+
+    <div class="mb-3">
+        <label class="form-label" for="@passwordId">@Localizer[Model.PasswordLabelKey]</label>
+        <input class="form-control" asp-for="Input.Password" id="@passwordId" autocomplete="new-password" />
+        <span class="text-danger" asp-validation-for="Input.Password"></span>
+    </div>
+
+    @if (Model.IncludeConfirmPassword)
+    {
+        <div class="mb-3">
+            <label class="form-label" for="@confirmId">@Localizer[Model.ConfirmPasswordLabelKey]</label>
+            <input class="form-control" asp-for="Input.ConfirmPassword" id="@confirmId" autocomplete="new-password" />
+            <span class="text-danger" asp-validation-for="Input.ConfirmPassword"></span>
+        </div>
+    }
+
+    @if (Model.IncludeReferralCode)
+    {
+        <div class="mb-3">
+            <label class="form-label" for="@referralId">@Localizer[Model.ReferralCodeLabelKey]</label>
+            <input class="form-control" asp-for="Input.ReferralCode" id="@referralId" />
+            <span class="text-danger" asp-validation-for="Input.ReferralCode"></span>
+        </div>
+    }
+
+    <div class="mb-3">
+        <altcha-widget id="@altchaId"
+                       name="@Model.AltchaWidgetName"
+                       challengeurl='@Url.Content(Model.AltchaChallengeUrl)'
+                       verifyurl='@Url.Content(Model.AltchaVerifyUrl)'
+                       workerurl='@workerUrl'
+                       workers='@Model.AltchaWorkers'
+                       maxnumber='@Model.AltchaMaxNumber'
+                       @(Model.EnableRefetchOnExpire ? "refetchonexpire" : null)>
+        </altcha-widget>
+        <noscript>@Localizer[Model.EnableJavascriptKey]</noscript>
+        <span class="text-danger" asp-validation-for="Input.Captcha"></span>
+    </div>
+
+    <button type="submit" class="btn btn-primary">@Localizer[Model.SubmitButtonKey]</button>
+</form>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -1,5 +1,7 @@
 @using System.Globalization
 @using SysJaky_N.Authorization
+@using SysJaky_N.Models.ViewModels
+@using SysJaky_N.Pages.Account
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
     var currentCulture = CultureInfo.CurrentUICulture;
@@ -145,6 +147,42 @@
 
     @if (!User.Identity.IsAuthenticated)
     {
+        var loginFormOptions = new LoginFormOptions
+        {
+            FormId = "login-modal-form",
+            FormCssClass = null,
+            AspPage = "/Account/Login",
+            HeadingLocalizationKey = null,
+            ValidationSummaryCssClass = "text-danger",
+            EmailInputId = "loginEmail",
+            PasswordInputId = "loginPassword",
+            RememberMeInputId = "rememberMe",
+            AltchaId = "altcha-login",
+            UseAbsoluteWorkerUrl = true,
+            AltchaWorkerVersionSuffix = "?v=5",
+            EnableRefetchOnExpire = false,
+            Input = new LoginModel.InputModel()
+        };
+
+        var registerFormOptions = new RegisterFormOptions
+        {
+            FormId = "register-modal-form",
+            FormCssClass = null,
+            AspPage = "/Account/Register",
+            HeadingLocalizationKey = null,
+            ValidationSummaryCssClass = "text-danger",
+            EmailInputId = "registerEmail",
+            PasswordInputId = "registerPassword",
+            ConfirmPasswordInputId = "registerConfirmPassword",
+            AltchaId = "altcha-register",
+            IncludeConfirmPassword = true,
+            IncludeReferralCode = false,
+            UseAbsoluteWorkerUrl = true,
+            AltchaWorkerVersionSuffix = "?v=5",
+            EnableRefetchOnExpire = false,
+            Input = new RegisterModel.InputModel()
+        };
+
         <div class="modal fade" id="authModal" tabindex="-1" aria-labelledby="authModalLabel" aria-hidden="true">
             <div class="modal-dialog">
                 <div class="modal-content">
@@ -163,61 +201,10 @@
                         </ul>
                         <div class="tab-content" id="authTabContent">
                             <div class="tab-pane fade show active" id="login-tab-pane" role="tabpanel" aria-labelledby="login-tab">
-                                <form method="post" asp-page="/Account/Login">
-                                    <div asp-validation-summary="All" class="text-danger"></div>
-                                    <div class="mb-3">
-                                        <label for="loginEmail" class="form-label">@Localizer["EmailLabel"]</label>
-                                        <input type="email" class="form-control" id="loginEmail" name="Input.Email" required />
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="loginPassword" class="form-label">@Localizer["PasswordLabel"]</label>
-                                        <input type="password" class="form-control" id="loginPassword" name="Input.Password" required />
-                                    </div>
-                                    <div class="mb-3">
-                                        <altcha-widget id="altcha-login" name="altcha"
-                                                       challengeurl='@Url.Content("~/altcha/challenge?d=2")'
-                                                       verifyurl='@Url.Content("~/altcha/verify")'
-                                                       workers="1"
-                                                       maxnumber="500000"
-                                                       workerurl='@($"{Context.Request.Scheme}://{Context.Request.Host}{Url.Content("~/lib/altcha/altcha.worker.js")}?v=5")'>
-                                        </altcha-widget>
-                                        <noscript>@Localizer["EnableJavascript"]</noscript>
-                                    </div>
-                                    <div class="mb-3 form-check">
-                                        <input type="hidden" name="Input.RememberMe" value="false" />
-                                        <input type="checkbox" class="form-check-input" id="rememberMe" name="Input.RememberMe" value="true" />
-                                        <label class="form-check-label" for="rememberMe">@Localizer["RememberMe"]</label>
-                                    </div>
-                                    <button type="submit" class="btn btn-primary">@Localizer["LoginTitle"]</button>
-                                </form>
+                                <partial name="~/Pages/Shared/Account/_LoginForm.cshtml" model="loginFormOptions" />
                             </div>
                             <div class="tab-pane fade" id="register-tab-pane" role="tabpanel" aria-labelledby="register-tab">
-                                <form method="post" asp-page="/Account/Register">
-                                    <div asp-validation-summary="All" class="text-danger"></div>
-                                    <div class="mb-3">
-                                        <label for="registerEmail" class="form-label">@Localizer["EmailLabel"]</label>
-                                        <input type="email" class="form-control" id="registerEmail" name="Input.Email" required />
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="registerPassword" class="form-label">@Localizer["PasswordLabel"]</label>
-                                        <input type="password" class="form-control" id="registerPassword" name="Input.Password" required />
-                                    </div>
-                                    <div class="mb-3">
-                                        <label for="registerConfirmPassword" class="form-label">@Localizer["ConfirmPasswordLabel"]</label>
-                                        <input type="password" class="form-control" id="registerConfirmPassword" name="Input.ConfirmPassword" required />
-                                    </div>
-                                    <div class="mb-3">
-                                        <altcha-widget id="altcha-register" name="altcha"
-                                                       challengeurl='@Url.Content("~/altcha/challenge?d=2")'
-                                                       verifyurl='@Url.Content("~/altcha/verify")'
-                                                       workers="1"
-                                                       maxnumber="500000"
-                                                       workerurl='@($"{Context.Request.Scheme}://{Context.Request.Host}{Url.Content("~/lib/altcha/altcha.worker.js")}?v=5")'>
-                                        </altcha-widget>
-                                        <noscript>@Localizer["EnableJavascript"]</noscript>
-                                    </div>
-                                    <button type="submit" class="btn btn-primary">@Localizer["RegisterTitle"]</button>
-                                </form>
+                                <partial name="~/Pages/Shared/Account/_RegisterForm.cshtml" model="registerFormOptions" />
                             </div>
                         </div>
                     </div>

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -1,4 +1,6 @@
 @using SysJaky_N
 @using SysJaky_N.Models
+@using SysJaky_N.Models.ViewModels
+@using SysJaky_N.Pages.Account
 @namespace SysJaky_N.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/Resources/Pages.Account.Login.cshtml.en.resx
+++ b/Resources/Pages.Account.Login.cshtml.en.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoginTitle" xml:space="preserve">
+    <value>Login</value>
+  </data>
+</root>

--- a/Resources/Pages.Account.Login.cshtml.resx
+++ b/Resources/Pages.Account.Login.cshtml.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoginTitle" xml:space="preserve">
+    <value>Přihlášení</value>
+  </data>
+</root>

--- a/Resources/Pages.Account.Register.cshtml.en.resx
+++ b/Resources/Pages.Account.Register.cshtml.en.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisterTitle" xml:space="preserve">
+    <value>Register</value>
+  </data>
+</root>

--- a/Resources/Pages.Account.Register.cshtml.resx
+++ b/Resources/Pages.Account.Register.cshtml.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisterTitle" xml:space="preserve">
+    <value>Registrace</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared.Account._LoginForm.cshtml.en.resx
+++ b/Resources/Pages.Shared.Account._LoginForm.cshtml.en.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoginTitle" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="PasswordLabel" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Remember me</value>
+  </data>
+  <data name="EnableJavascript" xml:space="preserve">
+    <value>Please enable JavaScript.</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared.Account._LoginForm.cshtml.resx
+++ b/Resources/Pages.Shared.Account._LoginForm.cshtml.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LoginTitle" xml:space="preserve">
+    <value>Přihlášení</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="PasswordLabel" xml:space="preserve">
+    <value>Heslo</value>
+  </data>
+  <data name="RememberMe" xml:space="preserve">
+    <value>Zapamatovat přihlášení</value>
+  </data>
+  <data name="EnableJavascript" xml:space="preserve">
+    <value>Prosím povolte JavaScript.</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared.Account._RegisterForm.cshtml.en.resx
+++ b/Resources/Pages.Shared.Account._RegisterForm.cshtml.en.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisterTitle" xml:space="preserve">
+    <value>Register</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="PasswordLabel" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfirmPasswordLabel" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="ReferralCodeLabel" xml:space="preserve">
+    <value>Referral code</value>
+  </data>
+  <data name="EnableJavascript" xml:space="preserve">
+    <value>Please enable JavaScript.</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared.Account._RegisterForm.cshtml.resx
+++ b/Resources/Pages.Shared.Account._RegisterForm.cshtml.resx
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="RegisterTitle" xml:space="preserve">
+    <value>Registrace</value>
+  </data>
+  <data name="EmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="PasswordLabel" xml:space="preserve">
+    <value>Heslo</value>
+  </data>
+  <data name="ConfirmPasswordLabel" xml:space="preserve">
+    <value>Potvrzení hesla</value>
+  </data>
+  <data name="ReferralCodeLabel" xml:space="preserve">
+    <value>Kód doporučení</value>
+  </data>
+  <data name="EnableJavascript" xml:space="preserve">
+    <value>Prosím povolte JavaScript.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- extract the login and registration markup into reusable partials that centralize validation, Altcha configuration, and localization
- introduce configurable form option models so pages and the shared layout can render the same forms with context-specific headings, IDs, and behaviors
- add confirm-password validation to registration along with resource files to localize the new shared components

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbdcee76988321b5f7ef0e1110e419