### PR TITLE
Fix EF design-time setup by adjusting services

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -66,7 +66,7 @@ try
         ConfigureApplicationDbContext(options));
 
     // --- Tichá továrna pro DB sink (žádné EF logy) ---
-    builder.Services.AddPooledDbContextFactory<ApplicationDbContext>(opt =>
+    builder.Services.AddDbContextFactory<ApplicationDbContext>(opt =>
         ConfigureApplicationDbContext(opt, quietLogging: true));
 
     // --- Serilog s možností vypnout DB sink přes DISABLE_DB_LOGS=1 ---
@@ -149,7 +149,7 @@ try
     builder.Services.Configure<PaymentGatewayOptions>(builder.Configuration.GetSection("PaymentGateway"));
     builder.Services.AddScoped<PaymentService>();
     builder.Services.AddSingleton<ICourseSearchOptionProvider, CourseSearchOptionProvider>();
-    builder.Services.AddSingleton<IConverter>(new SynchronizedConverter(new PdfTools()));
+    builder.Services.AddSingleton<IConverter>(sp => new SynchronizedConverter(new PdfTools()));
     builder.Services.AddSingleton<IRazorLightEngine>(sp =>
     {
         var environment = sp.GetRequiredService<IHostEnvironment>();


### PR DESCRIPTION
## Summary
- register the DinkToPdf converter through a factory delegate so the native library is loaded lazily
- replace the pooled DbContext factory with a regular factory to avoid scoped option validation issues during design-time

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d946d308321b34203d8979e2b6f