### PR TITLE
Lokalizovat administraci kurzů do češtiny

### DIFF
--- a/Models/CourseBlock.cs
+++ b/Models/CourseBlock.cs
@@ -6,14 +6,14 @@ public class CourseBlock
 {
     public int Id { get; set; }
 
-    [Required]
-    [StringLength(100)]
+    [Required(ErrorMessage = "Název je povinný.")]
+    [StringLength(100, ErrorMessage = "Název může mít nejvýše 100 znaků.")]
     public string Title { get; set; } = string.Empty;
 
-    [StringLength(1000)]
+    [StringLength(1000, ErrorMessage = "Popis může mít nejvýše 1000 znaků.")]
     public string? Description { get; set; }
 
-    [Range(0, double.MaxValue)]
+    [Range(0, double.MaxValue, ErrorMessage = "Cena musí být nezáporná.")]
     public decimal Price { get; set; }
 
     public ICollection<Course> Modules { get; set; } = new List<Course>();

--- a/Models/PriceSchedule.cs
+++ b/Models/PriceSchedule.cs
@@ -6,22 +6,22 @@ public class PriceSchedule
 {
     public int Id { get; set; }
 
-    [Required]
-    [Display(Name = "Course")]
+    [Required(ErrorMessage = "Kurz je povinný.")]
+    [Display(Name = "Kurz")]
     public int CourseId { get; set; }
 
     public Course? Course { get; set; }
 
     [DataType(DataType.DateTime)]
-    [Display(Name = "Valid From")]
+    [Display(Name = "Platí od")]
     public DateTime FromUtc { get; set; }
 
     [DataType(DataType.DateTime)]
-    [Display(Name = "Valid To")]
+    [Display(Name = "Platí do")]
     public DateTime ToUtc { get; set; }
 
-    [Range(0.01, double.MaxValue, ErrorMessage = "The new price must be greater than zero.")]
+    [Range(0.01, double.MaxValue, ErrorMessage = "Nová cena musí být větší než nula.")]
     [DataType(DataType.Currency)]
-    [Display(Name = "New Price (excl. VAT)")]
+    [Display(Name = "Nová cena (bez DPH)")]
     public decimal NewPriceExcl { get; set; }
 }

--- a/Pages/Admin/CourseBlocks/Create.cshtml
+++ b/Pages/Admin/CourseBlocks/Create.cshtml
@@ -1,12 +1,12 @@
 @page
 @model SysJaky_N.Pages.Admin.CourseBlocks.CreateModel
 @{
-    ViewData["Title"] = "Create Course Block";
+    ViewData["Title"] = "Vytvořit blok kurzů";
 }
-<h1>Create Course Block</h1>
+<h1>Vytvořit blok kurzů</h1>
 <form method="post">
     <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
-    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", ShowCancel = false }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Vytvořit", ShowCancel = false }' />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseBlocks/Delete.cshtml
+++ b/Pages/Admin/CourseBlocks/Delete.cshtml
@@ -1,15 +1,15 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.CourseBlocks.DeleteModel
 @{
-    ViewData["Title"] = "Delete Course Block";
+    ViewData["Title"] = "Smazat blok kurzů";
 }
-<h1>Delete Course Block</h1>
-<h3>Are you sure you want to delete this block?</h3>
+<h1>Smazat blok kurzů</h1>
+<h3>Opravdu chcete tento blok odstranit?</h3>
 <div>
     <h4>@Model.CourseBlock.Title</h4>
     <p>@Model.CourseBlock.Description</p>
-    <p>Price: @Model.CourseBlock.Price</p>
-    <h5>Modules:</h5>
+    <p>Cena: @Model.CourseBlock.Price</p>
+    <h5>Moduly:</h5>
     <ul>
     @foreach (var course in Model.CourseBlock.Modules)
     {
@@ -18,6 +18,6 @@
     </ul>
 </div>
 <form method="post">
-    <button type="submit" class="btn btn-danger">Delete</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <button type="submit" class="btn btn-danger">Smazat</button>
+    <a asp-page="Index" class="btn btn-secondary">Zrušit</a>
 </form>

--- a/Pages/Admin/CourseBlocks/Details.cshtml
+++ b/Pages/Admin/CourseBlocks/Details.cshtml
@@ -1,12 +1,12 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.CourseBlocks.DetailsModel
 @{
-    ViewData["Title"] = "Course Block Details";
+    ViewData["Title"] = "Detail bloku kurzů";
 }
 <h1>@Model.CourseBlock.Title</h1>
 <p>@Model.CourseBlock.Description</p>
-<p>Price: @Model.CourseBlock.Price</p>
-<h3>Modules</h3>
+<p>Cena: @Model.CourseBlock.Price</p>
+<h3>Moduly</h3>
 <ul>
 @foreach (var course in Model.CourseBlock.Modules)
 {
@@ -14,6 +14,6 @@
 }
 </ul>
 <p>
-    <a asp-page="Edit" asp-route-id="@Model.CourseBlock.Id">Edit</a> |
-    <a asp-page="Index">Back to list</a>
+    <a asp-page="Edit" asp-route-id="@Model.CourseBlock.Id">Upravit</a> |
+    <a asp-page="Index">Zpět na přehled</a>
 </p>

--- a/Pages/Admin/CourseBlocks/Edit.cshtml
+++ b/Pages/Admin/CourseBlocks/Edit.cshtml
@@ -1,12 +1,12 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.CourseBlocks.EditModel
 @{
-    ViewData["Title"] = "Edit Course Block";
+    ViewData["Title"] = "Upravit blok kurzů";
 }
-<h1>Edit Course Block</h1>
+<h1>Upravit blok kurzů</h1>
 <form method="post">
     <partial name="_CourseBlockForm" model="new SysJaky_N.Pages.Admin.CourseBlocks.CourseBlockFormModel(Model.CourseBlock, Model.AvailableCourses, Model.SelectedCourseIds)" />
-    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", ShowCancel = false }' />
+    <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Uložit", ShowCancel = false }' />
 </form>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/Pages/Admin/CourseBlocks/Index.cshtml
+++ b/Pages/Admin/CourseBlocks/Index.cshtml
@@ -1,16 +1,16 @@
 @page
 @model SysJaky_N.Pages.Admin.CourseBlocks.IndexModel
 @{
-    ViewData["Title"] = "Course Blocks";
+    ViewData["Title"] = "Bloky kurzů";
 }
-<h1>Course Blocks</h1>
-<p><a asp-page="Create">Create New</a></p>
+<h1>Bloky kurzů</h1>
+<p><a asp-page="Create">Vytvořit nový</a></p>
 <table class="table">
     <thead>
         <tr>
-            <th>Title</th>
-            <th>Price</th>
-            <th>Modules</th>
+            <th>Název</th>
+            <th>Cena</th>
+            <th>Moduly</th>
             <th></th>
         </tr>
     </thead>
@@ -22,9 +22,9 @@
             <td>@block.Price</td>
             <td>@block.Modules.Count</td>
             <td>
-                <a asp-page="Edit" asp-route-id="@block.Id">Edit</a> |
-                <a asp-page="Details" asp-route-id="@block.Id">Details</a> |
-                <a asp-page="Delete" asp-route-id="@block.Id">Delete</a>
+                <a asp-page="Edit" asp-route-id="@block.Id">Upravit</a> |
+                <a asp-page="Details" asp-route-id="@block.Id">Detail</a> |
+                <a asp-page="Delete" asp-route-id="@block.Id">Smazat</a>
             </td>
         </tr>
     }

