### PR TITLE
Localize course pages and compare interactions

### DIFF
--- a/Pages/CourseTerms/Details.cshtml
+++ b/Pages/CourseTerms/Details.cshtml
@@ -1,9 +1,11 @@
 @page "{id:int}"
+@using Microsoft.AspNetCore.Mvc.Localization
 @model SysJaky_N.Pages.CourseTerms.DetailsModel
 @using System.Globalization
+@inject IViewLocalizer Localizer
 
 @{
-    ViewData["Title"] = "Detail termínu";
+    ViewData["Title"] = Localizer["Title"];
     var startLocal = Model.Term.StartUtc.ToLocalTime();
     var endLocal = Model.Term.EndUtc.ToLocalTime();
     var seatsAvailable = Model.Term.Capacity - Model.Term.SeatsTaken;
@@ -14,23 +16,23 @@
 <h1>@Model.CourseTitle</h1>
 
 <section class="mb-4">
-    <h2 class="h4">Detail termínu</h2>
+    <h2 class="h4">@Localizer["Heading"]</h2>
     <dl class="row">
-        <dt class="col-sm-3">Začátek</dt>
+        <dt class="col-sm-3">@Localizer["Start"]</dt>
         <dd class="col-sm-9">@startLocal.ToString("f", CultureInfo.CurrentCulture)</dd>
-        <dt class="col-sm-3">Konec</dt>
+        <dt class="col-sm-3">@Localizer["End"]</dt>
         <dd class="col-sm-9">@endLocal.ToString("f", CultureInfo.CurrentCulture)</dd>
-        <dt class="col-sm-3">Kapacita</dt>
+        <dt class="col-sm-3">@Localizer["Capacity"]</dt>
         <dd class="col-sm-9">@Model.Term.Capacity</dd>
-        <dt class="col-sm-3">Obsazeno</dt>
+        <dt class="col-sm-3">@Localizer["Taken"]</dt>
         <dd class="col-sm-9">@Model.Term.SeatsTaken</dd>
-        <dt class="col-sm-3">Volná místa</dt>
+        <dt class="col-sm-3">@Localizer["Available"]</dt>
         <dd class="col-sm-9">@Math.Max(0, seatsAvailable)</dd>
-        <dt class="col-sm-3">Stav</dt>
-        <dd class="col-sm-9">@(Model.Term.IsActive ? "Aktivní" : "Neaktivní")</dd>
+        <dt class="col-sm-3">@Localizer["Status"]</dt>
+        <dd class="col-sm-9">@(Model.Term.IsActive ? Localizer["StatusActive"] : Localizer["StatusInactive"])</dd>
         @if (instructor != null)
         {
-            <dt class="col-sm-3">Lektor</dt>
+            <dt class="col-sm-3">@Localizer["Instructor"]</dt>
             <dd class="col-sm-9">@instructor.FullName</dd>
         }
     </dl>
@@ -39,12 +41,12 @@
 @if (!string.IsNullOrWhiteSpace(course?.Description))
 {
     <section class="mb-4">
-        <h2 class="h4">O kurzu</h2>
+        <h2 class="h4">@Localizer["AboutCourse"]</h2>
         <p>@course.Description</p>
     </section>
 }
 
 <section class="d-flex flex-column flex-sm-row gap-2">
-    <a class="btn btn-primary" href="/Courses/Details/@Model.Term.CourseId">Detail kurzu</a>
-    <a class="btn btn-outline-secondary" href="/CourseTerms/ICS/@Model.Term.Id">Přidat do kalendáře</a>
+    <a class="btn btn-primary" href="/Courses/Details/@Model.Term.CourseId">@Localizer["CourseDetailCta"]</a>
+    <a class="btn btn-outline-secondary" href="/CourseTerms/ICS/@Model.Term.Id">@Localizer["AddToCalendar"]</a>
 </section>

--- a/Pages/CourseTerms/Details.cshtml.cs
+++ b/Pages/CourseTerms/Details.cshtml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
 using SysJaky_N.Data;
 using SysJaky_N.Models;
 
@@ -11,10 +12,12 @@ namespace SysJaky_N.Pages.CourseTerms;
 public class DetailsModel : PageModel
 {
     private readonly ApplicationDbContext _context;
+    private readonly IStringLocalizer<DetailsModel> _localizer;
 
-    public DetailsModel(ApplicationDbContext context)
+    public DetailsModel(ApplicationDbContext context, IStringLocalizer<DetailsModel> localizer)
     {
         _context = context;
+        _localizer = localizer;
     }
 
     public CourseTerm Term { get; private set; } = null!;
@@ -36,7 +39,7 @@ public class DetailsModel : PageModel
 
         Term = term;
         CourseTitle = string.IsNullOrWhiteSpace(term.Course?.Title)
-            ? $"Kurz {term.CourseId}"
+            ? _localizer["CourseTitleFallback", term.CourseId]
             : term.Course!.Title;
 
         return Page();

--- a/Pages/Courses/Calendar.cshtml
+++ b/Pages/Courses/Calendar.cshtml
@@ -1,18 +1,23 @@
 @page
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
 @model SysJaky_N.Pages.Courses.CalendarModel
+@{
+    ViewData["Title"] = Localizer["Title"];
+}
 
-<h1>Kalendář kurzů</h1>
+<h1>@Localizer["Title"]</h1>
 
 <table class="table table-bordered">
     <thead>
         <tr>
-            <th>Po</th>
-            <th>Út</th>
-            <th>St</th>
-            <th>Čt</th>
-            <th>Pá</th>
-            <th>So</th>
-            <th>Ne</th>
+            <th>@Localizer["Monday"]</th>
+            <th>@Localizer["Tuesday"]</th>
+            <th>@Localizer["Wednesday"]</th>
+            <th>@Localizer["Thursday"]</th>
+            <th>@Localizer["Friday"]</th>
+            <th>@Localizer["Saturday"]</th>
+            <th>@Localizer["Sunday"]</th>
         </tr>
     </thead>
     <tbody>

--- a/Pages/Courses/Compare.cshtml
+++ b/Pages/Courses/Compare.cshtml
@@ -1,14 +1,16 @@
 @page
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
 @model SysJaky_N.Pages.Courses.CompareModel
 @{
-    ViewData["Title"] = "Porovnání kurzů";
+    ViewData["Title"] = Localizer["Title"];
 }
 
-<h1 class="h4 mb-3">Porovnání kurzů</h1>
+<h1 class="h4 mb-3">@Localizer["Title"]</h1>
 
 @if (Model.Courses.Count == 0)
 {
-    <div class="alert alert-info">Vyberte alespoň dva kurzy k porovnání.</div>
+    <div class="alert alert-info">@Localizer["EmptySelection"]</div>
 }
 else
 {
@@ -16,11 +18,11 @@ else
         <table class="table align-middle">
             <thead>
                 <tr>
-                    <th scope="col">Název</th>
-                    <th scope="col">Délka</th>
-                    <th scope="col">Úroveň</th>
-                    <th scope="col">Forma</th>
-                    <th scope="col">Cena</th>
+                    <th scope="col">@Localizer["ColumnName"]</th>
+                    <th scope="col">@Localizer["ColumnDuration"]</th>
+                    <th scope="col">@Localizer["ColumnLevel"]</th>
+                    <th scope="col">@Localizer["ColumnMode"]</th>
+                    <th scope="col">@Localizer["ColumnPrice"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -28,7 +30,7 @@ else
                 {
                     <tr>
                         <td>@course.Title</td>
-                        <td>@course.Duration min</td>
+                        <td>@Localizer["DurationWithUnit", course.Duration]</td>
                         <td>@course.Level</td>
                         <td>@course.Mode</td>
                         <td>@course.Price.ToString("C")</td>

--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -1,7 +1,10 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Courses.DetailsModel
+@using Microsoft.AspNetCore.Mvc.Localization
 @using System.Collections.Generic
+@using System.Globalization
 @using SysJaky_N.Models
+@inject IViewLocalizer Localizer
 @{
     var metaTitle = string.IsNullOrWhiteSpace(Model.Course.MetaTitle)
         ? Model.Course.Title
@@ -75,7 +78,7 @@
 @if (!string.IsNullOrEmpty(Model.Course.CoverImageUrl))
 {
     <figure class="mb-4">
-        <img src="@Model.Course.CoverImageUrl" alt="Obrázek kurzu @Model.Course.Title" class="img-fluid rounded" loading="lazy" decoding="async" />
+        <img src="@Model.Course.CoverImageUrl" alt="@Localizer["CourseImageAlt", Model.Course.Title]" class="img-fluid rounded" loading="lazy" decoding="async" />
     </figure>
 }
 
@@ -97,54 +100,54 @@
             {
                 outcomeTopics = new List<string>
                 {
-                    "Praktické postupy pro každodenní práci",
-                    "Aktuální normy a legislativní změny",
-                    "Ověřené tipy a doporučení z praxe"
+                    Localizer["OutcomeFallback1"].Value,
+                    Localizer["OutcomeFallback2"].Value,
+                    Localizer["OutcomeFallback3"].Value
                 };
             }
 
             string levelSummary = Model.Course.Level switch
             {
-                CourseLevel.Beginner => "Začínající profesionály, kteří se chtějí rychle zorientovat.",
-                CourseLevel.Intermediate => "Specialisty se základní zkušeností, kteří potřebují posunout své dovednosti dál.",
-                CourseLevel.Advanced => "Zkušené odborníky hledající detailní vhled do pokročilých témat.",
-                _ => "Odborníky se zájmem o prohloubení znalostí."
+                CourseLevel.Beginner => Localizer["LevelSummaryBeginner"].Value,
+                CourseLevel.Intermediate => Localizer["LevelSummaryIntermediate"].Value,
+                CourseLevel.Advanced => Localizer["LevelSummaryAdvanced"].Value,
+                _ => Localizer["LevelSummaryDefault"].Value
             };
 
             string levelLimitation = Model.Course.Level switch
             {
-                CourseLevel.Beginner => "Účastníky očekávající velmi pokročilé nebo strategické know-how.",
-                CourseLevel.Intermediate => "Úplné začátečníky bez předchozích zkušeností v dané oblasti.",
-                CourseLevel.Advanced => "Účastníky hledající jen úvodní seznámení s problematikou.",
-                _ => "Účastníky mimo zaměření kurzu."
+                CourseLevel.Beginner => Localizer["LevelLimitationBeginner"].Value,
+                CourseLevel.Intermediate => Localizer["LevelLimitationIntermediate"].Value,
+                CourseLevel.Advanced => Localizer["LevelLimitationAdvanced"].Value,
+                _ => Localizer["LevelLimitationDefault"].Value
             };
 
             string modePreference = Model.Course.Mode switch
             {
-                CourseMode.SelfPaced => "Lidi, kteří preferují studium vlastním tempem s možností vracet se k materiálům.",
-                CourseMode.InstructorLed => "Účastníky, kteří chtějí interaktivní vedení lektorem a prostor pro dotazy.",
-                CourseMode.Blended => "Týmy, které ocení kombinaci samostudia a živých setkání.",
-                _ => "Zájemce o flexibilní vzdělávání."
+                CourseMode.SelfPaced => Localizer["ModePreferenceSelfPaced"].Value,
+                CourseMode.InstructorLed => Localizer["ModePreferenceInstructorLed"].Value,
+                CourseMode.Blended => Localizer["ModePreferenceBlended"].Value,
+                _ => Localizer["ModePreferenceDefault"].Value
             };
 
             string modeLimitation = Model.Course.Mode switch
             {
-                CourseMode.SelfPaced => "Zájemce vyžadující intenzivní osobní vedení lektora v reálném čase.",
-                CourseMode.InstructorLed => "Ty, kteří preferují zcela samostatné tempo bez pevně daných termínů.",
-                CourseMode.Blended => "Účastníky, kteří nemohou kombinovat online studium se živými setkáními.",
-                _ => "Účastníky s odlišnými preferencemi formy výuky."
+                CourseMode.SelfPaced => Localizer["ModeLimitationSelfPaced"].Value,
+                CourseMode.InstructorLed => Localizer["ModeLimitationInstructorLed"].Value,
+                CourseMode.Blended => Localizer["ModeLimitationBlended"].Value,
+                _ => Localizer["ModeLimitationDefault"].Value
             };
 
             var audienceFor = new List<string> { levelSummary, modePreference };
             if (Model.Course.CourseGroup is not null)
             {
-                audienceFor.Add($"Členy vzdělávacího bloku „{Model.Course.CourseGroup.Name}“ hledající navazující obsah.");
+                audienceFor.Add(Localizer["AudienceCourseGroup", Model.Course.CourseGroup.Name].Value);
             }
 
             var audienceNotFor = new List<string> { levelLimitation, modeLimitation };
             if (!Model.Course.IsActive)
             {
-                audienceNotFor.Add("Zájemce o aktuálně otevřený termín – kurz je dočasně pozastaven.");
+                audienceNotFor.Add(Localizer["AudienceInactive"].Value);
             }
 
             audienceFor = audienceFor
@@ -161,7 +164,7 @@
         @if (!string.IsNullOrWhiteSpace(Model.Course.Description))
         {
             <section class="mb-4">
-                <h2 class="h5">O kurzu</h2>
+                <h2 class="h5">@Localizer["AboutCourse"]</h2>
                 <p>@Model.Course.Description</p>
             </section>
         }
@@ -169,40 +172,40 @@
         @if (Model.Terms.Any())
         {
             <section class="mb-4">
-                <h2 class="h5">Nejbližší termíny</h2>
+                <h2 class="h5">@Localizer["UpcomingTermsHeading"]</h2>
                 <div class="table-responsive">
                     <table class="table align-middle">
-                        <thead><tr><th>Datum</th><th>Místo</th><th>Dostupnost</th><th class="text-end"></th></tr></thead>
+                        <thead><tr><th>@Localizer["TermDate"]</th><th>@Localizer["TermLocation"]</th><th>@Localizer["TermAvailability"]</th><th class="text-end"></th></tr></thead>
                         <tbody>
                             @foreach (var term in Model.Terms)
                             {
                                 var scarce = term.SeatsLeft <= 3 && term.SeatsLeft > 0;
-                                var seatsLabel = term.SeatsLeft switch
+                                var scarcityText = term.SeatsLeft switch
                                 {
-                                    1 => "místo",
-                                    2 or 3 or 4 => "místa",
-                                    _ => "míst"
+                                    1 => Localizer["ScarceSeatsOne", term.SeatsLeft].Value,
+                                    2 or 3 or 4 => Localizer["ScarceSeatsFew", term.SeatsLeft].Value,
+                                    _ => Localizer["ScarceSeatsMany", term.SeatsLeft].Value
                                 };
                                 <tr>
-                                    <td>@term.StartsAt.ToString("d")</td>
-                                    <td>@(term.IsOnline ? "Online" : term.Location)</td>
+                                    <td>@term.StartsAt.ToString("d", CultureInfo.CurrentCulture)</td>
+                                    <td>@(term.IsOnline ? Localizer["TermOnline"] : term.Location)</td>
                                     <td>
                                         @if (term.SeatsLeft == 0)
                                         {
-                                            <span class="badge bg-secondary">Obsazeno</span>
+                                            <span class="badge bg-secondary">@Localizer["TermFull"]</span>
                                         }
                                         else if (scarce)
                                         {
-                                            <span class="badge bg-warning text-dark">Poslední @term.SeatsLeft @seatsLabel</span>
+                                            <span class="badge bg-warning text-dark">@scarcityText</span>
                                         }
                                         else
                                         {
-                                            <span class="badge bg-success">Volno</span>
+                                            <span class="badge bg-success">@Localizer["TermAvailable"]</span>
                                         }
                                     </td>
                                     <td class="text-end">
-                                        <a class="btn btn-outline-secondary btn-sm" asp-page="/CourseTerms/Details" asp-route-id="@term.Id">Detail</a>
-                                        <a class="btn btn-secondary btn-sm" href="/CourseTerms/ICS/@term.Id">.ics</a>
+                                        <a class="btn btn-outline-secondary btn-sm" asp-page="/CourseTerms/Details" asp-route-id="@term.Id">@Localizer["TermDetailButton"]</a>
+                                        <a class="btn btn-secondary btn-sm" href="/CourseTerms/ICS/@term.Id">@Localizer["TermIcsButton"]</a>
                                     </td>
                                 </tr>
                             }
@@ -213,7 +216,7 @@
         }
 
         <section class="mb-4">
-            <h2 class="h5 mb-3">Co se naučíte</h2>
+            <h2 class="h5 mb-3">@Localizer["LearningHeading"]</h2>
             <ul class="list-unstyled mb-0">
                 @foreach (var topic in outcomeTopics)
                 {
@@ -228,7 +231,7 @@
         <section class="mb-4">
             <div class="row g-4">
                 <div class="col-md-6">
-                    <h3 class="h6 text-uppercase text-muted mb-2">Pro koho je</h3>
+                    <h3 class="h6 text-uppercase text-muted mb-2">@Localizer["AudienceForHeading"]</h3>
                     <ul class="small text-muted mb-0">
                         @foreach (var item in audienceFor)
                         {
@@ -237,7 +240,7 @@
                     </ul>
                 </div>
                 <div class="col-md-6">
-                    <h3 class="h6 text-uppercase text-muted mb-2">Pro koho není</h3>
+                    <h3 class="h6 text-uppercase text-muted mb-2">@Localizer["AudienceNotForHeading"]</h3>
                     <ul class="small text-muted mb-0">
                         @foreach (var item in audienceNotFor)
                         {
@@ -249,35 +252,35 @@
         </section>
 
         <section class="mb-4">
-            <h2 class="h5">Detaily</h2>
+            <h2 class="h5">@Localizer["DetailsHeading"]</h2>
             <ul class="list-unstyled small">
-                <li><i class="bi bi-calendar2 me-2"></i>Termín: @Model.Course.Date.ToString("d")</li>
-                <li><i class="bi bi-clock me-2"></i>Délka: @Model.Course.Duration min</li>
-                <li><i class="bi bi-bar-chart me-2"></i>Úroveň: @Model.Course.Level</li>
-                <li><i class="bi bi-laptop me-2"></i>Forma: @Model.Course.Mode</li>
+                <li><i class="bi bi-calendar2 me-2"></i>@Localizer["DetailDateLabel"]: @Model.Course.Date.ToString("d", CultureInfo.CurrentCulture)</li>
+                <li><i class="bi bi-clock me-2"></i>@Localizer["DetailDurationLabel"]: @Localizer["MinutesValue", Model.Course.Duration]</li>
+                <li><i class="bi bi-bar-chart me-2"></i>@Localizer["DetailLevelLabel"]: @Model.Course.Level</li>
+                <li><i class="bi bi-laptop me-2"></i>@Localizer["DetailModeLabel"]: @Model.Course.Mode</li>
             </ul>
         </section>
 
         @if (Model.CourseBlock != null)
         {
             <section class="mb-4">
-                <h2 class="h5">Součást vzdělávacího bloku</h2>
+                <h2 class="h5">@Localizer["BlockHeading"]</h2>
                 <p class="mb-2">@Model.CourseBlock.Description</p>
                 <dl class="row small mb-3">
-                    <dt class="col-sm-4">Název bloku</dt>
+                    <dt class="col-sm-4">@Localizer["BlockNameLabel"]</dt>
                     <dd class="col-sm-8">@Model.CourseBlock.Title</dd>
-                    <dt class="col-sm-4">Cena bloku</dt>
+                    <dt class="col-sm-4">@Localizer["BlockPriceLabel"]</dt>
                     <dd class="col-sm-8">@Model.CourseBlock.Price.ToString("C")</dd>
                 </dl>
                 <form method="post" asp-page-handler="OrderBlock" class="d-inline">
                     <input type="hidden" name="blockId" value="@Model.CourseBlock.Id" />
-                    <button type="submit" class="btn btn-outline-primary btn-sm">Objednat celý blok</button>
+                    <button type="submit" class="btn btn-outline-primary btn-sm">@Localizer["OrderBlockButton"]</button>
                 </form>
             </section>
         }
 
         <section class="mt-4">
-            <h2 class="h5">Lekce</h2>
+            <h2 class="h5">@Localizer["LessonsHeading"]</h2>
             @if (Model.Lessons.Any())
             {
                 <div class="list-group">
@@ -289,18 +292,18 @@
                             <div class="d-flex flex-column gap-2">
                                 <div class="d-flex justify-content-between flex-wrap gap-3">
                                     <div>
-                                        <div class="fw-semibold">Lekce pořadí: @lesson.Order</div>
-                                        <div class="text-muted">Typ: @lesson.Type</div>
+                                        <div class="fw-semibold">@Localizer["LessonOrderLabel", lesson.Order]</div>
+                                        <div class="text-muted">@Localizer["LessonTypeLabel"]: @lesson.Type</div>
                                         @if (!string.IsNullOrWhiteSpace(lesson.ContentUrl))
                                         {
-                                            <a class="link-primary" href="@lesson.ContentUrl" target="_blank" rel="noopener">Otevřít obsah</a>
+                                            <a class="link-primary" href="@lesson.ContentUrl" target="_blank" rel="noopener">@Localizer["LessonOpenContent"]</a>
                                         }
                                     </div>
                                     <div class="text-end">
-                                        <div class="fw-semibold">@completion&nbsp;% dokončeno</div>
+                                        <div class="fw-semibold">@Localizer["LessonCompletion", completion]</div>
                                         @if (progressInfo is not null)
                                         {
-                                            <div class="text-muted small">Naposledy @(progressInfo.LastSeenUtc.ToLocalTime().ToString("g"))</div>
+                                            <div class="text-muted small">@Localizer["LessonLastSeen", progressInfo.LastSeenUtc.ToLocalTime().ToString("g", CultureInfo.CurrentCulture)]</div>
                                         }
                                     </div>
                                 </div>
@@ -309,19 +312,19 @@
                                     <form method="post" asp-page-handler="UpdateProgress" asp-route-id="@Model.Course.Id" class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
                                         <input type="hidden" name="lessonId" value="@lesson.Id" />
                                         <div class="input-group input-group-sm" style="max-width: 220px;">
-                                            <span class="input-group-text">Progres</span>
-                                            <input type="number" class="form-control" name="progress" min="0" max="100" value="@completion" aria-label="Procento dokončení lekce pořadí @lesson.Order" />
+                                            <span class="input-group-text">@Localizer["LessonProgressLabel"]</span>
+                                            <input type="number" class="form-control" name="progress" min="0" max="100" value="@completion" aria-label="@Localizer["LessonProgressAria", lesson.Order]" />
                                             <span class="input-group-text">%</span>
                                         </div>
                                         <div class="d-flex gap-2 flex-wrap">
-                                            <button type="submit" class="btn btn-sm btn-primary">Uložit</button>
-                                            <button type="submit" class="btn btn-sm btn-outline-success" onclick="this.form.querySelector('[name=progress]').value = 100;">Dokončeno</button>
+                                            <button type="submit" class="btn btn-sm btn-primary">@Localizer["LessonSave"]</button>
+                                            <button type="submit" class="btn btn-sm btn-outline-success" onclick="this.form.querySelector('[name=progress]').value = 100;">@Localizer["LessonMarkDone"]</button>
                                         </div>
                                     </form>
                                 }
                                 else
                                 {
-                                    <p class="text-muted small mb-0">Přihlaste se pro sledování postupu.</p>
+                                    <p class="text-muted small mb-0">@Localizer["SignInToTrack"]</p>
                                 }
                             </div>
                         </div>
@@ -330,33 +333,33 @@
             }
             else
             {
-                <p class="text-muted">Pro tento kurz zatím nejsou dostupné lekce.</p>
+                <p class="text-muted">@Localizer["NoLessons"]</p>
             }
         </section>
     </div>
     <div class="col-lg-4">
         <div class="p-3 border rounded-3 position-sticky top-0">
             <div class="d-flex justify-content-between align-items-center mb-2">
-                <strong>Cena</strong>
+                <strong>@Localizer["PriceHeading"]</strong>
                 <div class="fs-5 fw-bold">@Model.Course.Price.ToString("C")</div>
             </div>
             <ul class="list-unstyled small text-muted mb-3">
-                <li><i class="bi bi-check-circle"></i> Certifikát v ceně (pokud je u termínu uvedeno)</li>
-                <li><i class="bi bi-check-circle"></i> Materiály ke stažení</li>
-                <li><i class="bi bi-check-circle"></i> Snadné storno do 5 pracovních dnů</li>
+                <li><i class="bi bi-check-circle"></i> @Localizer["PriceBenefitCertificate"]</li>
+                <li><i class="bi bi-check-circle"></i> @Localizer["PriceBenefitMaterials"]</li>
+                <li><i class="bi bi-check-circle"></i> @Localizer["PriceBenefitCancellation"]</li>
             </ul>
             <div class="d-grid gap-2">
                 <form method="post">
-                    <button type="submit" class="btn btn-primary">Přihlásit se</button>
+                    <button type="submit" class="btn btn-primary">@Localizer["EnrollButton"]</button>
                 </form>
-                <a class="btn btn-outline-secondary" asp-page="/Contact" asp-route-subject="Firemní poptávka: @Model.Course.Title">Pro tým</a>
+                <a class="btn btn-outline-secondary" asp-page="/Contact" asp-route-subject="@Localizer["ContactSubject", Model.Course.Title]">@Localizer["TeamButton"]</a>
             </div>
         </div>
 
         @if (User.Identity?.IsAuthenticated ?? false)
         {
             <form method="post" asp-page-handler="AddToWishlist" class="mt-3">
-                <button type="submit" class="btn btn-outline-secondary w-100">Přidat do wishlistu</button>
+                <button type="submit" class="btn btn-outline-secondary w-100">@Localizer["WishlistButton"]</button>
             </form>
         }
     </div>
@@ -365,7 +368,7 @@
 @if (Model.Reviews.Any())
 {
     <section class="mt-5">
-        <h2 class="h5">Hodnocení</h2>
+        <h2 class="h5">@Localizer["ReviewsHeading"]</h2>
         <ul class="list-unstyled">
             @foreach (var review in Model.Reviews)
             {
@@ -382,7 +385,7 @@
 @if (User.Identity?.IsAuthenticated ?? false)
 {
     <section class="mt-4">
-        <h3 class="h5">Přidat hodnocení</h3>
+        <h3 class="h5">@Localizer["AddReviewHeading"]</h3>
         <form method="post" asp-page-handler="Review">
             <div class="mb-3">
                 <label asp-for="NewReview.Rating" class="form-label"></label>
@@ -394,13 +397,13 @@
                 <textarea asp-for="NewReview.Comment" class="form-control"></textarea>
                 <span asp-validation-for="NewReview.Comment" class="text-danger"></span>
             </div>
-            <button type="submit" class="btn btn-success">Odeslat hodnocení</button>
+            <button type="submit" class="btn btn-success">@Localizer["SubmitReviewButton"]</button>
         </form>
     </section>
 }
 else
 {
-    <p class="mt-4"><a asp-page="/Account/Login">Přihlaste se</a> pro přidání hodnocení.</p>
+    <p class="mt-4"><a asp-page="/Account/Login">@Localizer["SignInLinkText"]</a> @Localizer["ReviewSignInSuffix"]</p>
 }
 
 @section Scripts {

--- a/Pages/Courses/Details.cshtml.cs
+++ b/Pages/Courses/Details.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Localization;
 using SysJaky_N.Data;
 using SysJaky_N.Extensions;
 using SysJaky_N.Services;
@@ -16,17 +17,20 @@ public class DetailsModel : PageModel
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly CartService _cartService;
     private readonly ICacheService _cacheService;
+    private readonly IStringLocalizer<DetailsModel> _localizer;
 
     public DetailsModel(
         ApplicationDbContext context,
         UserManager<ApplicationUser> userManager,
         CartService cartService,
-        ICacheService cacheService)
+        ICacheService cacheService,
+        IStringLocalizer<DetailsModel> localizer)
     {
         _context = context;
         _userManager = userManager;
         _cartService = cartService;
         _cacheService = cacheService;
+        _localizer = localizer;
     }
 
     public Course Course { get; set; } = null!;
@@ -286,19 +290,19 @@ public class DetailsModel : PageModel
         return course.Type == CourseType.Online || course.Mode == CourseMode.SelfPaced;
     }
 
-    private static string ResolveLocation(Course? course)
+    private string ResolveLocation(Course? course)
     {
         if (course == null)
         {
-            return "Bude upřesněno";
+            return _localizer["LocationTbd"];
         }
 
         return course.Type switch
         {
-            CourseType.Online => "Online",
-            CourseType.Hybrid => "Hybridní (kombinace)",
-            CourseType.InPerson => "Prezenčně",
-            _ => "Bude upřesněno"
+            CourseType.Online => _localizer["LocationOnline"],
+            CourseType.Hybrid => _localizer["LocationHybrid"],
+            CourseType.InPerson => _localizer["LocationInPerson"],
+            _ => _localizer["LocationTbd"]
         };
     }
 }

--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -31,47 +31,62 @@
     </div>
 </div>
 
-<div id="cmpBar" class="compare-bar d-none">
+<div id="cmpBar" class="compare-bar d-none" data-count-format="@Localizer["CompareBarCountFormat"].Value" data-cta-text="@Localizer["CompareBarCta"].Value">
     <div class="container-xl d-flex justify-content-between align-items-center">
-        <div class="small" id="cmpCount">0 vybráno</div>
-        <a id="cmpGo" class="btn btn-primary btn-sm disabled" aria-disabled="true">Porovnat</a>
+        <div class="small" id="cmpCount">@Localizer["CompareBarCountFormat", 0]</div>
+        <a id="cmpGo" class="btn btn-primary btn-sm disabled" aria-disabled="true">@Localizer["CompareBarCta"]</a>
     </div>
 </div>
 <script>
     const bar = document.getElementById('cmpBar');
     const btn = document.getElementById('cmpGo');
     const cnt = document.getElementById('cmpCount');
-    const sel = new Set();
 
-    document.querySelectorAll('.cmp-check').forEach(ch => {
-        ch.addEventListener('change', () => {
-            if (ch.checked) {
-                sel.add(ch.value);
-            } else {
-                sel.delete(ch.value);
-            }
+    if (bar && btn && cnt) {
+        const countFormat = bar.dataset.countFormat ?? '{0}';
+        const ctaText = bar.dataset.ctaText ?? btn.textContent ?? '';
+        const sel = new Set();
 
-            const selected = sel.size;
-            cnt.textContent = `${selected} vybráno`;
+        if (ctaText) {
+            btn.textContent = ctaText;
+        }
 
-            if (selected > 1 && selected <= 3) {
-                bar.classList.remove('d-none');
-                btn.classList.remove('disabled');
-                btn.removeAttribute('aria-disabled');
-                btn.href = '/Courses/Compare?ids=' + Array.from(sel).join(',');
-            } else {
-                btn.classList.add('disabled');
-                btn.setAttribute('aria-disabled', 'true');
-                btn.removeAttribute('href');
+        const updateCountText = (value) => {
+            cnt.textContent = countFormat.replace('{0}', value.toString());
+        };
 
-                if (selected === 0) {
-                    bar.classList.add('d-none');
+        updateCountText(0);
+
+        document.querySelectorAll('.cmp-check').forEach(ch => {
+            ch.addEventListener('change', () => {
+                if (ch.checked) {
+                    sel.add(ch.value);
                 } else {
-                    bar.classList.remove('d-none');
+                    sel.delete(ch.value);
                 }
-            }
+
+                const selected = sel.size;
+                updateCountText(selected);
+
+                if (selected > 1 && selected <= 3) {
+                    bar.classList.remove('d-none');
+                    btn.classList.remove('disabled');
+                    btn.removeAttribute('aria-disabled');
+                    btn.href = '/Courses/Compare?ids=' + Array.from(sel).join(',');
+                } else {
+                    btn.classList.add('disabled');
+                    btn.setAttribute('aria-disabled', 'true');
+                    btn.removeAttribute('href');
+
+                    if (selected === 0) {
+                        bar.classList.add('d-none');
+                    } else {
+                        bar.classList.remove('d-none');
+                    }
+                }
+            });
         });
-    });
+    }
 </script>
 
 @if (TempData["CartError"] is string cartError && !string.IsNullOrWhiteSpace(cartError))

--- a/Resources/Pages.CourseTerms.Details.cshtml.en.resx
+++ b/Resources/Pages.CourseTerms.Details.cshtml.en.resx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Term detail</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>Term detail</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Starts</value>
+  </data>
+  <data name="End" xml:space="preserve">
+    <value>Ends</value>
+  </data>
+  <data name="Capacity" xml:space="preserve">
+    <value>Capacity</value>
+  </data>
+  <data name="Taken" xml:space="preserve">
+    <value>Booked</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Available seats</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="StatusActive" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="StatusInactive" xml:space="preserve">
+    <value>Inactive</value>
+  </data>
+  <data name="Instructor" xml:space="preserve">
+    <value>Instructor</value>
+  </data>
+  <data name="AboutCourse" xml:space="preserve">
+    <value>About the course</value>
+  </data>
+  <data name="CourseDetailCta" xml:space="preserve">
+    <value>Course detail</value>
+  </data>
+  <data name="AddToCalendar" xml:space="preserve">
+    <value>Add to calendar</value>
+  </data>
+</root>

--- a/Resources/Pages.CourseTerms.Details.cshtml.resx
+++ b/Resources/Pages.CourseTerms.Details.cshtml.resx
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Detail termínu</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>Detail termínu</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Začátek</value>
+  </data>
+  <data name="End" xml:space="preserve">
+    <value>Konec</value>
+  </data>
+  <data name="Capacity" xml:space="preserve">
+    <value>Kapacita</value>
+  </data>
+  <data name="Taken" xml:space="preserve">
+    <value>Obsazeno</value>
+  </data>
+  <data name="Available" xml:space="preserve">
+    <value>Volná místa</value>
+  </data>
+  <data name="Status" xml:space="preserve">
+    <value>Stav</value>
+  </data>
+  <data name="StatusActive" xml:space="preserve">
+    <value>Aktivní</value>
+  </data>
+  <data name="StatusInactive" xml:space="preserve">
+    <value>Neaktivní</value>
+  </data>
+  <data name="Instructor" xml:space="preserve">
+    <value>Lektor</value>
+  </data>
+  <data name="AboutCourse" xml:space="preserve">
+    <value>O kurzu</value>
+  </data>
+  <data name="CourseDetailCta" xml:space="preserve">
+    <value>Detail kurzu</value>
+  </data>
+  <data name="AddToCalendar" xml:space="preserve">
+    <value>Přidat do kalendáře</value>
+  </data>
+</root>

--- a/Resources/Pages.CourseTerms.DetailsModel.cs.en.resx
+++ b/Resources/Pages.CourseTerms.DetailsModel.cs.en.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CourseTitleFallback" xml:space="preserve">
+    <value>Course {0}</value>
+  </data>
+</root>

--- a/Resources/Pages.CourseTerms.DetailsModel.cs.resx
+++ b/Resources/Pages.CourseTerms.DetailsModel.cs.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CourseTitleFallback" xml:space="preserve">
+    <value>Kurz {0}</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Calendar.cshtml.en.resx
+++ b/Resources/Pages.Courses.Calendar.cshtml.en.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Course calendar</value>
+  </data>
+  <data name="Monday" xml:space="preserve">
+    <value>Mon</value>
+  </data>
+  <data name="Tuesday" xml:space="preserve">
+    <value>Tue</value>
+  </data>
+  <data name="Wednesday" xml:space="preserve">
+    <value>Wed</value>
+  </data>
+  <data name="Thursday" xml:space="preserve">
+    <value>Thu</value>
+  </data>
+  <data name="Friday" xml:space="preserve">
+    <value>Fri</value>
+  </data>
+  <data name="Saturday" xml:space="preserve">
+    <value>Sat</value>
+  </data>
+  <data name="Sunday" xml:space="preserve">
+    <value>Sun</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Calendar.cshtml.resx
+++ b/Resources/Pages.Courses.Calendar.cshtml.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Kalendář kurzů</value>
+  </data>
+  <data name="Monday" xml:space="preserve">
+    <value>Po</value>
+  </data>
+  <data name="Tuesday" xml:space="preserve">
+    <value>Út</value>
+  </data>
+  <data name="Wednesday" xml:space="preserve">
+    <value>St</value>
+  </data>
+  <data name="Thursday" xml:space="preserve">
+    <value>Čt</value>
+  </data>
+  <data name="Friday" xml:space="preserve">
+    <value>Pá</value>
+  </data>
+  <data name="Saturday" xml:space="preserve">
+    <value>So</value>
+  </data>
+  <data name="Sunday" xml:space="preserve">
+    <value>Ne</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Compare.cshtml.en.resx
+++ b/Resources/Pages.Courses.Compare.cshtml.en.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Course comparison</value>
+  </data>
+  <data name="EmptySelection" xml:space="preserve">
+    <value>Select at least two courses to compare.</value>
+  </data>
+  <data name="ColumnName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="ColumnDuration" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="ColumnLevel" xml:space="preserve">
+    <value>Level</value>
+  </data>
+  <data name="ColumnMode" xml:space="preserve">
+    <value>Format</value>
+  </data>
+  <data name="ColumnPrice" xml:space="preserve">
+    <value>Price</value>
+  </data>
+  <data name="DurationWithUnit" xml:space="preserve">
+    <value>{0} min</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Compare.cshtml.resx
+++ b/Resources/Pages.Courses.Compare.cshtml.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Porovnání kurzů</value>
+  </data>
+  <data name="EmptySelection" xml:space="preserve">
+    <value>Vyberte alespoň dva kurzy k porovnání.</value>
+  </data>
+  <data name="ColumnName" xml:space="preserve">
+    <value>Název</value>
+  </data>
+  <data name="ColumnDuration" xml:space="preserve">
+    <value>Délka</value>
+  </data>
+  <data name="ColumnLevel" xml:space="preserve">
+    <value>Úroveň</value>
+  </data>
+  <data name="ColumnMode" xml:space="preserve">
+    <value>Forma</value>
+  </data>
+  <data name="ColumnPrice" xml:space="preserve">
+    <value>Cena</value>
+  </data>
+  <data name="DurationWithUnit" xml:space="preserve">
+    <value>{0} min</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Details.cshtml.en.resx
+++ b/Resources/Pages.Courses.Details.cshtml.en.resx
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CourseImageAlt" xml:space="preserve">
+    <value>Course image {0}</value>
+  </data>
+  <data name="OutcomeFallback1" xml:space="preserve">
+    <value>Practical steps for everyday work</value>
+  </data>
+  <data name="OutcomeFallback2" xml:space="preserve">
+    <value>Current standards and legislative changes</value>
+  </data>
+  <data name="OutcomeFallback3" xml:space="preserve">
+    <value>Proven tips and recommendations from practice</value>
+  </data>
+  <data name="LevelSummaryBeginner" xml:space="preserve">
+    <value>Early-career professionals who want to get oriented quickly.</value>
+  </data>
+  <data name="LevelSummaryIntermediate" xml:space="preserve">
+    <value>Specialists with basic experience ready to grow their skills.</value>
+  </data>
+  <data name="LevelSummaryAdvanced" xml:space="preserve">
+    <value>Seasoned experts seeking deep insight into advanced topics.</value>
+  </data>
+  <data name="LevelSummaryDefault" xml:space="preserve">
+    <value>Professionals interested in expanding their knowledge.</value>
+  </data>
+  <data name="LevelLimitationBeginner" xml:space="preserve">
+    <value>Participants expecting highly advanced or strategic know-how.</value>
+  </data>
+  <data name="LevelLimitationIntermediate" xml:space="preserve">
+    <value>Complete beginners without prior experience in the field.</value>
+  </data>
+  <data name="LevelLimitationAdvanced" xml:space="preserve">
+    <value>Learners looking only for an introductory overview.</value>
+  </data>
+  <data name="LevelLimitationDefault" xml:space="preserve">
+    <value>Participants outside the focus of the course.</value>
+  </data>
+  <data name="ModePreferenceSelfPaced" xml:space="preserve">
+    <value>People who prefer studying at their own pace with the option to revisit materials.</value>
+  </data>
+  <data name="ModePreferenceInstructorLed" xml:space="preserve">
+    <value>Learners seeking interactive guidance from an instructor and time for questions.</value>
+  </data>
+  <data name="ModePreferenceBlended" xml:space="preserve">
+    <value>Teams who value a mix of self-study and live sessions.</value>
+  </data>
+  <data name="ModePreferenceDefault" xml:space="preserve">
+    <value>Learners looking for flexible education.</value>
+  </data>
+  <data name="ModeLimitationSelfPaced" xml:space="preserve">
+    <value>Attendees who require intensive real-time guidance from an instructor.</value>
+  </data>
+  <data name="ModeLimitationInstructorLed" xml:space="preserve">
+    <value>Those who want a completely self-directed schedule without fixed dates.</value>
+  </data>
+  <data name="ModeLimitationBlended" xml:space="preserve">
+    <value>Learners unable to combine online study with live meetings.</value>
+  </data>
+  <data name="ModeLimitationDefault" xml:space="preserve">
+    <value>Participants with different learning format preferences.</value>
+  </data>
+  <data name="AudienceCourseGroup" xml:space="preserve">
+    <value>Members of the learning block “{0}” looking for follow-up content.</value>
+  </data>
+  <data name="AudienceInactive" xml:space="preserve">
+    <value>Learners interested in an open date – the course is temporarily paused.</value>
+  </data>
+  <data name="UpcomingTermsHeading" xml:space="preserve">
+    <value>Upcoming dates</value>
+  </data>
+  <data name="TermDate" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="TermLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="TermAvailability" xml:space="preserve">
+    <value>Availability</value>
+  </data>
+  <data name="ScarceSeatsOne" xml:space="preserve">
+    <value>Last {0} seat</value>
+  </data>
+  <data name="ScarceSeatsFew" xml:space="preserve">
+    <value>Last {0} seats</value>
+  </data>
+  <data name="ScarceSeatsMany" xml:space="preserve">
+    <value>Last {0} seats</value>
+  </data>
+  <data name="TermOnline" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="TermFull" xml:space="preserve">
+    <value>Full</value>
+  </data>
+  <data name="TermAvailable" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="TermDetailButton" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="TermIcsButton" xml:space="preserve">
+    <value>.ics</value>
+  </data>
+  <data name="AboutCourse" xml:space="preserve">
+    <value>About the course</value>
+  </data>
+  <data name="LearningHeading" xml:space="preserve">
+    <value>What you will learn</value>
+  </data>
+  <data name="AudienceForHeading" xml:space="preserve">
+    <value>Who it’s for</value>
+  </data>
+  <data name="AudienceNotForHeading" xml:space="preserve">
+    <value>Who it’s not for</value>
+  </data>
+  <data name="DetailsHeading" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="DetailDateLabel" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="DetailDurationLabel" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="MinutesValue" xml:space="preserve">
+    <value>{0} min</value>
+  </data>
+  <data name="DetailLevelLabel" xml:space="preserve">
+    <value>Level</value>
+  </data>
+  <data name="DetailModeLabel" xml:space="preserve">
+    <value>Format</value>
+  </data>
+  <data name="BlockHeading" xml:space="preserve">
+    <value>Part of a learning block</value>
+  </data>
+  <data name="BlockNameLabel" xml:space="preserve">
+    <value>Block name</value>
+  </data>
+  <data name="BlockPriceLabel" xml:space="preserve">
+    <value>Block price</value>
+  </data>
+  <data name="OrderBlockButton" xml:space="preserve">
+    <value>Order the full block</value>
+  </data>
+  <data name="LessonsHeading" xml:space="preserve">
+    <value>Lessons</value>
+  </data>
+  <data name="LessonOrderLabel" xml:space="preserve">
+    <value>Lesson order: {0}</value>
+  </data>
+  <data name="LessonTypeLabel" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="LessonOpenContent" xml:space="preserve">
+    <value>Open content</value>
+  </data>
+  <data name="LessonCompletion" xml:space="preserve">
+    <value>{0}% complete</value>
+  </data>
+  <data name="LessonLastSeen" xml:space="preserve">
+    <value>Last viewed {0}</value>
+  </data>
+  <data name="LessonProgressLabel" xml:space="preserve">
+    <value>Progress</value>
+  </data>
+  <data name="LessonProgressAria" xml:space="preserve">
+    <value>Completion percentage for lesson order {0}</value>
+  </data>
+  <data name="LessonSave" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="LessonMarkDone" xml:space="preserve">
+    <value>Mark complete</value>
+  </data>
+  <data name="SignInToTrack" xml:space="preserve">
+    <value>Sign in to track your progress.</value>
+  </data>
+  <data name="NoLessons" xml:space="preserve">
+    <value>No lessons are available for this course yet.</value>
+  </data>
+  <data name="PriceHeading" xml:space="preserve">
+    <value>Price</value>
+  </data>
+  <data name="PriceBenefitCertificate" xml:space="preserve">
+    <value>Certificate included (where available)</value>
+  </data>
+  <data name="PriceBenefitMaterials" xml:space="preserve">
+    <value>Downloadable materials</value>
+  </data>
+  <data name="PriceBenefitCancellation" xml:space="preserve">
+    <value>Easy cancellation up to 5 business days</value>
+  </data>
+  <data name="EnrollButton" xml:space="preserve">
+    <value>Enroll</value>
+  </data>
+  <data name="ContactSubject" xml:space="preserve">
+    <value>Corporate inquiry: {0}</value>
+  </data>
+  <data name="TeamButton" xml:space="preserve">
+    <value>For teams</value>
+  </data>
+  <data name="WishlistButton" xml:space="preserve">
+    <value>Add to wishlist</value>
+  </data>
+  <data name="ReviewsHeading" xml:space="preserve">
+    <value>Reviews</value>
+  </data>
+  <data name="AddReviewHeading" xml:space="preserve">
+    <value>Add a review</value>
+  </data>
+  <data name="SubmitReviewButton" xml:space="preserve">
+    <value>Submit review</value>
+  </data>
+  <data name="SignInLinkText" xml:space="preserve">
+    <value>Sign in</value>
+  </data>
+  <data name="ReviewSignInSuffix" xml:space="preserve">
+    <value>to add a review.</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Details.cshtml.resx
+++ b/Resources/Pages.Courses.Details.cshtml.resx
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CourseImageAlt" xml:space="preserve">
+    <value>Obrázek kurzu {0}</value>
+  </data>
+  <data name="OutcomeFallback1" xml:space="preserve">
+    <value>Praktické postupy pro každodenní práci</value>
+  </data>
+  <data name="OutcomeFallback2" xml:space="preserve">
+    <value>Aktuální normy a legislativní změny</value>
+  </data>
+  <data name="OutcomeFallback3" xml:space="preserve">
+    <value>Ověřené tipy a doporučení z praxe</value>
+  </data>
+  <data name="LevelSummaryBeginner" xml:space="preserve">
+    <value>Začínající profesionály, kteří se chtějí rychle zorientovat.</value>
+  </data>
+  <data name="LevelSummaryIntermediate" xml:space="preserve">
+    <value>Specialisty se základní zkušeností, kteří potřebují posunout své dovednosti dál.</value>
+  </data>
+  <data name="LevelSummaryAdvanced" xml:space="preserve">
+    <value>Zkušené odborníky hledající detailní vhled do pokročilých témat.</value>
+  </data>
+  <data name="LevelSummaryDefault" xml:space="preserve">
+    <value>Odborníky se zájmem o prohloubení znalostí.</value>
+  </data>
+  <data name="LevelLimitationBeginner" xml:space="preserve">
+    <value>Účastníky očekávající velmi pokročilé nebo strategické know-how.</value>
+  </data>
+  <data name="LevelLimitationIntermediate" xml:space="preserve">
+    <value>Úplné začátečníky bez předchozích zkušeností v dané oblasti.</value>
+  </data>
+  <data name="LevelLimitationAdvanced" xml:space="preserve">
+    <value>Účastníky hledající jen úvodní seznámení s problematikou.</value>
+  </data>
+  <data name="LevelLimitationDefault" xml:space="preserve">
+    <value>Účastníky mimo zaměření kurzu.</value>
+  </data>
+  <data name="ModePreferenceSelfPaced" xml:space="preserve">
+    <value>Lidi, kteří preferují studium vlastním tempem s možností vracet se k materiálům.</value>
+  </data>
+  <data name="ModePreferenceInstructorLed" xml:space="preserve">
+    <value>Účastníky, kteří chtějí interaktivní vedení lektorem a prostor pro dotazy.</value>
+  </data>
+  <data name="ModePreferenceBlended" xml:space="preserve">
+    <value>Týmy, které ocení kombinaci samostudia a živých setkání.</value>
+  </data>
+  <data name="ModePreferenceDefault" xml:space="preserve">
+    <value>Zájemce o flexibilní vzdělávání.</value>
+  </data>
+  <data name="ModeLimitationSelfPaced" xml:space="preserve">
+    <value>Zájemce vyžadující intenzivní osobní vedení lektora v reálném čase.</value>
+  </data>
+  <data name="ModeLimitationInstructorLed" xml:space="preserve">
+    <value>Ty, kteří preferují zcela samostatné tempo bez pevně daných termínů.</value>
+  </data>
+  <data name="ModeLimitationBlended" xml:space="preserve">
+    <value>Účastníky, kteří nemohou kombinovat online studium se živými setkáními.</value>
+  </data>
+  <data name="ModeLimitationDefault" xml:space="preserve">
+    <value>Účastníky s odlišnými preferencemi formy výuky.</value>
+  </data>
+  <data name="AudienceCourseGroup" xml:space="preserve">
+    <value>Členy vzdělávacího bloku „{0}“ hledající navazující obsah.</value>
+  </data>
+  <data name="AudienceInactive" xml:space="preserve">
+    <value>Zájemce o aktuálně otevřený termín – kurz je dočasně pozastaven.</value>
+  </data>
+  <data name="UpcomingTermsHeading" xml:space="preserve">
+    <value>Nejbližší termíny</value>
+  </data>
+  <data name="TermDate" xml:space="preserve">
+    <value>Datum</value>
+  </data>
+  <data name="TermLocation" xml:space="preserve">
+    <value>Místo</value>
+  </data>
+  <data name="TermAvailability" xml:space="preserve">
+    <value>Dostupnost</value>
+  </data>
+  <data name="ScarceSeatsOne" xml:space="preserve">
+    <value>Poslední {0} místo</value>
+  </data>
+  <data name="ScarceSeatsFew" xml:space="preserve">
+    <value>Poslední {0} místa</value>
+  </data>
+  <data name="ScarceSeatsMany" xml:space="preserve">
+    <value>Poslední {0} míst</value>
+  </data>
+  <data name="TermOnline" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="TermFull" xml:space="preserve">
+    <value>Obsazeno</value>
+  </data>
+  <data name="TermAvailable" xml:space="preserve">
+    <value>Volno</value>
+  </data>
+  <data name="TermDetailButton" xml:space="preserve">
+    <value>Detail</value>
+  </data>
+  <data name="TermIcsButton" xml:space="preserve">
+    <value>.ics</value>
+  </data>
+  <data name="AboutCourse" xml:space="preserve">
+    <value>O kurzu</value>
+  </data>
+  <data name="LearningHeading" xml:space="preserve">
+    <value>Co se naučíte</value>
+  </data>
+  <data name="AudienceForHeading" xml:space="preserve">
+    <value>Pro koho je</value>
+  </data>
+  <data name="AudienceNotForHeading" xml:space="preserve">
+    <value>Pro koho není</value>
+  </data>
+  <data name="DetailsHeading" xml:space="preserve">
+    <value>Detaily</value>
+  </data>
+  <data name="DetailDateLabel" xml:space="preserve">
+    <value>Termín</value>
+  </data>
+  <data name="DetailDurationLabel" xml:space="preserve">
+    <value>Délka</value>
+  </data>
+  <data name="MinutesValue" xml:space="preserve">
+    <value>{0} min</value>
+  </data>
+  <data name="DetailLevelLabel" xml:space="preserve">
+    <value>Úroveň</value>
+  </data>
+  <data name="DetailModeLabel" xml:space="preserve">
+    <value>Forma</value>
+  </data>
+  <data name="BlockHeading" xml:space="preserve">
+    <value>Součást vzdělávacího bloku</value>
+  </data>
+  <data name="BlockNameLabel" xml:space="preserve">
+    <value>Název bloku</value>
+  </data>
+  <data name="BlockPriceLabel" xml:space="preserve">
+    <value>Cena bloku</value>
+  </data>
+  <data name="OrderBlockButton" xml:space="preserve">
+    <value>Objednat celý blok</value>
+  </data>
+  <data name="LessonsHeading" xml:space="preserve">
+    <value>Lekce</value>
+  </data>
+  <data name="LessonOrderLabel" xml:space="preserve">
+    <value>Lekce pořadí: {0}</value>
+  </data>
+  <data name="LessonTypeLabel" xml:space="preserve">
+    <value>Typ</value>
+  </data>
+  <data name="LessonOpenContent" xml:space="preserve">
+    <value>Otevřít obsah</value>
+  </data>
+  <data name="LessonCompletion" xml:space="preserve">
+    <value>{0}% dokončeno</value>
+  </data>
+  <data name="LessonLastSeen" xml:space="preserve">
+    <value>Naposledy {0}</value>
+  </data>
+  <data name="LessonProgressLabel" xml:space="preserve">
+    <value>Progres</value>
+  </data>
+  <data name="LessonProgressAria" xml:space="preserve">
+    <value>Procento dokončení lekce pořadí {0}</value>
+  </data>
+  <data name="LessonSave" xml:space="preserve">
+    <value>Uložit</value>
+  </data>
+  <data name="LessonMarkDone" xml:space="preserve">
+    <value>Dokončeno</value>
+  </data>
+  <data name="SignInToTrack" xml:space="preserve">
+    <value>Přihlaste se pro sledování postupu.</value>
+  </data>
+  <data name="NoLessons" xml:space="preserve">
+    <value>Pro tento kurz zatím nejsou dostupné lekce.</value>
+  </data>
+  <data name="PriceHeading" xml:space="preserve">
+    <value>Cena</value>
+  </data>
+  <data name="PriceBenefitCertificate" xml:space="preserve">
+    <value>Certifikát v ceně (pokud je u termínu uvedeno)</value>
+  </data>
+  <data name="PriceBenefitMaterials" xml:space="preserve">
+    <value>Materiály ke stažení</value>
+  </data>
+  <data name="PriceBenefitCancellation" xml:space="preserve">
+    <value>Snadné storno do 5 pracovních dnů</value>
+  </data>
+  <data name="EnrollButton" xml:space="preserve">
+    <value>Přihlásit se</value>
+  </data>
+  <data name="ContactSubject" xml:space="preserve">
+    <value>Firemní poptávka: {0}</value>
+  </data>
+  <data name="TeamButton" xml:space="preserve">
+    <value>Pro tým</value>
+  </data>
+  <data name="WishlistButton" xml:space="preserve">
+    <value>Přidat do wishlistu</value>
+  </data>
+  <data name="ReviewsHeading" xml:space="preserve">
+    <value>Hodnocení</value>
+  </data>
+  <data name="AddReviewHeading" xml:space="preserve">
+    <value>Přidat hodnocení</value>
+  </data>
+  <data name="SubmitReviewButton" xml:space="preserve">
+    <value>Odeslat hodnocení</value>
+  </data>
+  <data name="SignInLinkText" xml:space="preserve">
+    <value>Přihlaste se</value>
+  </data>
+  <data name="ReviewSignInSuffix" xml:space="preserve">
+    <value>pro přidání hodnocení.</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.DetailsModel.cs.en.resx
+++ b/Resources/Pages.Courses.DetailsModel.cs.en.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocationTbd" xml:space="preserve">
+    <value>To be announced</value>
+  </data>
+  <data name="LocationOnline" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="LocationHybrid" xml:space="preserve">
+    <value>Hybrid (combined)</value>
+  </data>
+  <data name="LocationInPerson" xml:space="preserve">
+    <value>In person</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.DetailsModel.cs.resx
+++ b/Resources/Pages.Courses.DetailsModel.cs.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="LocationTbd" xml:space="preserve">
+    <value>Bude upřesněno</value>
+  </data>
+  <data name="LocationOnline" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="LocationHybrid" xml:space="preserve">
+    <value>Hybridní (kombinace)</value>
+  </data>
+  <data name="LocationInPerson" xml:space="preserve">
+    <value>Prezenčně</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Index.cshtml.en.resx
+++ b/Resources/Pages.Courses.Index.cshtml.en.resx
@@ -39,4 +39,10 @@
   <data name="Next" xml:space="preserve">
     <value>Next</value>
   </data>
+  <data name="CompareBarCountFormat" xml:space="preserve">
+    <value>{0} selected</value>
+  </data>
+  <data name="CompareBarCta" xml:space="preserve">
+    <value>Compare</value>
+  </data>
 </root>

--- a/Resources/Pages.Courses.Index.cshtml.resx
+++ b/Resources/Pages.Courses.Index.cshtml.resx
@@ -39,4 +39,10 @@
   <data name="Next" xml:space="preserve">
     <value>Další</value>
   </data>
+  <data name="CompareBarCountFormat" xml:space="preserve">
+    <value>{0} vybráno</value>
+  </data>
+  <data name="CompareBarCta" xml:space="preserve">
+    <value>Porovnat</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add IViewLocalizer/IStringLocalizer usage to course detail, calendar, compare, and course term detail pages
- refactor the course comparison bar to source localized strings from resources and data attributes
- create Czech and English resource files covering the new UI copy across the affected pages

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbed559af4832189e8c7ca97a06ec1