### PR TITLE
Remove duplicate admin form actions partial view

### DIFF
--- a/Pages/Admin/_FormActions.cshtml
+++ b/Pages/Admin/_FormActions.cshtml
@@ -1,9 +1,0 @@
-@model SysJaky_N.Pages.Admin.Shared.FormActionsModel
-
-<div class="d-flex gap-2">
-    <button type="submit" class="@Model.SubmitCssClass">@Model.SubmitText</button>
-    @if (Model.ShowCancel)
-    {
-        <a asp-page="@Model.CancelPage" class="@Model.CancelCssClass">@Model.CancelText</a>
-    }
-</div>


### PR DESCRIPTION
## Summary
- delete the redundant `Pages/Admin/_FormActions.cshtml` partial so admin pages rely on the shared implementation

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd97e3e7c8321971c3245e6053050