--- a/Pages/Admin/CourseBlocks/_CourseBlockForm.cshtml
+++ b/Pages/Admin/CourseBlocks/_CourseBlockForm.cshtml
@@ -2,22 +2,22 @@
 @using System.Linq
 
 <div class="mb-3">
-    <label asp-for="CourseBlock.Title" class="form-label"></label>
+    <label asp-for="CourseBlock.Title" class="form-label">Název</label>
     <input asp-for="CourseBlock.Title" class="form-control" />
     <span asp-validation-for="CourseBlock.Title" class="text-danger"></span>
 </div>
 <div class="mb-3">
-    <label asp-for="CourseBlock.Description" class="form-label"></label>
+    <label asp-for="CourseBlock.Description" class="form-label">Popis</label>
     <textarea asp-for="CourseBlock.Description" class="form-control"></textarea>
     <span asp-validation-for="CourseBlock.Description" class="text-danger"></span>
 </div>
 <div class="mb-3">
-    <label asp-for="CourseBlock.Price" class="form-label"></label>
+    <label asp-for="CourseBlock.Price" class="form-label">Cena</label>
     <input asp-for="CourseBlock.Price" class="form-control" />
     <span asp-validation-for="CourseBlock.Price" class="text-danger"></span>
 </div>
 <div class="mb-3">
-    <label>Modules</label>
+    <label>Moduly</label>
     @foreach (var course in Model.AvailableCourses)
     {
         var isChecked = Model.SelectedCourseIds?.Contains(course.Id) == true;

--- a/Pages/Admin/CourseTerms/Create.cshtml
+++ b/Pages/Admin/CourseTerms/Create.cshtml
@@ -1,10 +1,10 @@
 @page
 @model SysJaky_N.Pages.Admin.CourseTerms.CreateModel
 @{
-    ViewData["Title"] = "Create Course Term";
+    ViewData["Title"] = "Vytvořit termín kurzu";
 }
 
-<h1>Create Course Term</h1>
+<h1>Vytvořit termín kurzu</h1>
 
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
@@ -12,7 +12,7 @@
     <partial name="_CourseTermForm" model="new SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel(Model.Input, Model.CourseOptions, Model.InstructorOptions)" />
 
     <div class="mt-4">
-        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Vytvořit", CancelText = "Zrušit" }' />
     </div>
 </form>
 

--- a/Pages/Admin/CourseTerms/Create.cshtml.cs
+++ b/Pages/Admin/CourseTerms/Create.cshtml.cs
@@ -59,7 +59,7 @@ public class CreateModel : PageModel
 
         if (endUtc <= startUtc)
         {
-            ModelState.AddModelError("Input.EndUtc", "End time must be after start time.");
+            ModelState.AddModelError("Input.EndUtc", "Koncový čas musí následovat po začátku.");
         }
 
         if (!ModelState.IsValid)
@@ -73,7 +73,7 @@ public class CreateModel : PageModel
 
         if (course == null)
         {
-            ModelState.AddModelError("Input.CourseId", "Selected course was not found.");
+            ModelState.AddModelError("Input.CourseId", "Zvolený kurz nebyl nalezen.");
             return Page();
         }
 
@@ -187,7 +187,7 @@ public class CreateModel : PageModel
 
         InstructorOptions = new List<SelectListItem>
         {
-            new("Unassigned", string.Empty, Input.InstructorId == null)
+            new("Nepřiřazeno", string.Empty, Input.InstructorId == null)
         };
         InstructorOptions.AddRange(instructorItems);
     }

--- a/Pages/Admin/CourseTerms/Delete.cshtml
+++ b/Pages/Admin/CourseTerms/Delete.cshtml
@@ -1,45 +1,45 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.CourseTerms.DeleteModel
 @{
-    ViewData["Title"] = "Delete Course Term";
+    ViewData["Title"] = "Smazat termín kurzu";
 }
 
-<h1>Delete Course Term</h1>
+<h1>Smazat termín kurzu</h1>
 
 @if (!string.IsNullOrEmpty(Model.ErrorMessage))
 {
     <div class="alert alert-danger">@Model.ErrorMessage</div>
 }
 
-<h3>Are you sure you want to delete this course term?</h3>
+<h3>Opravdu chcete tento termín odstranit?</h3>
 
 <dl class="row mt-4">
-    <dt class="col-sm-3">Course</dt>
+    <dt class="col-sm-3">Kurz</dt>
     <dd class="col-sm-9">@Model.Term.Course?.Title</dd>
-    <dt class="col-sm-3">Instructor</dt>
-    <dd class="col-sm-9">@Model.Term.Instructor?.FullName ?? "Unassigned"</dd>
-    <dt class="col-sm-3">Start</dt>
+    <dt class="col-sm-3">Lektor</dt>
+    <dd class="col-sm-9">@Model.Term.Instructor?.FullName ?? "Nepřiřazeno"</dd>
+    <dt class="col-sm-3">Začátek</dt>
     <dd class="col-sm-9">@DateTime.SpecifyKind(Model.Term.StartUtc, DateTimeKind.Utc).ToLocalTime().ToString("f")</dd>
-    <dt class="col-sm-3">End</dt>
+    <dt class="col-sm-3">Konec</dt>
     <dd class="col-sm-9">@DateTime.SpecifyKind(Model.Term.EndUtc, DateTimeKind.Utc).ToLocalTime().ToString("f")</dd>
-    <dt class="col-sm-3">Capacity</dt>
+    <dt class="col-sm-3">Kapacita</dt>
     <dd class="col-sm-9">@Model.Term.Capacity</dd>
-    <dt class="col-sm-3">Seats taken</dt>
+    <dt class="col-sm-3">Obsazeno</dt>
     <dd class="col-sm-9">@Model.Term.SeatsTaken</dd>
-    <dt class="col-sm-3">Status</dt>
+    <dt class="col-sm-3">Stav</dt>
     <dd class="col-sm-9">
         @if (Model.Term.IsActive)
         {
-            <span class="badge bg-success">Active</span>
+            <span class="badge bg-success">Aktivní</span>
         }
         else
         {
-            <span class="badge bg-secondary">Inactive</span>
+            <span class="badge bg-secondary">Neaktivní</span>
         }
     </dd>
 </dl>
 
 <form method="post" class="d-flex gap-2">
-    <button type="submit" class="btn btn-danger" @(Model.Term.SeatsTaken > 0 ? "disabled" : null)>Delete</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <button type="submit" class="btn btn-danger" @(Model.Term.SeatsTaken > 0 ? "disabled" : null)>Smazat</button>
+    <a asp-page="Index" class="btn btn-secondary">Zrušit</a>
 </form>

--- a/Pages/Admin/CourseTerms/Delete.cshtml.cs
+++ b/Pages/Admin/CourseTerms/Delete.cshtml.cs
@@ -52,7 +52,7 @@ public class DeleteModel : PageModel
 
         if (term.SeatsTaken > 0)
         {
-            ErrorMessage = "The term cannot be deleted while seats are already taken.";
+            ErrorMessage = "Termín nelze smazat, pokud jsou již obsazena místa.";
             Term = term;
             return Page();
         }

--- a/Pages/Admin/CourseTerms/Edit.cshtml
+++ b/Pages/Admin/CourseTerms/Edit.cshtml
@@ -1,10 +1,10 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.CourseTerms.EditModel
 @{
-    ViewData["Title"] = "Edit Course Term";
+    ViewData["Title"] = "Upravit termín kurzu";
 }
 
