### PR TITLE
Localize key Razor pages for CZ/EN support

### DIFF
--- a/Pages/Articles/Details.cshtml
+++ b/Pages/Articles/Details.cshtml
@@ -1,11 +1,20 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Articles.DetailsModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = Model.Article?.Title;
+    ViewData["Title"] = Model.Article?.Title ?? Localizer["Title"];
 }
 
-<h1>@Model.Article?.Title</h1>
+@if (Model.Article is not null)
+{
+    <h1>@Model.Article.Title</h1>
 
-<p>@Model.Article?.Content</p>
+    <p>@Model.Article.Content</p>
 
-<p><small>@Model.Article?.CreatedAt.ToString("g")</small></p>
+    <p><small>@Localizer["PublishedOn", Model.Article.CreatedAt.ToString("g")]</small></p>
+}
+else
+{
+    <h1>@Localizer["Title"]</h1>
+    <p>@Localizer["NotFound"]</p>
+}

--- a/Pages/Articles/Index.cshtml
+++ b/Pages/Articles/Index.cshtml
@@ -1,13 +1,14 @@
 @page
 @model SysJaky_N.Pages.Articles.IndexModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = "Articles";
+    ViewData["Title"] = Localizer["Title"];
 }
 
-<h1>Articles</h1>
-<form method="get" class="mb-3" role="search" aria-label="Vyhledávání článků">
-    <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" style="width:auto;display:inline-block" aria-label="Hledat články" />
-    <button type="submit" class="btn btn-primary">Search</button>
+<h1>@Localizer["Heading"]</h1>
+<form method="get" class="mb-3" role="search" aria-label="@Localizer["SearchAriaLabel"]">
+    <input type="text" asp-for="SearchString" placeholder="@Localizer["SearchPlaceholder"]" class="form-control" style="width:auto;display:inline-block" aria-label="@Localizer["SearchInputAriaLabel"]" />
+    <button type="submit" class="btn btn-primary">@Localizer["SearchButton"]</button>
 </form>
 
 <ul>
@@ -21,13 +22,13 @@
 
 @if (Model.TotalPages > 1)
 {
-    <nav aria-label="Stránkování článků">
+    <nav aria-label="@Localizer["PaginationAriaLabel"]">
         <ul class="pagination">
             <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-SearchString="@Model.SearchString">Previous</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-SearchString="@Model.SearchString">@Localizer["Previous"]</a>
             </li>
             <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-SearchString="@Model.SearchString">Next</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-SearchString="@Model.SearchString">@Localizer["Next"]</a>
             </li>
         </ul>
     </nav>

--- a/Pages/Error.cshtml
+++ b/Pages/Error.cshtml
@@ -1,24 +1,24 @@
 ﻿@page
 @model ErrorModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = "Došlo k chybě";
+    ViewData["Title"] = Localizer["Title"];
 }
 
 <section class="error-page">
-    <h1 class="text-danger">Omlouváme se, něco se pokazilo.</h1>
+    <h1 class="text-danger">@Localizer["Heading"]</h1>
     <p>
-        Zkuste prosím akci zopakovat o něco později. Pokud problém přetrvává, kontaktujte naši podporu
-        a uveďte uvedené korelační ID, aby bylo možné požadavek rychle dohledat.
+        @Localizer["Description"]
     </p>
 
     @if (Model.ShowRequestId)
     {
         <p>
-            <strong>Korelační ID:</strong> <code>@Model.RequestId</code>
+            <strong>@Localizer["CorrelationIdLabel"]</strong> <code>@Model.RequestId</code>
         </p>
     }
 
     <p>
-        Děkujeme za pochopení.
+        @Localizer["SignOff"]
     </p>
 </section>

--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -2,38 +2,38 @@
 @model IndexModel
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = Localizer["Title"];
 }
 
 <section class="py-5 gradient-hero text-white text-center rounded-4 mb-4">
     <div class="container-xl">
-        <h1 class="display-5 fw-bold mb-2">Najděte školení, které <span class="underline-accent">sedne vašemu cíli</span></h1>
-        <p class="lead mb-4 opacity-75">Vyberte roli a cíl – my zúžíme výběr. Nebo rovnou hledejte.</p>
+        <h1 class="display-5 fw-bold mb-2">@Localizer["HeroHeadingPrefix"] <span class="underline-accent">@Localizer["HeroHeadingAccent"]</span></h1>
+        <p class="lead mb-4 opacity-75">@Localizer["HeroSubheading"]</p>
 
         <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm">
             <div class="col-12 col-md-3">
