### PR TITLE
Enhance homepage hero animations

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -5,17 +5,23 @@
     ViewData["Title"] = Localizer["Title"];
 }
 
-<section class="py-5 gradient-hero text-white text-center rounded-4 mb-4">
-    <div class="container-xl">
-        <h1 class="display-5 fw-bold mb-2">@Localizer["HeroHeadingPrefix"] <span class="underline-accent">@Localizer["HeroHeadingAccent"]</span></h1>
+<section class="py-5 gradient-hero text-white text-center rounded-4 mb-4 hero-section">
+    <div class="hero-background" aria-hidden="true">
+        <span class="hero-floating-icon hero-icon-1">ISO<br />9001</span>
+        <span class="hero-floating-icon hero-icon-2">ISO<br />14001</span>
+        <span class="hero-floating-icon hero-icon-3">ISO<br />45001</span>
+        <span class="hero-floating-icon hero-icon-4">ISO<br />27001</span>
+    </div>
+    <div class="container-xl position-relative">
+        <h1 class="display-5 fw-bold mb-2">@Localizer["HeroHeadingPrefix"] <span class="underline-accent"><span class="typewriter" data-typewriter-text="@Localizer["HeroHeadingAccent"]">@Localizer["HeroHeadingAccent"]</span></span></h1>
         <p class="lead mb-4 opacity-75">@Localizer["HeroSubheading"]</p>
 
         <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm">
             <div class="col-12 col-md-3">
-                <select name="persona" class="form-select" aria-label="@Localizer["PersonaAriaLabel"]" persona-options></select>
+                <select name="persona" class="form-select filter-select" aria-label="@Localizer["PersonaAriaLabel"]" persona-options></select>
             </div>
             <div class="col-12 col-md-3">
-                <select name="goal" class="form-select" aria-label="@Localizer["GoalAriaLabel"]" goal-options></select>
+                <select name="goal" class="form-select filter-select" aria-label="@Localizer["GoalAriaLabel"]" goal-options></select>
             </div>
             <div class="col-12 col-md-4">
                 <div class="input-group">
@@ -44,13 +50,13 @@
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-star-fill"></i>
-                    <span>@Localizer["TrustRating", "4.8/5"]</span>
+                    <span>@Html.Raw(Localizer["TrustRating", "<span class=\"stat-number\" data-target=\"4.8\" data-decimals=\"1\" data-suffix=\"/5\">4.8</span>"])</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-people"></i>
-                    <span>@Localizer["TrustGraduates", "10 000+"]</span>
+                    <span>@Html.Raw(Localizer["TrustGraduates", "<span class=\"stat-number\" data-target=\"10000\" data-suffix=\"+\">10 000</span>"])</span>
                 </div>
             </div>
             <div class="col">
@@ -70,17 +76,84 @@
 </section>
 
 <script>
-    // Ulož volby pro pozdější předvyplnění (malý závazek = vyšší konverze)
     (function () {
-        const form = document.getElementById('heroForm');
-        const pSel = form?.querySelector('select[name="persona"]');
-        const gSel = form?.querySelector('select[name="goal"]');
-        if (pSel && localStorage.persona) pSel.value = localStorage.persona;
-        if (gSel && localStorage.goal) gSel.value = localStorage.goal;
-        form?.addEventListener('submit', () => {
-            if (pSel) localStorage.persona = pSel.value || "";
-            if (gSel) localStorage.goal = gSel.value || "";
-        });
+        const locale = document.documentElement.lang || 'cs';
+
+        const restoreSelections = () => {
+            const form = document.getElementById('heroForm');
+            const pSel = form?.querySelector('select[name="persona"]');
+            const gSel = form?.querySelector('select[name="goal"]');
+            if (pSel && localStorage.persona) pSel.value = localStorage.persona;
+            if (gSel && localStorage.goal) gSel.value = localStorage.goal;
+            form?.addEventListener('submit', () => {
+                if (pSel) localStorage.persona = pSel.value || "";
+                if (gSel) localStorage.goal = gSel.value || "";
+            });
+        };
+
+        const runTypewriter = () => {
+            const el = document.querySelector('.typewriter');
+            if (!el) return;
+            const text = el.getAttribute('data-typewriter-text') || '';
+            let index = 0;
+            el.classList.add('is-typing');
+            el.textContent = '';
+
+            const step = () => {
+                if (index <= text.length) {
+                    el.textContent = text.slice(0, index);
+                    index += 1;
+                    window.setTimeout(step, 70);
+                } else {
+                    el.classList.remove('is-typing');
+                    el.classList.add('typewriter-complete');
+                }
+            };
+
+            step();
+        };
+
+        const animateStats = () => {
+            const stats = document.querySelectorAll('.stat-number');
+            if (!stats.length) return;
+
+            stats.forEach((el) => {
+                const target = Number(el.getAttribute('data-target')) || 0;
+                const decimals = Number(el.getAttribute('data-decimals')) || 0;
+                const duration = Number(el.getAttribute('data-duration')) || 1600;
+                const prefix = el.getAttribute('data-prefix') || '';
+                const suffix = el.getAttribute('data-suffix') || '';
+
+                const startTimestamp = performance.now();
+
+                const tick = (now) => {
+                    const progress = Math.min((now - startTimestamp) / duration, 1);
+                    const current = target * progress;
+                    const formatted = current.toLocaleString(locale, {
+                        minimumFractionDigits: decimals,
+                        maximumFractionDigits: decimals
+                    });
+                    el.textContent = `${prefix}${formatted}${suffix}`;
+                    if (progress < 1) {
+                        requestAnimationFrame(tick);
+                    }
+                };
+
+                requestAnimationFrame(tick);
+            });
+        };
+
+        const init = () => {
+            restoreSelections();
+            runTypewriter();
+            animateStats();
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
     })();
 </script>
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -287,6 +287,149 @@ select:focus-visible,
   background: linear-gradient(transparent 65%, rgba(254, 204, 68, 0.65) 0);
 }
 