-<h1>Edit Course Term</h1>
+<h1>Upravit termín kurzu</h1>
 
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
@@ -13,13 +13,13 @@
 
     <div class="row g-3 mt-1">
         <div class="col-md-4">
-            <label class="form-label">Seats taken</label>
+            <label class="form-label">Obsazeno</label>
             <input class="form-control" value="@Model.SeatsTaken" readonly />
         </div>
     </div>
 
     <div class="mt-4">
-        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save changes", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Uložit změny", CancelText = "Zrušit" }' />
     </div>
 </form>
 

--- a/Pages/Admin/CourseTerms/Edit.cshtml.cs
+++ b/Pages/Admin/CourseTerms/Edit.cshtml.cs
@@ -80,12 +80,12 @@ public class EditModel : PageModel
 
         if (endUtc <= startUtc)
         {
-            ModelState.AddModelError("Input.EndUtc", "End time must be after start time.");
+            ModelState.AddModelError("Input.EndUtc", "Koncový čas musí následovat po začátku.");
         }
 
         if (Input.Capacity < term.SeatsTaken)
         {
-            ModelState.AddModelError("Input.Capacity", $"Capacity cannot be less than the current seats taken ({term.SeatsTaken}).");
+            ModelState.AddModelError("Input.Capacity", $"Kapacita nesmí být menší než aktuálně obsazená místa ({term.SeatsTaken}).");
         }
 
         if (!ModelState.IsValid)
@@ -128,7 +128,7 @@ public class EditModel : PageModel
 
         InstructorOptions = new List<SelectListItem>
         {
-            new("Unassigned", string.Empty, Input.InstructorId == null)
+            new("Nepřiřazeno", string.Empty, Input.InstructorId == null)
         };
         InstructorOptions.AddRange(instructorItems);
     }

--- a/Pages/Admin/CourseTerms/Index.cshtml
+++ b/Pages/Admin/CourseTerms/Index.cshtml
@@ -1,12 +1,12 @@
 @page
 @model SysJaky_N.Pages.Admin.CourseTerms.IndexModel
 @{
-    ViewData["Title"] = "Course Terms";
+    ViewData["Title"] = "Termíny kurzů";
 }
 
 <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
-    <h1 class="mb-0">Course Terms</h1>
-    <a class="btn btn-primary" asp-page="Create">Create term</a>
+    <h1 class="mb-0">Termíny kurzů</h1>
+    <a class="btn btn-primary" asp-page="Create">Vytvořit termín</a>
 </div>
 
 @if (!string.IsNullOrEmpty(Model.StatusMessage))
@@ -25,34 +25,34 @@
 
 <form method="get" class="row g-3 align-items-end mb-4">
     <div class="col-md-4">
-        <label asp-for="CourseId" class="form-label">Course</label>
+        <label asp-for="CourseId" class="form-label">Kurz</label>
         <select asp-for="CourseId" class="form-select" asp-items="Model.CourseOptions">
-            <option value="">All courses</option>
+            <option value="">Všechny kurzy</option>
         </select>
     </div>
     <div class="col-md-3">
         <div class="form-check mt-md-4">
             <input class="form-check-input" asp-for="OnlyActive" />
-            <label class="form-check-label" asp-for="OnlyActive">Active only</label>
+            <label class="form-check-label" asp-for="OnlyActive">Jen aktivní</label>
         </div>
     </div>
     <div class="col-auto">
-        <button type="submit" class="btn btn-primary">Filter</button>
+        <button type="submit" class="btn btn-primary">Filtrovat</button>
     </div>
     <div class="col-auto">
-        <a asp-page="Index" class="btn btn-outline-secondary">Clear</a>
+        <a asp-page="Index" class="btn btn-outline-secondary">Vymazat</a>
     </div>
 </form>
 
 <form method="post" asp-page-handler="Import" enctype="multipart/form-data" class="row g-3 align-items-end mb-4">
     <div class="col-md-5 col-lg-4">
-        <label asp-for="ImportFile" class="form-label">Import terms from Excel</label>
+        <label asp-for="ImportFile" class="form-label">Importovat termíny z Excelu</label>
         <input asp-for="ImportFile" class="form-control" type="file" accept=".xlsx" />
-        <div class="form-text">Required columns: CourseId, StartUtc, EndUtc, Capacity. Optional columns: Id, IsActive, InstructorId.</div>
+        <div class="form-text">Povinné sloupce: CourseId, StartUtc, EndUtc, Capacity. Volitelné sloupce: Id, IsActive, InstructorId.</div>
         <span asp-validation-for="ImportFile" class="text-danger"></span>
     </div>
     <div class="col-auto">
-        <button type="submit" class="btn btn-outline-primary">Import XLSX</button>
+        <button type="submit" class="btn btn-outline-primary">Importovat XLSX</button>
     </div>
     <div class="col-12">
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
@@ -62,7 +62,7 @@
 @if (Model.Terms.Count == 0)
 {
     <div class="alert alert-info" role="status">
-        No course terms found.
+        Nebyly nalezeny žádné termíny kurzů.
     </div>
 }
 else
@@ -71,13 +71,13 @@ else
         <table class="table table-striped align-middle">
             <thead>
                 <tr>
-                    <th>Course</th>
-                    <th>Instructor</th>
-                    <th>Start</th>
-                    <th>End</th>
-                    <th class="text-center">Capacity</th>
-                    <th class="text-center">Seats taken</th>
-                    <th>Status</th>
+                    <th>Kurz</th>
+                    <th>Lektor</th>
+                    <th>Začátek</th>
+                    <th>Konec</th>
+                    <th class="text-center">Kapacita</th>
+                    <th class="text-center">Obsazeno</th>
+                    <th>Stav</th>
                     <th></th>
                 </tr>
             </thead>
@@ -88,7 +88,7 @@ else
                 var endLocal = DateTime.SpecifyKind(term.EndUtc, DateTimeKind.Utc).ToLocalTime();
                 <tr>
                     <td>@term.Course?.Title</td>
-                    <td>@(term.Instructor?.FullName ?? "Unassigned")</td>
+                    <td>@(term.Instructor?.FullName ?? "Nepřiřazeno")</td>
                     <td>@startLocal.ToString("g")</td>
                     <td>@endLocal.ToString("g")</td>
                     <td class="text-center">@term.Capacity</td>
@@ -96,21 +96,21 @@ else
                     <td>
                         @if (term.IsActive)
                         {
-                            <span class="badge bg-success">Active</span>
+                            <span class="badge bg-success">Aktivní</span>
                         }
                         else
                         {
-                            <span class="badge bg-secondary">Inactive</span>
+                            <span class="badge bg-secondary">Neaktivní</span>
                         }
                     </td>
                     <td class="text-end">
                         <div class="d-flex flex-wrap justify-content-end gap-2">
-                            <div class="btn-group btn-group-sm" role="group" aria-label="Actions for @term.Course?.Title term">
-                                <a class="btn btn-outline-secondary" asp-page="Edit" asp-route-id="@term.Id">Edit</a>
-                                <a class="btn btn-outline-danger" asp-page="Delete" asp-route-id="@term.Id">Delete</a>
+                            <div class="btn-group btn-group-sm" role="group" aria-label="Akce pro termín kurzu @term.Course?.Title">
+                                <a class="btn btn-outline-secondary" asp-page="Edit" asp-route-id="@term.Id">Upravit</a>
+                                <a class="btn btn-outline-danger" asp-page="Delete" asp-route-id="@term.Id">Smazat</a>
                             </div>
                             <form method="post" asp-page-handler="ExportEnrollments" asp-route-id="@term.Id" class="d-inline">