-                <select name="persona" class="form-select" aria-label="Jsem" persona-options></select>
+                <select name="persona" class="form-select" aria-label="@Localizer["PersonaAriaLabel"]" persona-options></select>
             </div>
             <div class="col-12 col-md-3">
-                <select name="goal" class="form-select" aria-label="Chci" goal-options></select>
+                <select name="goal" class="form-select" aria-label="@Localizer["GoalAriaLabel"]" goal-options></select>
             </div>
             <div class="col-12 col-md-4">
                 <div class="input-group">
                     <span class="input-group-text"><i class="bi bi-search"></i></span>
-                    <input name="q" class="form-control" placeholder="Hledat kurz, nástroj nebo dovednost…" />
+                    <input name="q" class="form-control" placeholder="@Localizer["HeroSearchPlaceholder"]" />
                 </div>
             </div>
             <div class="col-12 col-md-2 d-grid">
-                <button class="btn btn-light fw-semibold" type="submit">Navrhnout kurzy</button>
+                <button class="btn btn-light fw-semibold" type="submit">@Localizer["HeroSubmit"]</button>
             </div>
         </form>
 
         <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
-            <a class="chip chip-light" href="/Courses/Index?Mode=Online">Online</a>
-            <a class="chip chip-light" href="/Courses/Index?CourseGroupId=REKVAL">Rekvalifikace</a>
-            <a class="chip chip-light" href="/Courses/Index?Level=Beginner">Začátečník</a>
-            <a class="chip chip-light" href="/Courses/Index?City=Praha">Praha</a>
-            <a class="chip chip-light" href="/Courses/Index?HasCertificate=true">S certifikátem</a>
+            <a class="chip chip-light" href="/Courses/Index?Mode=Online">@Localizer["ChipOnline"]</a>
+            <a class="chip chip-light" href="/Courses/Index?CourseGroupId=REKVAL">@Localizer["ChipRetraining"]</a>
+            <a class="chip chip-light" href="/Courses/Index?Level=Beginner">@Localizer["ChipBeginner"]</a>
+            <a class="chip chip-light" href="/Courses/Index?City=Praha">@Localizer["ChipPrague"]</a>
+            <a class="chip chip-light" href="/Courses/Index?HasCertificate=true">@Localizer["ChipCertificate"]</a>
         </div>
     </div>
 </section>
@@ -44,25 +44,25 @@
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-star-fill"></i>
-                    <span>Hodnocení 4.8/5</span>
+                    <span>@Localizer["TrustRating", "4.8/5"]</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-people"></i>
-                    <span>10 000+ absolventů</span>
+                    <span>@Localizer["TrustGraduates", "10 000+"]</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-shield-check"></i>
-                    <span>Garance spokojenosti / snadné storno</span>
+                    <span>@Localizer["TrustGuarantee"]</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-patch-check"></i>
-                    <span>Certifikát v ceně vybraných kurzů</span>
+                    <span>@Localizer["TrustCertificate"]</span>
                 </div>
             </div>
         </div>
@@ -89,8 +89,8 @@
     <div class="col-lg-8">
       <div class="feature-card h-100 p-3">
         <div class="d-flex justify-content-between align-items-center mb-2">
-          <h2 class="h5 mb-0">Doporučeno pro vás</h2>
-          <a class="btn btn-sm btn-outline-secondary" href="/Courses/Index">Zobrazit vše</a>
+          <h2 class="h5 mb-0">@Localizer["RecommendedForYou"]</h2>
+          <a class="btn btn-sm btn-outline-secondary" href="/Courses/Index">@Localizer["RecommendedViewAll"]</a>
         </div>
         <div class="row g-3">
           @foreach (var c in Model.PicksForPersona)
@@ -101,7 +101,7 @@
           }
           @if (!Model.PicksForPersona.Any())
           {
-            <div class="col-12 text-muted">Vyberte nahoře „Jsem… / Chci…“, nebo použijte vyhledávání.</div>
+            <div class="col-12 text-muted">@Localizer["RecommendedEmpty"]</div>
           }
         </div>
       </div>
@@ -109,7 +109,7 @@
 
     <div class="col-lg-4">
       <div class="feature-card h-100 p-3">
-        <h2 class="h6">Co startuje nejdřív</h2>
+        <h2 class="h6">@Localizer["StartingSoon"]</h2>
         <ul class="list-unstyled small mb-3">
           @foreach (var c in Model.FastSoonest)
           {
@@ -119,7 +119,7 @@
             </li>
           }
         </ul>
