### PR TITLE
Localize course card and advisor offcanvas views

### DIFF
--- a/Pages/Shared/Components/_CourseCard.cshtml
+++ b/Pages/Shared/Components/_CourseCard.cshtml
@@ -1,8 +1,9 @@
 @model SysJaky_N.Models.Course
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 <div class="feature-card h-100 p-3 d-flex flex-column justify-content-between">
   <div class="d-flex flex-column gap-2">
     @if (!string.IsNullOrWhiteSpace(Model.CoverImageUrl)){
-      <img src="@Model.CoverImageUrl" alt="Obrázek kurzu @Model.Title" class="img-fluid rounded mb-2" loading="lazy" decoding="async" />
+      <img src="@Model.CoverImageUrl" alt="@Localizer["CourseImageAlt", Model.Title]" class="img-fluid rounded mb-2" loading="lazy" decoding="async" />
     }
     <h3 class="h5 mb-1">@Model.Title</h3>
     @if (!string.IsNullOrWhiteSpace(Model.Description)){
@@ -33,13 +34,13 @@
     <div class="d-flex flex-column align-items-end gap-2">
       <div class="form-check form-check-inline">
         <input class="form-check-input cmp-check" type="checkbox" value="@Model.Id" id="cmp_@Model.Id">
-        <label class="form-check-label small" for="cmp_@Model.Id">Porovnat</label>
+        <label class="form-check-label small" for="cmp_@Model.Id">@Localizer["Compare"]</label>
       </div>
       <div class="d-flex gap-2">
-        <a class="btn btn-outline-secondary" asp-page="/Courses/Details" asp-route-id="@Model.Id">Detail</a>
+        <a class="btn btn-outline-secondary" asp-page="/Courses/Details" asp-route-id="@Model.Id">@Localizer["Details"]</a>
         <form method="post" asp-page="/Courses/Index" asp-page-handler="AddToCart" class="d-inline">
           <input type="hidden" name="courseId" value="@Model.Id" />
-          <button type="submit" class="btn btn-primary" aria-label="Přihlásit se na @Model.Title">Přihlásit se</button>
+          <button type="submit" class="btn btn-primary" aria-label="@Localizer["EnrollAriaLabel", Model.Title]">@Localizer["Enroll"]</button>
         </form>
       </div>
     </div>

--- a/Pages/Shared/_AdvisorOffcanvas.cshtml
+++ b/Pages/Shared/_AdvisorOffcanvas.cshtml
@@ -1,6 +1,7 @@
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 <div class="offcanvas offcanvas-end" tabindex="-1" id="advisor" aria-labelledby="advisorLabel">
   <div class="offcanvas-header">
-    <h5 id="advisorLabel">Najdeme vhodné školení</h5>
+    <h5 id="advisorLabel">@Localizer["Heading"]</h5>
     <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
   </div>
   <div class="offcanvas-body">
@@ -9,10 +10,10 @@
       <select name="goal" class="form-select" goal-options></select>
       <div class="input-group">
         <span class="input-group-text"><i class="bi bi-geo-alt"></i></span>
-        <input class="form-control" name="City" placeholder="Město (volitelně)" />
+        <input class="form-control" name="City" placeholder="@Localizer["CityPlaceholder"]" />
       </div>
-      <div class="d-grid"><button class="btn btn-primary">Zobrazit návrhy</button></div>
-      <div class="text-muted small">Tip: Vaši volbu si zapamatujeme pro příště.</div>
+      <div class="d-grid"><button class="btn btn-primary">@Localizer["ShowSuggestions"]</button></div>
+      <div class="text-muted small">@Localizer["Tip"]</div>
     </form>
   </div>
 </div>

--- a/Resources/Pages.Shared.Components._CourseCard.cshtml.en.resx
+++ b/Resources/Pages.Shared.Components._CourseCard.cshtml.en.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CourseImageAlt" xml:space="preserve">
+    <value>Course image for {0}</value>
+  </data>
+  <data name="Compare" xml:space="preserve">
+    <value>Compare</value>
+  </data>
+  <data name="Details" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="Enroll" xml:space="preserve">
+    <value>Enroll</value>
+  </data>
+  <data name="EnrollAriaLabel" xml:space="preserve">
+    <value>Enroll in {0}</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared.Components._CourseCard.cshtml.resx
+++ b/Resources/Pages.Shared.Components._CourseCard.cshtml.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CourseImageAlt" xml:space="preserve">
+    <value>Obrázek kurzu {0}</value>
+  </data>
+  <data name="Compare" xml:space="preserve">
+    <value>Porovnat</value>
+  </data>
+  <data name="Details" xml:space="preserve">
+    <value>Detail</value>
+  </data>
+  <data name="Enroll" xml:space="preserve">
+    <value>Přihlásit se</value>
+  </data>
+  <data name="EnrollAriaLabel" xml:space="preserve">
+    <value>Přihlásit se na {0}</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._AdvisorOffcanvas.cshtml.en.resx
+++ b/Resources/Pages.Shared._AdvisorOffcanvas.cshtml.en.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>We will find the right training</value>
+  </data>
+  <data name="CityPlaceholder" xml:space="preserve">
+    <value>City (optional)</value>
+  </data>
+  <data name="ShowSuggestions" xml:space="preserve">
+    <value>Show suggestions</value>
+  </data>
+  <data name="Tip" xml:space="preserve">
+    <value>Tip: We will remember your choice for next time.</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._AdvisorOffcanvas.cshtml.resx
+++ b/Resources/Pages.Shared._AdvisorOffcanvas.cshtml.resx
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Najdeme vhodné školení</value>
+  </data>
+  <data name="CityPlaceholder" xml:space="preserve">
+    <value>Město (volitelně)</value>
+  </data>
+  <data name="ShowSuggestions" xml:space="preserve">
+    <value>Zobrazit návrhy</value>
+  </data>
+  <data name="Tip" xml:space="preserve">
+    <value>Tip: Vaši volbu si zapamatujeme pro příště.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- localize the course card component using IViewLocalizer for interactive text and aria labels
- add Czech and English resource entries for the course card strings
- localize the advisor offcanvas partial and add matching resource files for both supported cultures

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dce618de848321a379d7a1b68b95a0