### PR TITLE
Fix article details title localization fallback

### DIFF
--- a/Pages/Articles/Details.cshtml
+++ b/Pages/Articles/Details.cshtml
@@ -2,7 +2,7 @@
 @model SysJaky_N.Pages.Articles.DetailsModel
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = Model.Article?.Title ?? Localizer["Title"];
+    ViewData["Title"] = Model.Article?.Title ?? Localizer["Title"].Value;
 }
 
 @if (Model.Article is not null)


### PR DESCRIPTION
## Summary
- ensure the article details page sets the view title using a string value from the localizer

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1ccd1ea08321850e2615b2a35130