### PR TITLE
Translate admin layout navigation to Czech

### DIFF
--- a/Pages/Admin/Shared/FormActionsModel.cs
+++ b/Pages/Admin/Shared/FormActionsModel.cs
@@ -2,13 +2,13 @@ namespace SysJaky_N.Pages.Admin.Shared;
 
 public class FormActionsModel
 {
-    public string SubmitText { get; set; } = "Save";
+    public string SubmitText { get; set; } = "Uložit";
 
     public string SubmitCssClass { get; set; } = "btn btn-primary";
 
     public string CancelPage { get; set; } = "Index";
 
-    public string CancelText { get; set; } = "Cancel";
+    public string CancelText { get; set; } = "Zrušit";
 
     public string CancelCssClass { get; set; } = "btn btn-secondary";
 

--- a/Pages/Admin/_Layout.cshtml
+++ b/Pages/Admin/_Layout.cshtml
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="cs">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -19,56 +19,56 @@
             <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
                 <a class="d-flex align-items-center gap-2 text-decoration-none text-dark" asp-page="/Admin/Dashboard/Index">
                     <i class="bi bi-speedometer2 fs-4"></i>
-                    <span class="h4 mb-0">Admin Panel</span>
+                    <span class="h4 mb-0">Administrace</span>
                 </a>
                 <nav class="flex-grow-1">
                     <ul class="nav nav-tabs flex-wrap" role="tablist">
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Dashboard")" asp-page="/Admin/Dashboard/Index">Dashboard</a>
+                            <a class="nav-link @ActiveClass("/Admin/Dashboard")" asp-page="/Admin/Dashboard/Index">Přehled</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Users")" asp-page="/Admin/Users/Index">Users</a>
+                            <a class="nav-link @ActiveClass("/Admin/Users")" asp-page="/Admin/Users/Index">Uživatelé</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Courses")" asp-page="/Admin/Courses/Index">Courses</a>
+                            <a class="nav-link @ActiveClass("/Admin/Courses")" asp-page="/Admin/Courses/Index">Kurzy</a>
                         </li>
                         <li class="nav-item" role="presentation">
                             <a class="nav-link @ActiveClass("/Admin/CourseGroups")" asp-page="/Admin/CourseGroups/Index">Skupiny kurzů</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/CourseTerms")" asp-page="/Admin/CourseTerms/Index">Course Terms</a>
+                            <a class="nav-link @ActiveClass("/Admin/CourseTerms")" asp-page="/Admin/CourseTerms/Index">Termíny kurzů</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Instructors")" asp-page="/Admin/Instructors/Index">Instructors</a>
+                            <a class="nav-link @ActiveClass("/Admin/Instructors")" asp-page="/Admin/Instructors/Index">Lektoři</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/CourseBlocks")" asp-page="/Admin/CourseBlocks/Index">Course Blocks</a>
+                            <a class="nav-link @ActiveClass("/Admin/CourseBlocks")" asp-page="/Admin/CourseBlocks/Index">Bloky kurzů</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/PriceSchedules")" asp-page="/Admin/PriceSchedules/Index">Price Schedules</a>
+                            <a class="nav-link @ActiveClass("/Admin/PriceSchedules")" asp-page="/Admin/PriceSchedules/Index">Ceníky</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Vouchers")" asp-page="/Admin/Vouchers/Index">Vouchers</a>
+                            <a class="nav-link @ActiveClass("/Admin/Vouchers")" asp-page="/Admin/Vouchers/Index">Poukázky</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Orders")" asp-page="/Admin/Orders/Index">Orders</a>
+                            <a class="nav-link @ActiveClass("/Admin/Orders")" asp-page="/Admin/Orders/Index">Objednávky</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Companies")" asp-page="/Admin/Companies/Index">Companies</a>
+                            <a class="nav-link @ActiveClass("/Admin/Companies")" asp-page="/Admin/Companies/Index">Firmy</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/CourseReviews")" asp-page="/Admin/CourseReviews/Index">Course Reviews</a>
+                            <a class="nav-link @ActiveClass("/Admin/CourseReviews")" asp-page="/Admin/CourseReviews/Index">Hodnocení kurzů</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/Articles")" asp-page="/Admin/Articles/Index">Articles</a>
+                            <a class="nav-link @ActiveClass("/Admin/Articles")" asp-page="/Admin/Articles/Index">Články</a>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link @ActiveClass("/Admin/AuditLogs")" asp-page="/Admin/AuditLogs/Index">Audit Logs</a>
+                            <a class="nav-link @ActiveClass("/Admin/AuditLogs")" asp-page="/Admin/AuditLogs/Index">Auditní záznamy</a>
                         </li>
                     </ul>
                 </nav>
                 <div class="ms-lg-3">
-                    <a class="btn btn-outline-primary" asp-page="/Index">Back to site</a>
+                    <a class="btn btn-outline-primary" asp-page="/Index">Zpět na web</a>
                 </div>
             </div>
         </div>

--- a/Resources/Pages.Shared._Layout.cshtml.en.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.en.resx
@@ -37,7 +37,7 @@
     <value>Privacy</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">
-    <value>Admin dashboard</value>
+    <value>Administration</value>
   </data>
   <data name="AdvisorButton" xml:space="preserve">
     <value>Get advice</value>

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -37,7 +37,7 @@
     <value>Ochrana soukromí</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">
-    <value>Admin Dashboard</value>
+    <value>Administrace</value>
   </data>
   <data name="AdvisorButton" xml:space="preserve">
     <value>Poradit s výběrem</value>


### PR DESCRIPTION
## Summary
- translate the admin layout header, navigation, and language attribute to Czech terminology
- localize the default admin form action button labels to Czech
- update the shared layout resource value for the admin dashboard in Czech and English

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd93595ac8321a76ce9bdce3b4b3a