-                                <button type="submit" class="btn btn-sm btn-outline-primary">Export XLSX</button>
+                                <button type="submit" class="btn btn-sm btn-outline-primary">Exportovat XLSX</button>
                             </form>
                         </div>
                     </td>

--- a/Pages/Admin/CourseTerms/Index.cshtml.cs
+++ b/Pages/Admin/CourseTerms/Index.cshtml.cs
@@ -124,7 +124,7 @@ public class IndexModel : PageModel
             worksheet.Cells[worksheet.Dimension.Address].AutoFitColumns();
         }
 
-        var courseTitle = term.Course?.Title ?? $"Course_{term.CourseId}";
+        var courseTitle = term.Course?.Title ?? $"Kurz_{term.CourseId}";
         var safeCourseTitle = SanitizeForFileName(courseTitle);
         var fileName = $"{safeCourseTitle}_term_{term.Id}_enrollments.xlsx";
         var content = package.GetAsByteArray();
@@ -136,16 +136,16 @@ public class IndexModel : PageModel
     {
         if (ImportFile == null || ImportFile.Length == 0)
         {
-            ModelState.AddModelError(nameof(ImportFile), "Please select an XLSX file to import.");
-            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            ModelState.AddModelError(nameof(ImportFile), "Vyberte XLSX soubor pro import.");
+            ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
             await LoadPageDataAsync();
             return Page();
         }
 
         if (!string.Equals(Path.GetExtension(ImportFile.FileName), ".xlsx", StringComparison.OrdinalIgnoreCase))
         {
-            ModelState.AddModelError(nameof(ImportFile), "Only XLSX files are supported.");
-            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            ModelState.AddModelError(nameof(ImportFile), "Podporovány jsou pouze soubory XLSX.");
+            ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
             await LoadPageDataAsync();
             return Page();
         }
@@ -163,8 +163,8 @@ public class IndexModel : PageModel
             var worksheet = package.Workbook.Worksheets.FirstOrDefault();
             if (worksheet == null || worksheet.Dimension == null)
             {
-                ModelState.AddModelError(nameof(ImportFile), "The uploaded file does not contain any data.");
-                ErrorMessage = "Import failed. Please review the highlighted issues.";
+                ModelState.AddModelError(nameof(ImportFile), "Nahraný soubor neobsahuje žádná data.");
+                ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
                 await LoadPageDataAsync();
                 return Page();
             }
@@ -175,13 +175,13 @@ public class IndexModel : PageModel
             {
                 if (!headerMap.ContainsKey(header))
                 {
-                    ModelState.AddModelError(nameof(ImportFile), $"Missing required column '{header}'.");
+                    ModelState.AddModelError(nameof(ImportFile), $"Chybí povinný sloupec '{header}'.");
                 }
             }
 
             if (!ModelState.IsValid)
             {
-                ErrorMessage = "Import failed. Please review the highlighted issues.";
+                ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
                 await LoadPageDataAsync();
                 return Page();
             }
@@ -201,13 +201,13 @@ public class IndexModel : PageModel
                 {
                     if (!TryGetNullableInt(worksheet.Cells[row, idColumn], out id))
                     {
-                        rowErrors.Add("Invalid value for Id.");
+                        rowErrors.Add("Neplatná hodnota ve sloupci Id.");
                     }
                 }
 
                 if (!TryGetInt(worksheet.Cells[row, headerMap["CourseId"]], out var courseId))
                 {
-                    rowErrors.Add("CourseId is required and must be a number.");
+                    rowErrors.Add("CourseId je povinný a musí být číslo.");
                 }
                 else
                 {
@@ -216,21 +216,21 @@ public class IndexModel : PageModel
 
                 if (!TryGetDateTime(worksheet.Cells[row, headerMap["StartUtc"]], out var startUtc))
                 {
-                    rowErrors.Add("StartUtc is required and must be a valid date/time.");
+                    rowErrors.Add("StartUtc je povinný a musí být platné datum a čas.");
                 }
 
                 if (!TryGetDateTime(worksheet.Cells[row, headerMap["EndUtc"]], out var endUtc))
                 {
-                    rowErrors.Add("EndUtc is required and must be a valid date/time.");
+                    rowErrors.Add("EndUtc je povinný a musí být platné datum a čas.");
                 }
 
                 if (!TryGetInt(worksheet.Cells[row, headerMap["Capacity"]], out var capacity))
                 {
-                    rowErrors.Add("Capacity is required and must be a number.");
+                    rowErrors.Add("Capacity je povinná a musí být číslo.");
                 }
                 else if (capacity < 1)
                 {
-                    rowErrors.Add("Capacity must be at least 1.");
+                    rowErrors.Add("Kapacita musí být alespoň 1.");
                 }
 
                 bool? isActive = null;
@@ -238,7 +238,7 @@ public class IndexModel : PageModel
                 {
                     if (!TryGetNullableBool(worksheet.Cells[row, isActiveColumn], out isActive))
                     {
-                        rowErrors.Add("IsActive must be a boolean value.");
+                        rowErrors.Add("IsActive musí být logická hodnota.");
                     }
                 }
 
@@ -247,7 +247,7 @@ public class IndexModel : PageModel
                 {
                     if (!TryGetNullableInt(worksheet.Cells[row, instructorColumn], out instructorId))
                     {
-                        rowErrors.Add("InstructorId must be a number.");
+                        rowErrors.Add("InstructorId musí být číslo.");
                     }
                     else if (instructorId.HasValue)
                     {
@@ -257,7 +257,7 @@ public class IndexModel : PageModel
 
                 if (!rowErrors.Any() && EnsureUtc(startUtc) >= EnsureUtc(endUtc))
                 {
-                    rowErrors.Add("StartUtc must be earlier than EndUtc.");
+                    rowErrors.Add("StartUtc musí být dříve než EndUtc.");
                 }
 
                 if (rowErrors.Count > 0)
@@ -282,14 +282,14 @@ public class IndexModel : PageModel
 
         if (!ModelState.IsValid)
         {
-            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
             await LoadPageDataAsync();
             return Page();
         }
 
         if (parsedRows.Count == 0)
         {
-            StatusMessage = "No course terms were found in the uploaded file.";
+            StatusMessage = "V nahraném souboru nebyly nalezeny žádné termíny.";
             return RedirectToPage(new { CourseId, OnlyActive });
         }
 
@@ -300,7 +300,7 @@ public class IndexModel : PageModel
 
         foreach (var missingCourseId in courseIds.Except(existingCourseIds))
         {
-            ModelState.AddModelError(nameof(ImportFile), $"Course with ID {missingCourseId} does not exist.");
+            ModelState.AddModelError(nameof(ImportFile), $"Kurz s ID {missingCourseId} neexistuje.");
         }
 
         if (instructorIds.Count > 0)
@@ -312,13 +312,13 @@ public class IndexModel : PageModel
 
             foreach (var missingInstructorId in instructorIds.Except(existingInstructorIds))
             {
-                ModelState.AddModelError(nameof(ImportFile), $"Instructor with ID {missingInstructorId} does not exist.");
+                ModelState.AddModelError(nameof(ImportFile), $"Lektor s ID {missingInstructorId} neexistuje.");
             }
         }
 
         if (!ModelState.IsValid)
         {
-            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
             await LoadPageDataAsync();
             return Page();
         }
@@ -335,12 +335,12 @@ public class IndexModel : PageModel
 
             foreach (var missingTermId in termIds.Except(termsToUpdate.Keys))
             {
-                ModelState.AddModelError(nameof(ImportFile), $"Course term with ID {missingTermId} does not exist.");
+                ModelState.AddModelError(nameof(ImportFile), $"Termín s ID {missingTermId} neexistuje.");
             }
 
             if (!ModelState.IsValid)
             {
-                ErrorMessage = "Import failed. Please review the highlighted issues.";
+                ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
                 await LoadPageDataAsync();
                 return Page();
             }
@@ -359,7 +359,7 @@ public class IndexModel : PageModel
                 term = termsToUpdate[row.Id.Value];
                 if (term.SeatsTaken > row.Capacity)
                 {
-                    ModelState.AddModelError(nameof(ImportFile), $"Row {row.RowNumber}: Capacity {row.Capacity} is smaller than the current number of seats taken ({term.SeatsTaken}).");
+                    ModelState.AddModelError(nameof(ImportFile), $"Řádek {row.RowNumber}: Kapacita {row.Capacity} je menší než aktuálně obsazená místa ({term.SeatsTaken}).");
                     continue;
                 }
 
@@ -397,7 +397,7 @@ public class IndexModel : PageModel
 
         if (!ModelState.IsValid)
         {
-            ErrorMessage = "Import failed. Please review the highlighted issues.";
+            ErrorMessage = "Import se nezdařil. Zkontrolujte zvýrazněné problémy.";
             await LoadPageDataAsync();
             return Page();
         }
@@ -410,7 +410,7 @@ public class IndexModel : PageModel
             _cacheService.InvalidateCourseDetail(courseId);
         }
 
-        StatusMessage = $"Imported {created} new term(s) and updated {updated} existing term(s).";
+        StatusMessage = $"Importováno {created} nových termínů a aktualizováno {updated} stávajících termínů.";
         return RedirectToPage(new { CourseId, OnlyActive });
     }
 

--- a/Pages/Admin/CourseTerms/_CourseTermForm.cshtml
+++ b/Pages/Admin/CourseTerms/_CourseTermForm.cshtml
@@ -1,19 +1,19 @@
 @model SysJaky_N.Pages.Admin.CourseTerms.CourseTermFormModel
 
 <div class="mb-3">
-    <label asp-for="Input.CourseId" class="form-label"></label>
+    <label asp-for="Input.CourseId" class="form-label">Kurz</label>
     <select asp-for="Input.CourseId" class="form-select" asp-items="Model.CourseOptions"></select>
     <span asp-validation-for="Input.CourseId" class="text-danger"></span>
 </div>
 
 <div class="row g-3">
     <div class="col-md-6">
-        <label asp-for="Input.StartUtc" class="form-label"></label>
+        <label asp-for="Input.StartUtc" class="form-label">Začátek</label>
         <input asp-for="Input.StartUtc" type="datetime-local" class="form-control" />
         <span asp-validation-for="Input.StartUtc" class="text-danger"></span>
     </div>
     <div class="col-md-6">
-        <label asp-for="Input.EndUtc" class="form-label"></label>
+        <label asp-for="Input.EndUtc" class="form-label">Konec</label>
         <input asp-for="Input.EndUtc" type="datetime-local" class="form-control" />
         <span asp-validation-for="Input.EndUtc" class="text-danger"></span>
     </div>
@@ -21,19 +21,19 @@
 
 <div class="row g-3 mt-1">
     <div class="col-md-4">
-        <label asp-for="Input.Capacity" class="form-label"></label>
+        <label asp-for="Input.Capacity" class="form-label">Kapacita</label>
         <input asp-for="Input.Capacity" class="form-control" type="number" min="1" />
         <span asp-validation-for="Input.Capacity" class="text-danger"></span>
     </div>
     <div class="col-md-4">
-        <label asp-for="Input.InstructorId" class="form-label"></label>
+        <label asp-for="Input.InstructorId" class="form-label">Lektor</label>
         <select asp-for="Input.InstructorId" class="form-select" asp-items="Model.InstructorOptions"></select>
         <span asp-validation-for="Input.InstructorId" class="text-danger"></span>
     </div>
     <div class="col-md-4 d-flex align-items-center">
         <div class="form-check mt-3">
             <input class="form-check-input" asp-for="Input.IsActive" />
-            <label class="form-check-label" asp-for="Input.IsActive"></label>
+            <label class="form-check-label" asp-for="Input.IsActive">Aktivní</label>
         </div>
     </div>
 </div>

--- a/Pages/Admin/Courses/Index.cshtml
+++ b/Pages/Admin/Courses/Index.cshtml
@@ -1,31 +1,31 @@
 @page
 @model SysJaky_N.Pages.Admin.Courses.IndexModel
 @{
-    ViewData["Title"] = "Courses";
+    ViewData["Title"] = "Kurzy";
 }
 
-<h1>Courses</h1>
+<h1>Kurzy</h1>
 
 <form method="get" class="mb-3" role="search" aria-label="Filtr kurzů">
-    <input type="text" asp-for="SearchString" placeholder="Search..." class="form-control" style="width:auto;display:inline-block" aria-label="Hledat kurzy" />
+    <input type="text" asp-for="SearchString" placeholder="Hledat..." class="form-control" style="width:auto;display:inline-block" aria-label="Hledat kurzy" />
     <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-control" style="width:auto;display:inline-block" aria-label="Filtrovat podle skupiny">
-        <option value="">All Groups</option>
+        <option value="">Všechny skupiny</option>
     </select>
-    <button type="submit" class="btn btn-primary">Filter</button>
-    <a class="btn btn-secondary" asp-page="/Admin/Courses/Index">Reset</a>
+    <button type="submit" class="btn btn-primary">Filtrovat</button>
+    <a class="btn btn-secondary" asp-page="/Admin/Courses/Index">Resetovat</a>
 </form>
 
 <p>
-    <a asp-page="/Courses/Create">Create New</a>
+    <a asp-page="/Courses/Create">Vytvořit kurz</a>
 </p>
 
 <table class="table">
     <thead>
         <tr>
-            <th>Title</th>
-            <th>Group</th>
-            <th>Price</th>
-            <th>Date</th>
+            <th>Název</th>
+            <th>Skupina</th>
+            <th>Cena</th>
+            <th>Datum</th>
             <th></th>
         </tr>
     </thead>
@@ -38,8 +38,8 @@
             <td>@item.Price</td>
             <td>@item.Date.ToString("d")</td>
             <td>
-                <a asp-page="/Courses/Edit" asp-route-id="@item.Id">Edit</a>
-                <a asp-page="/Courses/Delete" asp-route-id="@item.Id">Delete</a>
+                <a asp-page="/Courses/Edit" asp-route-id="@item.Id">Upravit</a>
+                <a asp-page="/Courses/Delete" asp-route-id="@item.Id">Smazat</a>
             </td>
         </tr>
     }
