### PR TITLE
Localize course cover image validation messages

### DIFF
--- a/Resources/Services.CourseEditor.en.resx
+++ b/Resources/Services.CourseEditor.en.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CoverImageMustBeJpeg" xml:space="preserve">
+    <value>Please upload a cover image in JPEG format.</value>
+  </data>
+  <data name="CoverImageEmpty" xml:space="preserve">
+    <value>The cover image file is empty.</value>
+  </data>
+  <data name="CoverImageSaveFailed" xml:space="preserve">
+    <value>Could not save the course cover image. Please check the file and try again.</value>
+  </data>
+</root>

--- a/Resources/Services.CourseEditor.resx
+++ b/Resources/Services.CourseEditor.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CoverImageMustBeJpeg" xml:space="preserve">
+    <value>Nahrajte prosím obálku ve formátu JPEG.</value>
+  </data>
+  <data name="CoverImageEmpty" xml:space="preserve">
+    <value>Soubor s obálkou je prázdný.</value>
+  </data>
+  <data name="CoverImageSaveFailed" xml:space="preserve">
+    <value>Nepodařilo se uložit obálku kurzu. Zkontrolujte prosím soubor a zkuste to znovu.</value>
+  </data>
+</root>

--- a/Services/CourseEditor.cs
+++ b/Services/CourseEditor.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Localization;
 
 namespace SysJaky_N.Services;
 
@@ -11,11 +12,16 @@ public sealed class CourseEditor : ICourseEditor
 {
     private readonly ICourseMediaStorage _courseMediaStorage;
     private readonly ICacheService _cacheService;
+    private readonly IStringLocalizer<CourseEditor> _localizer;
 
-    public CourseEditor(ICourseMediaStorage courseMediaStorage, ICacheService cacheService)
+    public CourseEditor(
+        ICourseMediaStorage courseMediaStorage,
+        ICacheService cacheService,
+        IStringLocalizer<CourseEditor> localizer)
     {
         _courseMediaStorage = courseMediaStorage;
         _cacheService = cacheService;
+        _localizer = localizer;
     }
 
     public bool ValidateCoverImage(IFormFile? coverImage, ModelStateDictionary modelState, string fieldName)
@@ -24,12 +30,12 @@ public sealed class CourseEditor : ICourseEditor
 
         if (coverImage is { Length: > 0 } && !string.Equals(coverImage.ContentType, "image/jpeg", StringComparison.OrdinalIgnoreCase))
         {
-            modelState.AddModelError(fieldName, "Nahrajte prosím obálku ve formátu JPEG.");
+            modelState.AddModelError(fieldName, _localizer["CoverImageMustBeJpeg"].Value);
             isValid = false;
         }
         else if (coverImage is { Length: 0 })
         {
-            modelState.AddModelError(fieldName, "Soubor s obálkou je prázdný.");
+            modelState.AddModelError(fieldName, _localizer["CoverImageEmpty"].Value);
             isValid = false;
         }
 
@@ -58,7 +64,7 @@ public sealed class CourseEditor : ICourseEditor
         }
         catch (Exception ex) when (ex is IOException or InvalidOperationException)
         {
-            return CourseCoverImageResult.Failure("Nepodařilo se uložit obálku kurzu. Zkontrolujte prosím soubor a zkuste to znovu.");
+            return CourseCoverImageResult.Failure(_localizer["CoverImageSaveFailed"].Value);
         }
     }
 


### PR DESCRIPTION
## Summary
- add Czech and English resource strings for course cover image validation and save failures
- inject an `IStringLocalizer<CourseEditor>` so cover image validation and persistence use localized text

## Testing
- ⚠️ `dotnet test` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbec1eadf08321a09aff6874f8e246