### PR TITLE
Simplify design-time DbContext factory

### DIFF
--- a/Data/ApplicationDbContextFactory.cs
+++ b/Data/ApplicationDbContextFactory.cs
@@ -1,8 +1,6 @@
 using System;
-using System.IO;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
-using Microsoft.Extensions.Configuration;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 namespace SysJaky_N.Data;
@@ -11,22 +9,8 @@ public sealed class ApplicationDbContextFactory : IDesignTimeDbContextFactory<Ap
 {
     public ApplicationDbContext CreateDbContext(string[] args)
     {
-        var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
-        var basePath = Directory.GetCurrentDirectory();
-
-        var configuration = new ConfigurationBuilder()
-            .SetBasePath(basePath)
-            .AddJsonFile("appsettings.json", optional: false)
-            .AddJsonFile($"appsettings.{environmentName}.json", optional: true)
-            .AddUserSecrets<Program>(optional: true)
-            .AddEnvironmentVariables()
-            .Build();
-
-        var connectionString = configuration.GetConnectionString("DefaultConnection");
-        if (string.IsNullOrWhiteSpace(connectionString))
-        {
-            throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
-        }
+        var connectionString = Environment.GetEnvironmentVariable("MIGRATIONS_CONNSTR")
+                              ?? "Server=localhost;Database=SysJaky_N;User=root;Password=Kocour07!;";
 
         var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
         optionsBuilder.UseMySql(connectionString, new MySqlServerVersion(new Version(8, 0, 36)));


### PR DESCRIPTION
## Summary
- simplify the design-time ApplicationDbContext factory to use an environment-provided connection string without building the full host
- configure the factory to fall back to the local MySQL development connection string when the environment variable is absent

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc2142a8388321bf4d4681618ce057