@@ -51,10 +51,10 @@
     <nav aria-label="Stránkování kurzů">
         <ul class="pagination">
             <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Previous</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Předchozí</a>
             </li>
             <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
-                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Next</a>
+                <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString">Další</a>
             </li>
         </ul>
     </nav>

--- a/Pages/Admin/PriceSchedules/Create.cshtml
+++ b/Pages/Admin/PriceSchedules/Create.cshtml
@@ -1,10 +1,10 @@
 @page
 @model SysJaky_N.Pages.Admin.PriceSchedules.CreateModel
 @{
-    ViewData["Title"] = "Create Price Schedule";
+    ViewData["Title"] = "Vytvořit cenový plán";
 }
 
-<h1>Create Price Schedule</h1>
+<h1>Vytvořit cenový plán</h1>
 
 <form method="post" class="mt-4">
     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
@@ -12,7 +12,7 @@
     <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Create", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Vytvořit", CancelText = "Zrušit" }' />
     </div>
 </form>
 

--- a/Pages/Admin/PriceSchedules/Create.cshtml.cs
+++ b/Pages/Admin/PriceSchedules/Create.cshtml.cs
@@ -41,7 +41,7 @@ public class CreateModel : PageModel
 
         if (toUtc <= fromUtc)
         {
-            ModelState.AddModelError("PriceSchedule.ToUtc", "End time must be after start time.");
+            ModelState.AddModelError("PriceSchedule.ToUtc", "Koncový čas musí následovat po začátku.");
         }
 
         if (!ModelState.IsValid)

