### PR TITLE
Fix admin form actions partial lookup

### DIFF
--- a/Pages/Admin/Articles/Create.cshtml
+++ b/Pages/Admin/Articles/Create.cshtml
@@ -8,7 +8,7 @@
 
 <form method="post">
     <partial name="_ArticleForm" for="Article" />
-    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to list" }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to list" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/Articles/Edit.cshtml
+++ b/Pages/Admin/Articles/Edit.cshtml
@@ -9,7 +9,7 @@
 <form method="post">
     <input type="hidden" asp-for="Article.Id" />
     <partial name="_ArticleForm" for="Article" />
-    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to list" }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to list" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseBlocks/Create.cshtml
+++ b/Pages/Admin/CourseBlocks/Create.cshtml
@@ -6,7 +6,7 @@
 <h1>Create Course Block</h1>
 <form method="post">
     <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
-    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", ShowCancel = false }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", ShowCancel = false }' />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseBlocks/Edit.cshtml
+++ b/Pages/Admin/CourseBlocks/Edit.cshtml
@@ -6,7 +6,7 @@
 <h1>Edit Course Block</h1>
 <form method="post">
     <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
-    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", ShowCancel = false }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", ShowCancel = false }' />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseGroups/Create.cshtml
+++ b/Pages/Admin/CourseGroups/Create.cshtml
@@ -8,7 +8,7 @@
 
 <form method="post">
     <partial name="_CourseGroupForm" for="CourseGroup" />
-    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to List" }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to List" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseGroups/Edit.cshtml
+++ b/Pages/Admin/CourseGroups/Edit.cshtml
@@ -9,7 +9,7 @@
 <form method="post">
     <input type="hidden" asp-for="CourseGroup.Id" />
     <partial name="_CourseGroupForm" for="CourseGroup" />
-    <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to List" }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to List" }' />
 </form>
 
 @section Scripts {

--- a/Pages/Admin/CourseTerms/Create.cshtml
+++ b/Pages/Admin/CourseTerms/Create.cshtml
@@ -12,7 +12,7 @@
     <partial name="_CourseTermForm" model="new SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel(Model.Input, Model.CourseOptions, Model.InstructorOptions)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/CourseTerms/Edit.cshtml
+++ b/Pages/Admin/CourseTerms/Edit.cshtml
@@ -19,7 +19,7 @@
     </div>
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Instructors/Create.cshtml
+++ b/Pages/Admin/Instructors/Create.cshtml
@@ -12,7 +12,7 @@
     <partial name="_InstructorForm" for="Instructor" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Instructors/Edit.cshtml
+++ b/Pages/Admin/Instructors/Edit.cshtml
@@ -13,7 +13,7 @@
     <partial name="_InstructorForm" for="Instructor" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/PriceSchedules/Create.cshtml
+++ b/Pages/Admin/PriceSchedules/Create.cshtml
@@ -12,7 +12,7 @@
     <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/PriceSchedules/Edit.cshtml
+++ b/Pages/Admin/PriceSchedules/Edit.cshtml
@@ -13,7 +13,7 @@
     <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Cancel" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Vouchers/Create.cshtml
+++ b/Pages/Admin/Vouchers/Create.cshtml
@@ -13,7 +13,7 @@
     <partial name="_VoucherForm" model="new SysJaky_N.Pages.Admin.Vouchers.VoucherFormModel(Model.Voucher, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to List" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Back to List" }' />
     </div>
 </form>
 

--- a/Pages/Admin/Vouchers/Edit.cshtml
+++ b/Pages/Admin/Vouchers/Edit.cshtml
@@ -19,7 +19,7 @@
     </div>
 
     <div class="mt-4">
-        <partial name="_FormActions" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to List" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Back to List" }' />
     </div>
 </form>
 


### PR DESCRIPTION
## Summary
- update admin Razor pages to reference the shared _FormActions partial by its absolute path so it can be resolved at runtime

## Testing
- dotnet build *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2519d6a08321b4072497b3ff5218