-        <a class="btn btn-outline-primary btn-sm" href="/Courses/Calendar"><i class="bi bi-calendar3"></i> Kalendář termínů</a>
+        <a class="btn btn-outline-primary btn-sm" href="/Courses/Calendar"><i class="bi bi-calendar3"></i> @Localizer["CalendarButton"]</a>
       </div>
     </div>
   </div>
@@ -127,7 +127,7 @@
   <div class="row g-3 mt-1">
     <div class="col-12">
       <div class="feature-card p-3">
-        <h2 class="h6 mb-2">Novinky</h2>
+        <h2 class="h6 mb-2">@Localizer["NewsHeading"]</h2>
         <div class="d-flex flex-wrap gap-3">
           @foreach (var a in Model.FreshNews)
           {
@@ -176,8 +176,8 @@
 
 <section class="app-section app-section-alt">
     <div class="container-xl text-center">
-        <h2 class="section-title mb-3">Why Choose Our Platform?</h2>
-        <p class="mx-auto app-section-description">Our courses are crafted by experts and delivered in an accessible format that helps you learn quickly and effectively.</p>
+        <h2 class="section-title mb-3">@Localizer["WhyChooseHeading"]</h2>
+        <p class="mx-auto app-section-description">@Localizer["WhyChooseDescription"]</p>
     </div>
 </section>
 

--- a/Pages/Instructor/Attendance.cshtml
+++ b/Pages/Instructor/Attendance.cshtml
@@ -1,21 +1,23 @@
 @page
 @model SysJaky_N.Pages.Instructor.AttendanceModel
+@using System.Text.Json
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = "Attendance check-in";
+    ViewData["Title"] = Localizer["Title"];
 }
 
-<h1 class="mb-4">Attendance check-in</h1>
-<p class="text-muted">Scan a QR code or enter a code manually to mark a participant as present.</p>
+<h1 class="mb-4">@Localizer["Heading"]</h1>
+<p class="text-muted">@Localizer["Intro"]</p>
 
 <div class="row g-4">
     <div class="col-lg-6">
         <div class="card h-100">
             <div class="card-header">
-                Scan QR code
+                @Localizer["ScanQr"]
             </div>
             <div class="card-body">
                 <div id="qr-reader" class="border rounded position-relative" style="min-height: 320px;">
-                    <div id="qr-reader-placeholder" class="position-absolute top-50 start-50 translate-middle text-muted">Camera initialising…</div>
+                    <div id="qr-reader-placeholder" class="position-absolute top-50 start-50 translate-middle text-muted">@Localizer["PlaceholderCameraInitialising"]</div>
                 </div>
                 <div id="qr-reader-error" class="alert alert-warning mt-3 d-none" role="alert"></div>
             </div>
@@ -24,30 +26,30 @@
     <div class="col-lg-6">
         <div class="card h-100">
             <div class="card-header">
-                Manual entry
+                @Localizer["ManualEntry"]
             </div>
             <div class="card-body">
                 <form id="manual-form" class="mb-3" autocomplete="off">
-                    <label for="manualCode" class="form-label">Enrollment code</label>
+                    <label for="manualCode" class="form-label">@Localizer["ManualCodeLabel"]</label>
                     <input type="text" id="manualCode" class="form-control" autocomplete="off" />
-                    <div class="form-text">Enter the numeric enrollment ID or a code containing it (for example, <code>enrollment=123</code>).</div>
-                    <button type="submit" class="btn btn-primary mt-3">Check in</button>
+                    <div class="form-text">@Html.Raw(Localizer["ManualHelper", "<code>enrollment=123</code>"].Value)</div>
+                    <button type="submit" class="btn btn-primary mt-3">@Localizer["ManualSubmit"]</button>
                 </form>
                 <div id="result" class="alert d-none" role="alert"></div>
                 <div id="details" class="card d-none">
                     <div class="card-body">
                         <dl class="row mb-0">
-                            <dt class="col-sm-4">Enrollment ID</dt>
+                            <dt class="col-sm-4">@Localizer["DetailEnrollmentId"]</dt>
                             <dd class="col-sm-8" id="detail-enrollment-id"></dd>
-                            <dt class="col-sm-4">Participant</dt>
+                            <dt class="col-sm-4">@Localizer["DetailParticipant"]</dt>
                             <dd class="col-sm-8" id="detail-participant"></dd>