--- a/Pages/Admin/PriceSchedules/Delete.cshtml
+++ b/Pages/Admin/PriceSchedules/Delete.cshtml
@@ -1,28 +1,28 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.PriceSchedules.DeleteModel
 @{
-    ViewData["Title"] = "Delete Price Schedule";
+    ViewData["Title"] = "Smazat cenový plán";
 }
 
-<h1>Delete Price Schedule</h1>
+<h1>Smazat cenový plán</h1>
 
-<h3>Are you sure you want to delete this price schedule?</h3>
+<h3>Opravdu chcete tento cenový plán odstranit?</h3>
 
 <div>
     <dl class="row">
-        <dt class="col-sm-3">Course</dt>
+        <dt class="col-sm-3">Kurz</dt>
         <dd class="col-sm-9">@Model.PriceSchedule.Course?.Title</dd>
-        <dt class="col-sm-3">Valid From</dt>
+        <dt class="col-sm-3">Platí od</dt>
         <dd class="col-sm-9">@DateTime.SpecifyKind(Model.PriceSchedule.FromUtc, DateTimeKind.Utc).ToLocalTime().ToString("g")</dd>
-        <dt class="col-sm-3">Valid To</dt>
+        <dt class="col-sm-3">Platí do</dt>
         <dd class="col-sm-9">@DateTime.SpecifyKind(Model.PriceSchedule.ToUtc, DateTimeKind.Utc).ToLocalTime().ToString("g")</dd>
-        <dt class="col-sm-3">New Price (excl. VAT)</dt>
+        <dt class="col-sm-3">Nová cena (bez DPH)</dt>
         <dd class="col-sm-9">@Model.PriceSchedule.NewPriceExcl.ToString("C")</dd>
     </dl>
 
     <form method="post">
         <input type="hidden" asp-for="PriceSchedule.Id" />
-        <button type="submit" class="btn btn-danger">Delete</button>
-        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+        <button type="submit" class="btn btn-danger">Smazat</button>
+        <a asp-page="Index" class="btn btn-secondary">Zrušit</a>
     </form>
 </div>

--- a/Pages/Admin/PriceSchedules/Edit.cshtml
+++ b/Pages/Admin/PriceSchedules/Edit.cshtml
@@ -1,10 +1,10 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Admin.PriceSchedules.EditModel
 @{
-    ViewData["Title"] = "Edit Price Schedule";
+    ViewData["Title"] = "Upravit cenový plán";
 }
 
-<h1>Edit Price Schedule</h1>
+<h1>Upravit cenový plán</h1>
 
 <form method="post" class="mt-4">
     <input type="hidden" asp-for="PriceSchedule.Id" />
@@ -13,7 +13,7 @@
     <partial name="_PriceScheduleForm" model="new SysJaky_N.Pages.Admin.PriceSchedules.PriceScheduleFormModel(Model.PriceSchedule, Model.Courses)" />
 
     <div class="mt-4">
-        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Save", CancelText = "Cancel" }' />
+        <partial name="~/Pages/Shared/_FormActions.cshtml" model='new SysJaky_N.Pages.Admin.Shared.FormActionsModel { SubmitText = "Uložit", CancelText = "Zrušit" }' />
     </div>
 </form>
 

--- a/Pages/Admin/PriceSchedules/Edit.cshtml.cs
+++ b/Pages/Admin/PriceSchedules/Edit.cshtml.cs
@@ -60,7 +60,7 @@ public class EditModel : PageModel
 
         if (toUtc <= fromUtc)
         {
-            ModelState.AddModelError("PriceSchedule.ToUtc", "End time must be after start time.");
+            ModelState.AddModelError("PriceSchedule.ToUtc", "Koncový čas musí následovat po začátku.");
         }
 
         if (!ModelState.IsValid)

--- a/Pages/Admin/PriceSchedules/Index.cshtml
+++ b/Pages/Admin/PriceSchedules/Index.cshtml
@@ -1,18 +1,18 @@
 @page
 @model SysJaky_N.Pages.Admin.PriceSchedules.IndexModel
 @{
-    ViewData["Title"] = "Price Schedules";
+    ViewData["Title"] = "Cenové plány";
 }
 
-<h1>Price Schedules</h1>
+<h1>Cenové plány</h1>
 
 <p>
-    <a class="btn btn-primary" asp-page="Create">Create New</a>
+    <a class="btn btn-primary" asp-page="Create">Vytvořit nový</a>
 </p>
 
 @if (Model.PriceSchedules.Count == 0)
 {
-    <p>No price schedules found.</p>
+    <p>Nebyly nalezeny žádné cenové plány.</p>
 }
 else
 {
@@ -20,10 +20,10 @@ else
         <table class="table table-striped align-middle">
         <thead>
             <tr>
-                <th>Course</th>
-                <th>Valid From</th>
-                <th>Valid To</th>
-                <th>New Price (excl. VAT)</th>
+                <th>Kurz</th>
+                <th>Platí od</th>
+                <th>Platí do</th>
+                <th>Nová cena (bez DPH)</th>
                 <th></th>
             </tr>
         </thead>
@@ -36,8 +36,8 @@ else
                 <td>@DateTime.SpecifyKind(schedule.ToUtc, DateTimeKind.Utc).ToLocalTime().ToString("g")</td>
                 <td>@schedule.NewPriceExcl.ToString("C")</td>
                 <td>
-                    <a class="btn btn-sm btn-secondary" asp-page="Edit" asp-route-id="@schedule.Id">Edit</a>
-                    <a class="btn btn-sm btn-danger" asp-page="Delete" asp-route-id="@schedule.Id">Delete</a>
+                    <a class="btn btn-sm btn-secondary" asp-page="Edit" asp-route-id="@schedule.Id">Upravit</a>
+                    <a class="btn btn-sm btn-danger" asp-page="Delete" asp-route-id="@schedule.Id">Smazat</a>
                 </td>
             </tr>
         }

--- a/Pages/Courses/Create.cshtml
+++ b/Pages/Courses/Create.cshtml
@@ -4,18 +4,18 @@
 @using Microsoft.AspNetCore.Mvc.Rendering
 @using SysJaky_N.Pages.Courses
 @{
-    ViewData["Title"] = "Create Course";
+    ViewData["Title"] = "Vytvořit kurz";
     var actions = new HtmlContentBuilder();
     var submitButton = new TagBuilder("button");
     submitButton.Attributes["type"] = "submit";
     submitButton.AddCssClass("btn btn-primary");
-    submitButton.InnerHtml.Append("Create");
+    submitButton.InnerHtml.Append("Vytvořit");
     actions.AppendHtml(submitButton);
 
     var backLink = new TagBuilder("a");
     backLink.AddCssClass("btn btn-secondary");
     backLink.Attributes["href"] = Url.Page("Index");
-    backLink.InnerHtml.Append("Back to List");
+    backLink.InnerHtml.Append("Zpět na přehled");
     actions.AppendHtml(backLink);
 
     var formModel = new CourseFormModel
@@ -27,7 +27,7 @@
     };
 }
 