+.hero-section {
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-section .container-xl {
+  position: relative;
+  z-index: 2;
+}
+
+.hero-background {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.08), transparent 45%),
+              radial-gradient(circle at 85% 25%, rgba(254, 204, 68, 0.12), transparent 60%),
+              radial-gradient(circle at 20% 80%, rgba(28, 168, 215, 0.12), transparent 55%);
+}
+
+.hero-floating-icon {
+  position: absolute;
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: clamp(4rem, 10vw, 6rem);
+  height: clamp(4rem, 10vw, 6rem);
+  border-radius: 1.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: clamp(0.8rem, 2vw, 1rem);
+  color: rgba(15, 23, 42, 0.75);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.6));
+  box-shadow: 0 18px 32px rgba(28, 168, 215, 0.18);
+  animation: heroFloat 18s ease-in-out infinite;
+}
+
+.hero-icon-1 {
+  top: 12%;
+  left: 10%;
+  animation-delay: -2s;
+}
+
+.hero-icon-2 {
+  top: 20%;
+  right: 12%;
+  animation-delay: -6s;
+}
+
+.hero-icon-3 {
+  bottom: 18%;
+  left: 18%;
+  animation-delay: -10s;
+}
+
+.hero-icon-4 {
+  bottom: 12%;
+  right: 20%;
+  animation-delay: -14s;
+}
+
+@keyframes heroFloat {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) rotate(-2deg);
+    opacity: 0.7;
+  }
+  25% {
+    transform: translate3d(8px, -12px, 0) rotate(2deg);
+    opacity: 0.85;
+  }
+  50% {
+    transform: translate3d(-6px, -20px, 0) rotate(-3deg);
+    opacity: 0.95;
+  }
+  75% {
+    transform: translate3d(-10px, 8px, 0) rotate(3deg);
+    opacity: 0.8;
+  }
+}
+
+.typewriter {
+  position: relative;
+  display: inline-block;
+  padding-right: 0.25rem;
+  white-space: nowrap;
+}
+
+.typewriter::after {
+  content: "";
+  position: absolute;
+  right: -0.15rem;
+  top: 10%;
+  bottom: 10%;
+  width: 2px;
+  background-color: var(--accent);
+  border-radius: 999px;
+  animation: caretBlink 1s steps(2, start) infinite;
+}
+
+.typewriter.is-typing::after {
+  animation: none;
+  opacity: 1;
+}
+
+@keyframes caretBlink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.stat-number {
+  display: inline-block;
+  min-width: 3ch;
+  font-variant-numeric: tabular-nums;
+}
+
+.filter-select {
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background-color: rgba(255, 255, 255, 0.15);
+  color: var(--neutral-900);
+}
+
+.filter-select:hover,
+.filter-select:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px rgba(28, 168, 215, 0.25);
+  border-color: rgba(254, 204, 68, 0.7);
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.filter-select option {
+  color: var(--neutral-900);
+}
+
 .trust-stripe {
   background: linear-gradient(180deg, rgba(28, 168, 215, 0.06), rgba(28, 168, 215, 0.02));
   border: 1px solid rgba(28, 168, 215, 0.15);


### PR DESCRIPTION
## Summary
- add animated ISO certificate background and hover interactions to the homepage hero
- implement a localized typewriter effect and animated statistics counters
- refresh hero filter styling with subtle micro-interactions while preserving existing form persistence

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcef9586f08321a1713ceea5ee30fe