-                            <dt class="col-sm-4">Course</dt>
+                            <dt class="col-sm-4">@Localizer["DetailCourse"]</dt>
                             <dd class="col-sm-8" id="detail-course"></dd>
-                            <dt class="col-sm-4">Term start</dt>
+                            <dt class="col-sm-4">@Localizer["DetailTermStart"]</dt>
                             <dd class="col-sm-8" id="detail-term-start"></dd>
-                            <dt class="col-sm-4">Term end</dt>
+                            <dt class="col-sm-4">@Localizer["DetailTermEnd"]</dt>
                             <dd class="col-sm-8" id="detail-term-end"></dd>
-                            <dt class="col-sm-4">Checked in at</dt>
+                            <dt class="col-sm-4">@Localizer["DetailCheckedIn"]</dt>
                             <dd class="col-sm-8" id="detail-checked-in"></dd>
                         </dl>
                     </div>
@@ -82,6 +84,19 @@
                 termStartEl.textContent = '';
                 termEndEl.textContent = '';
                 checkedInEl.textContent = '';
+            };
+
+            const resources = {
+                messageCheckedIn: @Html.Raw(JsonSerializer.Serialize(Localizer["MessageCheckedIn"].Value)),
+                messageAlreadyCheckedIn: @Html.Raw(JsonSerializer.Serialize(Localizer["MessageAlreadyCheckedIn"].Value)),
+                messageAttendanceFailed: @Html.Raw(JsonSerializer.Serialize(Localizer["MessageAttendanceFailed"].Value)),
+                messageMissingCode: @Html.Raw(JsonSerializer.Serialize(Localizer["MessageMissingCode"].Value)),
+                messageUnexpected: @Html.Raw(JsonSerializer.Serialize(Localizer["MessageUnexpected"].Value)),
+                logParseError: @Html.Raw(JsonSerializer.Serialize(Localizer["LogParseError"].Value)),
+                errorCameraAccess: @Html.Raw(JsonSerializer.Serialize(Localizer["ErrorCameraAccess"].Value)),
+                errorCameraInit: @Html.Raw(JsonSerializer.Serialize(Localizer["ErrorCameraInit"].Value)),
+                errorQrUnavailable: @Html.Raw(JsonSerializer.Serialize(Localizer["ErrorQrUnavailable"].Value)),
+                errorQrUnsupported: @Html.Raw(JsonSerializer.Serialize(Localizer["ErrorQrUnsupported"].Value))
             };
 
             const showResult = (type, message, details) => {
@@ -119,10 +134,10 @@
             const processResponse = payload => {
                 const { status, checkedInAtUtc, enrollment } = payload ?? {};
                 const messages = {
-                    'checked-in': 'Attendance recorded.',
-                    'already-checked-in': 'This enrollment was already checked in.'
+                    'checked-in': resources.messageCheckedIn,
+                    'already-checked-in': resources.messageAlreadyCheckedIn
                 };
-                const message = messages[status] ?? 'Attendance recorded.';
+                const message = messages[status] ?? resources.messageCheckedIn;
 
                 showResult('alert-success', message, {
                     enrollmentId: enrollment?.id,
@@ -135,14 +150,14 @@
             };
 
             const handleErrorResponse = async response => {
-                let message = 'Attendance could not be recorded.';
+                let message = resources.messageAttendanceFailed;
                 try {
                     const data = await response.json();
                     if (data?.message) {
                         message = data.message;
                     }
                 } catch (err) {
-                    console.warn('Unable to parse error response.', err);
+                    console.warn(resources.logParseError, err);
                 }
 
                 showResult('alert-danger', message);
@@ -150,7 +165,7 @@
 
             const submitCode = async code => {
                 if (!code) {
-                    showResult('alert-warning', 'Please provide a code to check in.');
+                    showResult('alert-warning', resources.messageMissingCode);
                     return;
                 }
 
@@ -172,7 +187,7 @@
                     }
                 } catch (err) {
                     console.error('Check-in request failed.', err);
-                    showResult('alert-danger', 'An unexpected error occurred while recording attendance.');
+                    showResult('alert-danger', resources.messageUnexpected);
                 }
             };
 
@@ -213,19 +228,19 @@
                     .catch(error => {
                         console.error('Unable to start QR scanner.', error);
                         if (placeholder) {
-                            placeholder.textContent = 'Unable to access the camera.';
+                            placeholder.textContent = resources.errorCameraAccess;
                         }
                         if (qrError) {
-                            qrError.textContent = (error && error.message) ? error.message : 'Camera initialisation failed.';
+                            qrError.textContent = (error && error.message) ? error.message : resources.errorCameraInit;
                             qrError.classList.remove('d-none');
                         }
                     });
             } else {
                 if (placeholder) {
-                    placeholder.textContent = 'QR scanning library is unavailable.';
+                    placeholder.textContent = resources.errorQrUnavailable;
                 }
                 if (qrError) {
-                    qrError.textContent = 'QR scanning is not supported in this browser.';
+                    qrError.textContent = resources.errorQrUnsupported;
                     qrError.classList.remove('d-none');
                 }
             }

--- a/Resources/Pages.Articles.Details.cshtml.en.resx
+++ b/Resources/Pages.Articles.Details.cshtml.en.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NotFound" xml:space="preserve">
+    <value>The requested article could not be found.</value>
+  </data>
+  <data name="PublishedOn" xml:space="preserve">
+    <value>Published on {0}</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Article</value>
+  </data>
+</root>

--- a/Resources/Pages.Articles.Details.cshtml.resx
+++ b/Resources/Pages.Articles.Details.cshtml.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NotFound" xml:space="preserve">
+    <value>Požadovaný článek nebyl nalezen.</value>
+  </data>
+  <data name="PublishedOn" xml:space="preserve">
+    <value>Publikováno {0}</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Článek</value>
+  </data>
+</root>

--- a/Resources/Pages.Articles.Index.cshtml.en.resx
+++ b/Resources/Pages.Articles.Index.cshtml.en.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Articles</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="PaginationAriaLabel" xml:space="preserve">
+    <value>Articles pagination</value>
+  </data>
+  <data name="Previous" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="SearchAriaLabel" xml:space="preserve">
+    <value>Search articles</value>
+  </data>
+  <data name="SearchButton" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="SearchInputAriaLabel" xml:space="preserve">
+    <value>Search articles</value>
+  </data>
+  <data name="SearchPlaceholder" xml:space="preserve">
+    <value>Search…</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Articles</value>
+  </data>
+</root>

--- a/Resources/Pages.Articles.Index.cshtml.resx
+++ b/Resources/Pages.Articles.Index.cshtml.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Články</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Další</value>
+  </data>
+  <data name="PaginationAriaLabel" xml:space="preserve">
+    <value>Stránkování článků</value>
+  </data>
+  <data name="Previous" xml:space="preserve">
+    <value>Předchozí</value>
+  </data>
+  <data name="SearchAriaLabel" xml:space="preserve">
+    <value>Vyhledávání článků</value>
+  </data>
+  <data name="SearchButton" xml:space="preserve">
+    <value>Hledat</value>
+  </data>
+  <data name="SearchInputAriaLabel" xml:space="preserve">
+    <value>Hledat články</value>
+  </data>
+  <data name="SearchPlaceholder" xml:space="preserve">
+    <value>Hledat…</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Články</value>
+  </data>
+</root>

--- a/Resources/Pages.Error.cshtml.en.resx
+++ b/Resources/Pages.Error.cshtml.en.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CorrelationIdLabel" xml:space="preserve">
+    <value>Correlation ID:</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Please try again in a moment. If the problem persists, contact our support team and include the correlation ID so we can locate your request quickly.</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>We're sorry, something went wrong.</value>
+  </data>
+  <data name="SignOff" xml:space="preserve">
+    <value>Thank you for your understanding.</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>An error occurred</value>
+  </data>
+</root>

--- a/Resources/Pages.Error.cshtml.resx
+++ b/Resources/Pages.Error.cshtml.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CorrelationIdLabel" xml:space="preserve">
+    <value>Korelační ID:</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Zkuste prosím akci zopakovat o něco později. Pokud problém přetrvává, kontaktujte naši podporu a uveďte uvedené korelační ID, aby bylo možné požadavek rychle dohledat.</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>Omlouváme se, něco se pokazilo.</value>
+  </data>
+  <data name="SignOff" xml:space="preserve">
+    <value>Děkujeme za pochopení.</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Došlo k chybě</value>
+  </data>
+</root>

--- a/Resources/Pages.Index.cshtml.en.resx
+++ b/Resources/Pages.Index.cshtml.en.resx
@@ -18,8 +18,26 @@
   <data name="HeroDescription" xml:space="preserve">
     <value>Professional courses and training for your company.</value>
   </data>
+  <data name="HeroHeadingAccent" xml:space="preserve">
+    <value>match your goals</value>
+  </data>
+  <data name="HeroHeadingPrefix" xml:space="preserve">
+    <value>Find training that will</value>
+  </data>
+  <data name="HeroSearchPlaceholder" xml:space="preserve">
+    <value>Search for a course, tool, or skill…</value>
+  </data>
+  <data name="HeroSubheading" xml:space="preserve">
+    <value>Pick your role and goal — we will narrow the list for you. Or just start searching.</value>
+  </data>
+  <data name="HeroSubmit" xml:space="preserve">
+    <value>Suggest courses</value>
+  </data>
   <data name="HowItWorksTitle" xml:space="preserve">
     <value>How it works</value>
+  </data>
+  <data name="PersonaAriaLabel" xml:space="preserve">
+    <value>I am</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Select a course</value>
@@ -38,5 +56,62 @@
   </data>
   <data name="StepPayDescription" xml:space="preserve">
     <value>Secure online payment reserves your spot.</value>
+  </data>
+  <data name="CalendarButton" xml:space="preserve">
+    <value>Course calendar</value>
+  </data>
+  <data name="ChipBeginner" xml:space="preserve">
+    <value>Beginner</value>
+  </data>
+  <data name="ChipCertificate" xml:space="preserve">
+    <value>With certificate</value>
+  </data>
+  <data name="ChipOnline" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="ChipPrague" xml:space="preserve">
+    <value>Prague</value>
+  </data>
+  <data name="ChipRetraining" xml:space="preserve">
+    <value>Retraining</value>
+  </data>
+  <data name="GoalAriaLabel" xml:space="preserve">
+    <value>I want to</value>
+  </data>
+  <data name="NewsHeading" xml:space="preserve">
+    <value>News</value>
+  </data>
+  <data name="RecommendedEmpty" xml:space="preserve">
+    <value>Select “I am… / I want to…” above or use the search field.</value>
+  </data>
+  <data name="RecommendedForYou" xml:space="preserve">
+    <value>Recommended for you</value>
+  </data>
+  <data name="RecommendedViewAll" xml:space="preserve">
+    <value>View all</value>
+  </data>
+  <data name="StartingSoon" xml:space="preserve">
+    <value>Starting soon</value>
+  </data>
+  <data name="TrustCertificate" xml:space="preserve">
+    <value>Certificates included with selected courses</value>
+  </data>
+  <data name="TrustGraduates" xml:space="preserve">
+    <value>{0} graduates</value>
+  </data>
+  <data name="TrustGuarantee" xml:space="preserve">
+    <value>Satisfaction guarantee / easy cancellation</value>
+  </data>
+  <data name="TrustRating" xml:space="preserve">
+    <value>Rating {0}</value>
+  </data>
+  <data name="WhyChooseDescription" xml:space="preserve">
+    <value>Our courses are crafted by experts and delivered in a practical format that helps you learn quickly and effectively.</value>
+  </data>
+  <data name="WhyChooseHeading" xml:space="preserve">
+    <value>Why choose our platform?</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Home</value>
   </data>
 </root>

--- a/Resources/Pages.Index.cshtml.resx
+++ b/Resources/Pages.Index.cshtml.resx
@@ -18,8 +18,26 @@
   <data name="HeroDescription" xml:space="preserve">
     <value>Profesionální kurzy a školení pro vaši firmu.</value>
   </data>
+  <data name="HeroHeadingAccent" xml:space="preserve">
+    <value>sedne vašemu cíli</value>
+  </data>
+  <data name="HeroHeadingPrefix" xml:space="preserve">
+    <value>Najděte školení, které</value>
+  </data>
+  <data name="HeroSearchPlaceholder" xml:space="preserve">
+    <value>Hledat kurz, nástroj nebo dovednost…</value>
+  </data>
+  <data name="HeroSubheading" xml:space="preserve">
+    <value>Vyberte roli a cíl – my zúžíme výběr. Nebo rovnou hledejte.</value>
+  </data>
+  <data name="HeroSubmit" xml:space="preserve">
+    <value>Navrhnout kurzy</value>
+  </data>
   <data name="HowItWorksTitle" xml:space="preserve">
     <value>Jak to funguje</value>
+  </data>
+  <data name="PersonaAriaLabel" xml:space="preserve">
+    <value>Jsem</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Vyberte kurz</value>
@@ -38,5 +56,62 @@
   </data>
   <data name="StepPayDescription" xml:space="preserve">
     <value>Bezpečná online platba zajistí vaše místo na kurzu.</value>
+  </data>
+  <data name="CalendarButton" xml:space="preserve">
+    <value>Kalendář termínů</value>
+  </data>
+  <data name="ChipBeginner" xml:space="preserve">
+    <value>Začátečník</value>
+  </data>
+  <data name="ChipCertificate" xml:space="preserve">
+    <value>S certifikátem</value>
+  </data>
+  <data name="ChipOnline" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="ChipPrague" xml:space="preserve">
+    <value>Praha</value>
+  </data>
+  <data name="ChipRetraining" xml:space="preserve">
+    <value>Rekvalifikace</value>
+  </data>
+  <data name="GoalAriaLabel" xml:space="preserve">
+    <value>Chci</value>
+  </data>
+  <data name="NewsHeading" xml:space="preserve">
+    <value>Novinky</value>
+  </data>
+  <data name="RecommendedEmpty" xml:space="preserve">
+    <value>Vyberte nahoře „Jsem… / Chci…“, nebo použijte vyhledávání.</value>
+  </data>
+  <data name="RecommendedForYou" xml:space="preserve">
+    <value>Doporučeno pro vás</value>
+  </data>
+  <data name="RecommendedViewAll" xml:space="preserve">
+    <value>Zobrazit vše</value>
+  </data>
+  <data name="StartingSoon" xml:space="preserve">
+    <value>Co startuje nejdřív</value>
+  </data>
+  <data name="TrustCertificate" xml:space="preserve">
+    <value>Certifikát v ceně vybraných kurzů</value>
+  </data>
+  <data name="TrustGraduates" xml:space="preserve">
+    <value>{0} absolventů</value>
+  </data>
+  <data name="TrustGuarantee" xml:space="preserve">
+    <value>Garance spokojenosti / snadné storno</value>
+  </data>
+  <data name="TrustRating" xml:space="preserve">
+    <value>Hodnocení {0}</value>
+  </data>
+  <data name="WhyChooseDescription" xml:space="preserve">
+    <value>Naše kurzy připravují odborníci a předáváme je v praktické formě, která pomáhá učit se rychle a efektivně.</value>
+  </data>
+  <data name="WhyChooseHeading" xml:space="preserve">
+    <value>Proč si vybrat naši platformu?</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Domů</value>
   </data>
 </root>

--- a/Resources/Pages.Instructor.Attendance.cshtml.en.resx
+++ b/Resources/Pages.Instructor.Attendance.cshtml.en.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DetailCheckedIn" xml:space="preserve">
+    <value>Checked in at</value>
+  </data>
+  <data name="DetailCourse" xml:space="preserve">
+    <value>Course</value>
+  </data>
+  <data name="DetailEnrollmentId" xml:space="preserve">
+    <value>Enrollment ID</value>
+  </data>
+  <data name="DetailParticipant" xml:space="preserve">
+    <value>Participant</value>
+  </data>
+  <data name="DetailTermEnd" xml:space="preserve">
+    <value>Term end</value>
+  </data>
+  <data name="DetailTermStart" xml:space="preserve">
+    <value>Term start</value>
+  </data>
+  <data name="ErrorCameraAccess" xml:space="preserve">
+    <value>Unable to access the camera.</value>
+  </data>
+  <data name="ErrorCameraInit" xml:space="preserve">
+    <value>Camera initialisation failed.</value>
+  </data>
+  <data name="ErrorQrUnavailable" xml:space="preserve">
+    <value>QR scanning library is unavailable.</value>
+  </data>
+  <data name="ErrorQrUnsupported" xml:space="preserve">
+    <value>QR scanning is not supported in this browser.</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>Attendance check-in</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Scan a QR code or enter a code manually to mark a participant as present.</value>
+  </data>
+  <data name="LogParseError" xml:space="preserve">
+    <value>Unable to parse error response.</value>
+  </data>
+  <data name="ManualCodeLabel" xml:space="preserve">
+    <value>Enrollment code</value>
+  </data>
+  <data name="ManualEntry" xml:space="preserve">
+    <value>Manual entry</value>
+  </data>
+  <data name="ManualHelper" xml:space="preserve">
+    <value>Enter the numeric enrollment ID or a code containing it (for example, {0}).</value>
+  </data>
+  <data name="ManualSubmit" xml:space="preserve">
+    <value>Check in</value>
+  </data>
+  <data name="MessageAlreadyCheckedIn" xml:space="preserve">
+    <value>This enrollment was already checked in.</value>
+  </data>
+  <data name="MessageAttendanceFailed" xml:space="preserve">
+    <value>Attendance could not be recorded.</value>
+  </data>
+  <data name="MessageCheckedIn" xml:space="preserve">
+    <value>Attendance recorded.</value>
+  </data>
+  <data name="MessageMissingCode" xml:space="preserve">
+    <value>Please provide a code to check in.</value>
+  </data>
+  <data name="MessageUnexpected" xml:space="preserve">
+    <value>An unexpected error occurred while recording attendance.</value>
+  </data>
+  <data name="PlaceholderCameraInitialising" xml:space="preserve">
+    <value>Camera initialising…</value>
+  </data>
+  <data name="ScanQr" xml:space="preserve">
+    <value>Scan QR code</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Attendance check-in</value>
+  </data>
+</root>

--- a/Resources/Pages.Instructor.Attendance.cshtml.resx
+++ b/Resources/Pages.Instructor.Attendance.cshtml.resx
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DetailCheckedIn" xml:space="preserve">
+    <value>Zapsáno v</value>
+  </data>
+  <data name="DetailCourse" xml:space="preserve">
+    <value>Kurz</value>
+  </data>
+  <data name="DetailEnrollmentId" xml:space="preserve">
+    <value>ID přihlášky</value>
+  </data>
+  <data name="DetailParticipant" xml:space="preserve">
+    <value>Účastník</value>
+  </data>
+  <data name="DetailTermEnd" xml:space="preserve">
+    <value>Konec termínu</value>
+  </data>
+  <data name="DetailTermStart" xml:space="preserve">
+    <value>Začátek termínu</value>
+  </data>
+  <data name="ErrorCameraAccess" xml:space="preserve">
+    <value>Kamera není dostupná.</value>
+  </data>
+  <data name="ErrorCameraInit" xml:space="preserve">
+    <value>Inicializace kamery selhala.</value>
+  </data>
+  <data name="ErrorQrUnavailable" xml:space="preserve">
+    <value>Knihovna pro čtení QR kódů není k dispozici.</value>
+  </data>
+  <data name="ErrorQrUnsupported" xml:space="preserve">
+    <value>QR kódy nejsou v tomto prohlížeči podporovány.</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>Označení docházky</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Skenujte QR kód nebo ručně zadejte kód a označte účastníka jako přítomného.</value>
+  </data>
+  <data name="LogParseError" xml:space="preserve">
+    <value>Nelze zpracovat odpověď s chybou.</value>
+  </data>
+  <data name="ManualCodeLabel" xml:space="preserve">
+    <value>Kód přihlášky</value>
+  </data>
+  <data name="ManualEntry" xml:space="preserve">
+    <value>Ruční zadání</value>
+  </data>
+  <data name="ManualHelper" xml:space="preserve">
+    <value>Zadejte číselné ID přihlášky nebo kód, který jej obsahuje (například {0}).</value>
+  </data>
+  <data name="ManualSubmit" xml:space="preserve">
+    <value>Zapsat docházku</value>
+  </data>
+  <data name="MessageAlreadyCheckedIn" xml:space="preserve">
+    <value>Tato přihláška již byla označena.</value>
+  </data>
+  <data name="MessageAttendanceFailed" xml:space="preserve">
+    <value>Docházku se nepodařilo zaznamenat.</value>
+  </data>
+  <data name="MessageCheckedIn" xml:space="preserve">
+    <value>Docházka zaznamenána.</value>
+  </data>
+  <data name="MessageMissingCode" xml:space="preserve">
+    <value>Zadejte kód pro označení docházky.</value>
+  </data>
+  <data name="MessageUnexpected" xml:space="preserve">
+    <value>Při záznamu docházky došlo k neočekávané chybě.</value>
+  </data>
+  <data name="PlaceholderCameraInitialising" xml:space="preserve">
+    <value>Inicializuji kameru…</value>
+  </data>
+  <data name="ScanQr" xml:space="preserve">
+    <value>Skenovat QR kód</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Docházka</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- wire `IViewLocalizer` into the home, articles, instructor attendance, and error Razor pages
- replace hard-coded UI strings with localized lookups for hero content, navigation, helper copy, and messaging
- add Czech and English resource files that translate headings, helper text, and validation feedback across the updated pages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfdabe10c83219885e0e79ad17852