### PR TITLE
Fix DbContextFactory lifetime conflict for logging sink

### DIFF
--- a/Data/DelegateDbContextFactory.cs
+++ b/Data/DelegateDbContextFactory.cs
@@ -1,0 +1,15 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace SysJaky_N.Data;
+
+internal sealed class DelegateDbContextFactory<TContext> : IDbContextFactory<TContext>
+    where TContext : DbContext
+{
+    private readonly Func<TContext> _factory;
+
+    public DelegateDbContextFactory(Func<TContext> factory)
+        => _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+
+    public TContext CreateDbContext() => _factory();
+}

--- a/Program.cs
+++ b/Program.cs
@@ -66,8 +66,13 @@ try
         ConfigureApplicationDbContext(options));
 
     // --- Tichá továrna pro DB sink (žádné EF logy) ---
-    builder.Services.AddDbContextFactory<ApplicationDbContext>(opt =>
-        ConfigureApplicationDbContext(opt, quietLogging: true));
+    builder.Services.AddSingleton<IDbContextFactory<ApplicationDbContext>>(_ =>
+        new DelegateDbContextFactory<ApplicationDbContext>(() =>
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            ConfigureApplicationDbContext(optionsBuilder, quietLogging: true);
+            return new ApplicationDbContext(optionsBuilder.Options);
+        }));
 
     // --- Serilog s možností vypnout DB sink přes DISABLE_DB_LOGS=1 ---
     builder.Host.UseSerilog((context, services, configuration) =>


### PR DESCRIPTION
## Summary
- replace AddDbContextFactory registration with a custom delegate-based factory to avoid lifetime conflicts
- add a reusable DelegateDbContextFactory helper for creating quiet ApplicationDbContext instances used by the logging sink

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc1ec43168832184d57bc123b25c3c