-<h1>Create Course</h1>
+<h1>Vytvořit kurz</h1>
 
 <form method="post" enctype="multipart/form-data">
     <partial name="Courses/Shared/_CourseForm" model="formModel" />

--- a/Pages/Courses/Delete.cshtml
+++ b/Pages/Courses/Delete.cshtml
@@ -1,12 +1,12 @@
 @page "{id:int}"
 @model SysJaky_N.Pages.Courses.DeleteModel
 @{
-    ViewData["Title"] = "Delete Course";
+    ViewData["Title"] = "Smazat kurz";
 }
 
-<h1>Delete Course</h1>
+<h1>Smazat kurz</h1>
 
-<h3>Are you sure you want to delete this?</h3>
+<h3>Opravdu chcete tento kurz odstranit?</h3>
 <div>
     <h4>@Model.Course.Title</h4>
     <p>@Model.Course.Description</p>
@@ -14,6 +14,6 @@
 
 <form method="post">
     <input type="hidden" asp-for="Course.Id" />
-    <button type="submit" class="btn btn-danger">Delete</button>
-    <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    <button type="submit" class="btn btn-danger">Smazat</button>
+    <a asp-page="Index" class="btn btn-secondary">Zrušit</a>
 </form>

--- a/Pages/Courses/Edit.cshtml
+++ b/Pages/Courses/Edit.cshtml
@@ -4,18 +4,18 @@
 @using Microsoft.AspNetCore.Mvc.Rendering
 @using SysJaky_N.Pages.Courses
 @{
-    ViewData["Title"] = "Edit Course";
+    ViewData["Title"] = "Upravit kurz";
     var actions = new HtmlContentBuilder();
     var submitButton = new TagBuilder("button");
     submitButton.Attributes["type"] = "submit";
     submitButton.AddCssClass("btn btn-primary");
-    submitButton.InnerHtml.Append("Save");
+    submitButton.InnerHtml.Append("Uložit");
     actions.AppendHtml(submitButton);
 
     var backLink = new TagBuilder("a");
     backLink.AddCssClass("btn btn-secondary");
     backLink.Attributes["href"] = Url.Page("Index");
-    backLink.InnerHtml.Append("Back to List");
+    backLink.InnerHtml.Append("Zpět na přehled");
     actions.AppendHtml(backLink);
 
     var formModel = new CourseFormModel
@@ -27,14 +27,14 @@
     };
 }
 
-<h1>Edit Course</h1>
+<h1>Upravit kurz</h1>
 
 <form method="post" enctype="multipart/form-data">
     <input type="hidden" asp-for="Course.Id" />
     @if (!string.IsNullOrEmpty(Model.Course.CoverImageUrl))
     {
         <div class="mb-3">
-            <img src="@Model.Course.CoverImageUrl" alt="Cover for @Model.Course.Title" class="img-fluid rounded" style="max-width: 240px;" />
+            <img src="@Model.Course.CoverImageUrl" alt="Obálka kurzu @Model.Course.Title" class="img-fluid rounded" style="max-width: 240px;" />
         </div>
     }
 

--- a/Pages/Courses/Shared/_CourseForm.cshtml
+++ b/Pages/Courses/Shared/_CourseForm.cshtml
@@ -1,71 +1,76 @@
 @model SysJaky_N.Pages.Courses.CourseFormModel
 @using SysJaky_N.Models
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 
 <div class="mb-3">
-    <label asp-for="Course.Title" class="form-label"></label>
-    <input asp-for="Course.Title" class="form-control" />
+    <label asp-for="Course.Title" class="form-label">@Localizer["CourseTitleLabel"]</label>
+    <input asp-for="Course.Title" class="form-control" placeholder="@Localizer["TitlePlaceholder"]" />
     <span asp-validation-for="Course.Title" class="text-danger"></span>
 </div>
 <div class="mb-3">
-    <label asp-for="Course.Description" class="form-label"></label>
-    <textarea asp-for="Course.Description" class="form-control" rows="4"></textarea>
+    <label asp-for="Course.Description" class="form-label">@Localizer["CourseDescriptionLabel"]</label>
+    <textarea asp-for="Course.Description" class="form-control" rows="4" placeholder="@Localizer["DescriptionPlaceholder"]"></textarea>
     <span asp-validation-for="Course.Description" class="text-danger"></span>
 </div>
 <div class="row g-3">
     <div class="col-md-6">
-        <label asp-for="Course.MetaTitle" class="form-label"></label>
-        <input asp-for="Course.MetaTitle" class="form-control" />
+        <label asp-for="Course.MetaTitle" class="form-label">@Localizer["MetaTitleLabel"]</label>
+        <input asp-for="Course.MetaTitle" class="form-control" placeholder="@Localizer["MetaTitlePlaceholder"]" />
         <span asp-validation-for="Course.MetaTitle" class="text-danger"></span>
     </div>
     <div class="col-md-6">
-        <label asp-for="Course.MetaDescription" class="form-label"></label>
-        <textarea asp-for="Course.MetaDescription" class="form-control" rows="2"></textarea>
+        <label asp-for="Course.MetaDescription" class="form-label">@Localizer["MetaDescriptionLabel"]</label>
+        <textarea asp-for="Course.MetaDescription" class="form-control" rows="2" placeholder="@Localizer["MetaDescriptionPlaceholder"]"></textarea>
         <span asp-validation-for="Course.MetaDescription" class="text-danger"></span>
     </div>
 </div>
 <div class="mb-3">
-    <label asp-for="Course.OpenGraphImage" class="form-label"></label>
-    <input asp-for="Course.OpenGraphImage" class="form-control" />
+    <label asp-for="Course.OpenGraphImage" class="form-label">@Localizer["OpenGraphImageLabel"]</label>
+    <input asp-for="Course.OpenGraphImage" class="form-control" placeholder="@Localizer["OpenGraphImagePlaceholder"]" />
     <span asp-validation-for="Course.OpenGraphImage" class="text-danger"></span>
 </div>
 <div class="row g-3">
     <div class="col-md-6">
-        <label asp-for="Course.CourseGroupId" class="form-label"></label>
+        <label asp-for="Course.CourseGroupId" class="form-label">@Localizer["CourseGroupLabel"]</label>
         <select asp-for="Course.CourseGroupId" asp-items="Model.CourseGroups" class="form-select">
-            <option value="">-- Select Group --</option>
+            <option value="">@Localizer["SelectGroup"]</option>
         </select>
         <span asp-validation-for="Course.CourseGroupId" class="text-danger"></span>
     </div>
     <div class="col-md-3">
-        <label asp-for="Course.Price" class="form-label"></label>
-        <input asp-for="Course.Price" class="form-control" />
+        <label asp-for="Course.Price" class="form-label">@Localizer["PriceLabel"]</label>
+        <input asp-for="Course.Price" class="form-control" placeholder="@Localizer["PricePlaceholder"]" />
         <span asp-validation-for="Course.Price" class="text-danger"></span>
     </div>
     <div class="col-md-3">
