### PR TITLE
Fix footer overlapping action buttons

### DIFF
--- a/Pages/Shared/_Layout.cshtml.css
+++ b/Pages/Shared/_Layout.cshtml.css
@@ -40,9 +40,9 @@ button.accept-policy {
 }
 
 .footer {
-  position: absolute;
-  bottom: 0;
+  position: static;
   width: 100%;
-  white-space: nowrap;
-  line-height: 60px;
+  white-space: normal;
+  line-height: normal;
+  margin-top: auto;
 }


### PR DESCRIPTION
## Summary
- stop the layout footer from using absolute positioning so it no longer overlaps interactive content
- let the footer respect the page's flex layout and add auto top margin to keep it below the main content

## Testing
- Not run (dotnet CLI is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcd3b1da1883219883747d7b06087c