-        <label asp-for="Course.Date" class="form-label"></label>
-        <input asp-for="Course.Date" class="form-control" />
+        <label asp-for="Course.Date" class="form-label">@Localizer["DateLabel"]</label>
+        <input asp-for="Course.Date" class="form-control" placeholder="@Localizer["DatePlaceholder"]" />
         <span asp-validation-for="Course.Date" class="text-danger"></span>
     </div>
 </div>
 <div class="mb-3">
-    <label asp-for="CoverImage" class="form-label"></label>
+    <label asp-for="CoverImage" class="form-label">@Localizer["CoverImageLabel"]</label>
     <input asp-for="CoverImage" type="file" class="form-control" accept="image/jpeg" />
     <span asp-validation-for="CoverImage" class="text-danger"></span>
 </div>
 <div class="row g-3">
     <div class="col-md-4">
-        <label asp-for="Course.Level" class="form-label"></label>
-        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<CourseLevel>()"></select>
+        <label asp-for="Course.Level" class="form-label">@Localizer["LevelLabel"]</label>
+        <select asp-for="Course.Level" class="form-select" asp-items="Html.GetEnumSelectList<CourseLevel>()">
+            <option value="">@Localizer["SelectLevel"]</option>
+        </select>
         <span asp-validation-for="Course.Level" class="text-danger"></span>
     </div>
     <div class="col-md-4">
-        <label asp-for="Course.Mode" class="form-label"></label>
-        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<CourseMode>()"></select>
+        <label asp-for="Course.Mode" class="form-label">@Localizer["ModeLabel"]</label>
+        <select asp-for="Course.Mode" class="form-select" asp-items="Html.GetEnumSelectList<CourseMode>()">
+            <option value="">@Localizer["SelectMode"]</option>
+        </select>
         <span asp-validation-for="Course.Mode" class="text-danger"></span>
     </div>
     <div class="col-md-4">
-        <label asp-for="Course.Duration" class="form-label"></label>
-        <input asp-for="Course.Duration" class="form-control" min="0" />
+        <label asp-for="Course.Duration" class="form-label">@Localizer["DurationLabel"]</label>
+        <input asp-for="Course.Duration" class="form-control" min="0" placeholder="@Localizer["DurationPlaceholder"]" />
         <span asp-validation-for="Course.Duration" class="text-danger"></span>
     </div>
 </div>

--- a/Resources/Pages.Courses.Shared._CourseForm.cshtml.en.resx
+++ b/Resources/Pages.Courses.Shared._CourseForm.cshtml.en.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TitlePlaceholder" xml:space="preserve">
+    <value>Course title</value>
+  </data>
+  <data name="CourseTitleLabel" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="DescriptionPlaceholder" xml:space="preserve">
+    <value>Describe the course content</value>
+  </data>
+  <data name="CourseDescriptionLabel" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="MetaTitlePlaceholder" xml:space="preserve">
+    <value>Meta title for search engines</value>
+  </data>
+  <data name="MetaTitleLabel" xml:space="preserve">
+    <value>Meta title</value>
+  </data>
+  <data name="MetaDescriptionPlaceholder" xml:space="preserve">
+    <value>Short SEO description</value>
+  </data>
+  <data name="MetaDescriptionLabel" xml:space="preserve">
+    <value>Meta description</value>
+  </data>
+  <data name="OpenGraphImagePlaceholder" xml:space="preserve">
+    <value>Image URL for social sharing</value>
+  </data>
+  <data name="OpenGraphImageLabel" xml:space="preserve">
+    <value>Open Graph image</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Select a group</value>
+  </data>
+  <data name="CourseGroupLabel" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="PricePlaceholder" xml:space="preserve">
+    <value>Enter the price</value>
+  </data>
+  <data name="PriceLabel" xml:space="preserve">
+    <value>Price</value>
+  </data>
+  <data name="DatePlaceholder" xml:space="preserve">
+    <value>Start date</value>
+  </data>
+  <data name="DateLabel" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="SelectLevel" xml:space="preserve">
+    <value>Select a level</value>
+  </data>
+  <data name="LevelLabel" xml:space="preserve">
+    <value>Level</value>
+  </data>
+  <data name="SelectMode" xml:space="preserve">
+    <value>Select a mode</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Mode</value>
+  </data>
+  <data name="DurationPlaceholder" xml:space="preserve">
+    <value>Duration in hours</value>
+  </data>
+  <data name="DurationLabel" xml:space="preserve">
+    <value>Duration</value>
+  </data>
+  <data name="CoverImageLabel" xml:space="preserve">
+    <value>Cover image</value>
+  </data>
+</root>

--- a/Resources/Pages.Courses.Shared._CourseForm.cshtml.resx
+++ b/Resources/Pages.Courses.Shared._CourseForm.cshtml.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TitlePlaceholder" xml:space="preserve">
+    <value>Název kurzu</value>
+  </data>
+  <data name="CourseTitleLabel" xml:space="preserve">
+    <value>Název</value>
+  </data>
+  <data name="DescriptionPlaceholder" xml:space="preserve">
+    <value>Stručně popište obsah kurzu</value>
+  </data>
+  <data name="CourseDescriptionLabel" xml:space="preserve">
+    <value>Popis</value>
+  </data>
+  <data name="MetaTitlePlaceholder" xml:space="preserve">
+    <value>Meta titulek pro vyhledávače</value>
+  </data>
+  <data name="MetaTitleLabel" xml:space="preserve">
+    <value>Meta titulek</value>
+  </data>
+  <data name="MetaDescriptionPlaceholder" xml:space="preserve">
+    <value>Krátký popis pro SEO</value>
+  </data>
+  <data name="MetaDescriptionLabel" xml:space="preserve">
+    <value>Meta popis</value>
+  </data>
+  <data name="OpenGraphImagePlaceholder" xml:space="preserve">
+    <value>URL obrázku pro sdílení na sociálních sítích</value>
+  </data>
+  <data name="OpenGraphImageLabel" xml:space="preserve">
+    <value>Open Graph obrázek</value>
+  </data>
+  <data name="SelectGroup" xml:space="preserve">
+    <value>Vyberte skupinu</value>
+  </data>
+  <data name="CourseGroupLabel" xml:space="preserve">
+    <value>Skupina</value>
+  </data>
+  <data name="PricePlaceholder" xml:space="preserve">
+    <value>Zadejte cenu</value>
+  </data>
+  <data name="PriceLabel" xml:space="preserve">
+    <value>Cena</value>
+  </data>
+  <data name="DatePlaceholder" xml:space="preserve">
+    <value>Datum zahájení</value>
+  </data>
+  <data name="DateLabel" xml:space="preserve">
+    <value>Datum</value>
+  </data>
+  <data name="SelectLevel" xml:space="preserve">
+    <value>Zvolte úroveň</value>
+  </data>
+  <data name="LevelLabel" xml:space="preserve">
+    <value>Úroveň</value>
+  </data>
+  <data name="SelectMode" xml:space="preserve">
+    <value>Zvolte formu</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Forma</value>
+  </data>
+  <data name="DurationPlaceholder" xml:space="preserve">
+    <value>Délka v hodinách</value>
+  </data>
+  <data name="DurationLabel" xml:space="preserve">
+    <value>Délka</value>
+  </data>
+  <data name="CoverImageLabel" xml:space="preserve">
+    <value>Úvodní obrázek</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- Translate the admin course overview, creation, editing, and deletion pages to Czech wording
- Localize the shared course form with Czech labels/placeholders and resource files so the English strings remain available
- Update course block, term, and price schedule admin pages and validation messages to Czech, including import/export feedback

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dce19fbfd883219d747eb1df201ff6