### PR TITLE
Enhance course filters with live search and compare

### DIFF
--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -14,22 +14,14 @@
 </ul>
 
 <div class="result-header sticky-top z-2 d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 py-2 bg-body border-bottom">
-    <div class="small text-muted">
-        @Localizer["ResultCount", Model.TotalCount]
-        @if (!string.IsNullOrWhiteSpace(HttpContext.Request.Query["persona"]))
-        {
-            <span class="ms-2 badge bg-primary-subtle text-primary">@(HttpContext.Request.Query["persona"])</span>
-        }
-        @if (!string.IsNullOrWhiteSpace(HttpContext.Request.Query["goal"]))
-        {
-            <span class="ms-1 badge bg-warning">@((string)HttpContext.Request.Query["goal"])</span>
-        }
-    </div>
+    <div class="small text-muted" id="resultCount" data-count-template="@Localizer["ResultCount", "{0}"].Value">@Localizer["ResultCount", Model.TotalCount]</div>
     <div class="d-flex gap-2">
-        <a class="btn btn-sm btn-outline-secondary" href="@Url.Page("/Courses/Index")">@Localizer["ResetFilters"]</a>
+        <a class="btn btn-sm btn-outline-secondary" data-action="reset-all" href="@Url.Page("/Courses/Index")">@Localizer["ResetFilters"]</a>
         <a class="btn btn-sm btn-outline-primary d-lg-none" data-bs-toggle="offcanvas" href="#filters"><i class="bi bi-sliders"></i> @Localizer["FiltersButton"]</a>
     </div>
 </div>
+
+<div id="activeFilters" class="d-flex flex-wrap gap-2 mb-3"></div>
 
 <div id="cmpBar" class="compare-bar d-none" data-count-format="@Localizer["CompareBarCountFormat"].Value" data-cta-text="@Localizer["CompareBarCta"].Value">
     <div class="container-xl d-flex justify-content-between align-items-center">
@@ -37,57 +29,8 @@
         <a id="cmpGo" class="btn btn-primary btn-sm disabled" aria-disabled="true">@Localizer["CompareBarCta"]</a>
     </div>
 </div>
-<script>
-    const bar = document.getElementById('cmpBar');
-    const btn = document.getElementById('cmpGo');
-    const cnt = document.getElementById('cmpCount');
 
-    if (bar && btn && cnt) {
-        const countFormat = bar.dataset.countFormat ?? '{0}';
-        const ctaText = bar.dataset.ctaText ?? btn.textContent ?? '';
-        const sel = new Set();
-
-        if (ctaText) {
-            btn.textContent = ctaText;
-        }
-
-        const updateCountText = (value) => {
-            cnt.textContent = countFormat.replace('{0}', value.toString());
-        };
-
-        updateCountText(0);
-
-        document.querySelectorAll('.cmp-check').forEach(ch => {
-            ch.addEventListener('change', () => {
-                if (ch.checked) {
-                    sel.add(ch.value);
-                } else {
-                    sel.delete(ch.value);
-                }
-
-                const selected = sel.size;
-                updateCountText(selected);
-
-                if (selected > 1 && selected <= 3) {
-                    bar.classList.remove('d-none');
-                    btn.classList.remove('disabled');
-                    btn.removeAttribute('aria-disabled');
-                    btn.href = '/Courses/Compare?ids=' + Array.from(sel).join(',');
-                } else {
-                    btn.classList.add('disabled');
-                    btn.setAttribute('aria-disabled', 'true');
-                    btn.removeAttribute('href');
-
-                    if (selected === 0) {
-                        bar.classList.add('d-none');
-                    } else {
-                        bar.classList.remove('d-none');
-                    }
-                }
-            });
-        });
-    }
-</script>
+<div id="courseError" class="alert alert-danger d-none" role="alert"></div>
 
 @if (TempData["CartError"] is string cartError && !string.IsNullOrWhiteSpace(cartError))
 {
@@ -103,25 +46,130 @@
         </div>
     </aside>
     <main class="col-lg-9">
-        <div class="courses-grid">
+        <div id="coursesGrid" class="courses-grid">
             @foreach (var c in Model.Courses)
             {
                 @await Html.PartialAsync("/Pages/Shared/Components/_CourseCard.cshtml", c)
             }
         </div>
 
-        @if (Model.TotalPages > 1)
-        {
-            <nav class="mt-3" aria-label='@Localizer["PaginationLabel"]'>
-                <ul class="pagination">
-                    <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : "")">
-                        <a class="page-link" asp-route-PageNumber="@(Model.PageNumber - 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">@Localizer["Previous"]</a>
-                    </li>
-                    <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : "")">
-                        <a class="page-link" asp-route-PageNumber="@(Model.PageNumber + 1)" asp-route-CourseGroupId="@Model.CourseGroupId" asp-route-SearchString="@Model.SearchString" asp-route-Level="@Model.Level" asp-route-Mode="@Model.Mode" asp-route-MinDuration="@Model.MinDuration" asp-route-MaxDuration="@Model.MaxDuration" asp-route-SelectedTagIds="@Model.SelectedTagIds">@Localizer["Next"]</a>
-                    </li>
-                </ul>
-            </nav>
-        }
+        <div id="noCourses" class="alert alert-info @(Model.Courses.Count == 0 ? string.Empty : "d-none")" role="status">@Localizer["NoCoursesFound"]</div>
+
+        <nav class="mt-3 @(Model.TotalPages > 1 ? string.Empty : "d-none")" aria-label='@Localizer["PaginationLabel"]' id="coursePagination">
+            <ul class="pagination mb-0">
+                <li class="page-item @(Model.PageNumber <= 1 ? "disabled" : string.Empty)">
+                    <button class="page-link" type="button" data-action="prev-page">@Localizer["Previous"]</button>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link" id="paginationStatus">@Model.PageNumber / @Model.TotalPages</span>
+                </li>
+                <li class="page-item @(Model.PageNumber >= Model.TotalPages ? "disabled" : string.Empty)">
+                    <button class="page-link" type="button" data-action="next-page">@Localizer["Next"]</button>
+                </li>
+            </ul>
+        </nav>
     </main>
 </div>
+
+@{
+    var culture = System.Globalization.CultureInfo.CurrentCulture;
+    var decimalSeparator = culture.NumberFormat.NumberDecimalSeparator;
+    string cultureName = culture.Name;
+    string currencyCode;
+    try
+    {
+        var region = new System.Globalization.RegionInfo(culture.LCID);
+        currencyCode = region.ISOCurrencySymbol;
+    }
+    catch
+    {
+        currencyCode = "CZK";
+    }
+
+    var config = new
+    {
+        price = new { min = Model.PriceMinimum, max = Model.PriceMaximum },
+        initial = new
+        {
+            pageNumber = Model.PageNumber,
+            totalPages = Model.TotalPages,
+            totalCount = Model.TotalCount,
+            search = Model.SearchString ?? string.Empty,
+            norms = Model.SelectedTagIds,
+            cities = Model.SelectedCityTagIds,
+            levels = Model.SelectedLevels.Select(l => l.ToString()),
+            types = Model.SelectedTypes.Select(t => t.ToString()),
+            minPrice = Model.MinPrice ?? Model.PriceMinimum,
+            maxPrice = Model.MaxPrice ?? Model.PriceMaximum,
+            hasFilters = Model.HasActiveFilters,
+            courses = Model.Courses.Select(c => new
+            {
+                id = c.Id,
+                title = c.Title,
+                description = c.Description,
+                level = c.Level.ToString(),
+                mode = c.Mode.ToString(),
+                type = c.Type.ToString(),
+                duration = c.Duration,
+                durationDisplay = string.Format(culture, "{0} min", c.Duration),
+                dateDisplay = c.Date.ToString("d", culture),
+                price = c.Price,
+                priceDisplay = c.Price.ToString("C", culture),
+                coverImageUrl = c.CoverImageUrl,
+                popoverHtml = c.PopoverHtml,
+                detailsUrl = Url.Page("/Courses/Details", new { id = c.Id }) ?? $"/Courses/Details/{c.Id}",
+                addToCartUrl = Url.Page("/Courses/Index", pageHandler: "AddToCart") ?? "/Courses/Index?handler=AddToCart"
+            })
+        },
+        filters = new
+        {
+            norms = Model.NormOptions.Select(o => new { id = o.Id, name = o.Name }),
+            cities = Model.CityOptions.Select(o => new { id = o.Id, name = o.Name }),
+            levels = Model.LevelOptions.Select(o => new { value = o.Value, label = o.Label }),
+            types = Model.TypeOptions.Select(o => new { value = o.Value, label = o.Label })
+        },
+        resources = new
+        {
+            searchPlaceholder = Localizer["SearchPlaceholder"].Value ?? string.Empty,
+            searchLabel = Localizer["SearchLabel"].Value ?? "Hledat",
+            normsLabel = Localizer["NormsLabel"].Value ?? "Normy",
+            citiesLabel = Localizer["CitiesLabel"].Value ?? "Města",
+            levelsLabel = Localizer["LevelsLabel"].Value ?? "Úrovně",
+            typesLabel = Localizer["TypesLabel"].Value ?? "Forma",
+            priceRangeLabel = Localizer["PriceRangeLabel"].Value ?? "Rozsah ceny",
+            priceLabel = Localizer["PriceLabel"].Value ?? "Cena",
+            saveFilters = Localizer["SaveFilters"].Value ?? "Uložit filtry",
+            savedMessage = Localizer["FiltersSaved"].Value ?? "Filtry byly uloženy.",
+            clearFilters = Localizer["ResetFilters"].Value ?? "Resetovat",
+            compareLabel = Localizer["Compare"].Value ?? "Porovnat",
+            detailsLabel = Localizer["Details"].Value ?? "Detail",
+            enrollLabel = Localizer["Enroll"].Value ?? "Přihlásit",
+            resultCountTemplate = Localizer["ResultCount", "{0}"].Value ?? "{0}",
+            noResults = Localizer["NoCoursesFound"].Value ?? "Žádné kurzy neodpovídají výběru.",
+            fetchError = Localizer["FetchError"].Value ?? "Nepodařilo se načíst kurzy.",
+            pageStatusTemplate = Localizer["PageStatus", "{0}", "{1}"].Value ?? "{0}/{1}",
+            removeLabel = Localizer["RemoveFilter"].Value ?? "Odebrat filtr",
+            currencySymbol = culture.NumberFormat.CurrencySymbol
+        },
+        culture = new
+        {
+            name = cultureName,
+            decimalSeparator,
+            currencySymbol = culture.NumberFormat.CurrencySymbol,
+            currencyCode
+        }
+    };
+
+    var jsonOptions = new System.Text.Json.JsonSerializerOptions
+    {
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    var configJson = System.Text.Json.JsonSerializer.Serialize(config, jsonOptions);
+}
+<script type="application/json" id="courseFiltersData">@Html.Raw(configJson)</script>
+
+@section Scripts {
+    <script type="module" src="~/js/courseFilters.js"></script>
+}

--- a/Pages/Courses/Index.cshtml.cs
+++ b/Pages/Courses/Index.cshtml.cs
@@ -1,10 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 using SysJaky_N.Data;
 using SysJaky_N.Services;
 using SysJaky_N.Models;
+using System.Globalization;
 
 namespace SysJaky_N.Pages.Courses;
 
@@ -27,185 +27,404 @@ public class IndexModel : PageModel
     public int PageNumber { get; set; } = 1;
 
     [BindProperty(SupportsGet = true)]
-    public int? CourseGroupId { get; set; }
-
-    [BindProperty(SupportsGet = true)]
     public string? SearchString { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    public CourseLevel? Level { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    public CourseMode? Mode { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    public int? MinDuration { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    public int? MaxDuration { get; set; }
 
     [BindProperty(SupportsGet = true)]
     public List<int> SelectedTagIds { get; set; } = new();
 
-    public SelectList CourseGroups { get; set; } = default!;
+    [BindProperty(SupportsGet = true)]
+    public List<int> SelectedCityTagIds { get; set; } = new();
 
-    public IEnumerable<SelectListItem> LevelOptions { get; set; } = Enumerable.Empty<SelectListItem>();
+    [BindProperty(SupportsGet = true)]
+    public List<CourseLevel> SelectedLevels { get; set; } = new();
 
-    public IEnumerable<SelectListItem> ModeOptions { get; set; } = Enumerable.Empty<SelectListItem>();
+    [BindProperty(SupportsGet = true)]
+    public List<CourseType> SelectedTypes { get; set; } = new();
 
-    public IEnumerable<SelectListItem> TagOptions { get; set; } = Enumerable.Empty<SelectListItem>();
+    [BindProperty(SupportsGet = true)]
+    public decimal? MinPrice { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    public decimal? MaxPrice { get; set; }
+
+    public IReadOnlyList<FilterOption> NormOptions { get; private set; } = Array.Empty<FilterOption>();
+
+    public IReadOnlyList<FilterOption> CityOptions { get; private set; } = Array.Empty<FilterOption>();
+
+    public IReadOnlyList<EnumOption> LevelOptions { get; private set; } = Array.Empty<EnumOption>();
+
+    public IReadOnlyList<EnumOption> TypeOptions { get; private set; } = Array.Empty<EnumOption>();
+
+    public decimal PriceMinimum { get; private set; }
+
+    public decimal PriceMaximum { get; private set; }
 
     public int TotalPages { get; set; }
 
     public int TotalCount { get; set; }
 
+    public bool HasActiveFilters { get; private set; }
+
+    private static readonly string[] KnownCityNames = new[]
+    {
+        "Praha",
+        "Brno",
+        "Ostrava",
+        "Plzeň",
+        "Liberec",
+        "Olomouc",
+        "Hradec Králové",
+        "Pardubice",
+        "České Budějovice",
+        "Zlín"
+    };
+
+    private const int PageSize = 10;
+
     public async Task OnGetAsync()
     {
-        const int pageSize = 10;
+        await InitializeFiltersAsync();
 
-        if (PageNumber < 1)
-        {
-            PageNumber = 1;
-        }
-
-        CourseGroups = new SelectList(_context.CourseGroups, "Id", "Name");
-        LevelOptions = Enum.GetValues<CourseLevel>()
-            .Select(level => new SelectListItem
-            {
-                Text = level.ToString(),
-                Value = level.ToString(),
-                Selected = Level == level
-            })
-            .ToList();
-        ModeOptions = Enum.GetValues<CourseMode>()
-            .Select(mode => new SelectListItem
-            {
-                Text = mode.ToString(),
-                Value = mode.ToString(),
-                Selected = Mode == mode
-            })
-            .ToList();
-
-        SelectedTagIds ??= new List<int>();
-        var selectedTagSet = new HashSet<int>(SelectedTagIds);
-        TagOptions = await _context.Tags
-            .AsNoTracking()
-            .OrderBy(t => t.Name)
-            .Select(t => new SelectListItem
-            {
-                Text = t.Name,
-                Value = t.Id.ToString(),
-                Selected = selectedTagSet.Contains(t.Id)
-            })
-            .ToListAsync();
-
-        var sortedTagIds = selectedTagSet.OrderBy(id => id).ToArray();
-        var normalizedSearch = string.IsNullOrWhiteSpace(SearchString) ? null : SearchString.Trim();
-        var courseGroupId = CourseGroupId;
-        var level = Level;
-        var mode = Mode;
-        var pageNumber = PageNumber;
-
-        var minDuration = MinDuration;
-        var maxDuration = MaxDuration;
-        if (minDuration.HasValue && maxDuration.HasValue && minDuration > maxDuration)
-        {
-            (minDuration, maxDuration) = (maxDuration, minDuration);
-        }
-
-        var cacheKey = BuildCourseListCacheKey(
-            pageNumber,
-            courseGroupId,
-            normalizedSearch,
-            level,
-            mode,
-            minDuration,
-            maxDuration,
-            sortedTagIds);
-
-        var cacheEntry = await _cacheService.GetCourseListAsync(cacheKey, async () =>
-        {
-            var query = _context.Courses
-                .AsNoTracking()
-                .Include(c => c.CourseGroup)
-                .Include(c => c.CourseTags)
-                    .ThenInclude(ct => ct.Tag)
-                .AsQueryable();
-
-            if (courseGroupId.HasValue)
-            {
-                query = query.Where(c => c.CourseGroupId == courseGroupId.Value);
-            }
-
-            if (!string.IsNullOrEmpty(normalizedSearch))
-            {
-                var pattern = $"%{normalizedSearch}%";
-                query = query.Where(c => EF.Functions.Like(c.Title, pattern));
-            }
-
-            if (level.HasValue)
-            {
-                query = query.Where(c => c.Level == level.Value);
-            }
-
-            if (mode.HasValue)
-            {
-                query = query.Where(c => c.Mode == mode.Value);
-            }
-
-            if (minDuration.HasValue)
-            {
-                query = query.Where(c => c.Duration >= minDuration.Value);
-            }
-
-            if (maxDuration.HasValue)
-            {
-                query = query.Where(c => c.Duration <= maxDuration.Value);
-            }
-
-            if (sortedTagIds.Length > 0)
-            {
-                var tagIds = sortedTagIds;
-                query = query.Where(c => c.CourseTags.Any(ct => tagIds.Contains(ct.TagId)));
-            }
-
-            query = query.OrderBy(c => c.Date);
-
-            var count = await query.CountAsync();
-            var totalPages = (int)Math.Ceiling(count / (double)pageSize);
-            var courses = await query
-                .Skip((pageNumber - 1) * pageSize)
-                .Take(pageSize)
-                .ToListAsync();
-
-            return new CourseListCacheEntry(courses, totalPages, count);
-        });
+        var filterContext = BuildFilterContext();
+        var cacheKey = BuildCourseListCacheKey(filterContext);
+        var cacheEntry = await LoadCoursesAsync(filterContext, cacheKey);
 
         TotalPages = cacheEntry.TotalPages;
         TotalCount = cacheEntry.TotalCount;
         Courses = cacheEntry.Courses.ToList();
     }
 
-    private static string BuildCourseListCacheKey(
-        int pageNumber,
-        int? courseGroupId,
-        string? search,
-        CourseLevel? level,
-        CourseMode? mode,
-        int? minDuration,
-        int? maxDuration,
-        IReadOnlyList<int> tagIds)
+    public async Task<IActionResult> OnGetCoursesAsync()
     {
-        var searchKey = string.IsNullOrWhiteSpace(search) ? "none" : Uri.EscapeDataString(search);
-        var tagsKey = tagIds.Count == 0 ? "none" : string.Join('-', tagIds);
-        var levelKey = level?.ToString() ?? "null";
-        var modeKey = mode?.ToString() ?? "null";
-        var groupKey = courseGroupId?.ToString() ?? "null";
-        var minKey = minDuration?.ToString() ?? "null";
-        var maxKey = maxDuration?.ToString() ?? "null";
+        await InitializeFiltersAsync();
 
-        return $"page={pageNumber}|group={groupKey}|search={searchKey}|level={levelKey}|mode={modeKey}|min={minKey}|max={maxKey}|tags={tagsKey}";
+        var filterContext = BuildFilterContext();
+        var cacheKey = BuildCourseListCacheKey(filterContext);
+        var cacheEntry = await LoadCoursesAsync(filterContext, cacheKey);
+
+        var courseSummaries = cacheEntry.Courses
+            .Select(ToCourseSummary)
+            .ToList();
+
+        return new JsonResult(new CoursesResponse(
+            new PaginationMetadata(filterContext.PageNumber, cacheEntry.TotalPages, cacheEntry.TotalCount),
+            courseSummaries,
+            new PriceRange(PriceMinimum, PriceMaximum)));
     }
+
+    private async Task InitializeFiltersAsync()
+    {
+        SelectedTagIds ??= new List<int>();
+        SelectedCityTagIds ??= new List<int>();
+        SelectedLevels ??= new List<CourseLevel>();
+        SelectedTypes ??= new List<CourseType>();
+
+        var allTags = await _context.Tags
+            .AsNoTracking()
+            .OrderBy(t => t.Name)
+            .Select(t => new FilterOption(t.Id, t.Name))
+            .ToListAsync();
+
+        var normCandidates = allTags
+            .Where(t => t.Name.Contains("ISO", StringComparison.OrdinalIgnoreCase)
+                || t.Name.Contains("ČSN", StringComparison.OrdinalIgnoreCase)
+                || t.Name.Contains("EN", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        NormOptions = normCandidates.Count > 0 ? normCandidates : allTags;
+
+        var knownCitySet = new HashSet<string>(KnownCityNames, StringComparer.OrdinalIgnoreCase);
+        var cityOptions = allTags
+            .Where(t => knownCitySet.Contains(t.Name))
+            .ToList();
+        CityOptions = cityOptions;
+
+        LevelOptions = Enum.GetValues<CourseLevel>()
+            .Select(level => new EnumOption(level.ToString(), level.ToString()))
+            .ToList();
+
+        TypeOptions = Enum.GetValues<CourseType>()
+            .Select(type => new EnumOption(type.ToString(), type.ToString()))
+            .ToList();
+
+        SelectedTagIds = SelectedTagIds
+            .Where(id => NormOptions.Any(opt => opt.Id == id))
+            .Distinct()
+            .OrderBy(id => id)
+            .ToList();
+
+        SelectedCityTagIds = SelectedCityTagIds
+            .Where(id => CityOptions.Any(opt => opt.Id == id))
+            .Distinct()
+            .OrderBy(id => id)
+            .ToList();
+
+        SelectedLevels = SelectedLevels
+            .Distinct()
+            .OrderBy(l => l)
+            .ToList();
+
+        SelectedTypes = SelectedTypes
+            .Distinct()
+            .OrderBy(t => t)
+            .ToList();
+
+        var priceQuery = _context.Courses
+            .AsNoTracking()
+            .Where(c => c.IsActive)
+            .Select(c => c.Price);
+
+        if (await priceQuery.AnyAsync())
+        {
+            PriceMinimum = await priceQuery.MinAsync();
+            PriceMaximum = await priceQuery.MaxAsync();
+        }
+        else
+        {
+            PriceMinimum = 0m;
+            PriceMaximum = 0m;
+        }
+
+        if (!MinPrice.HasValue)
+        {
+            MinPrice = PriceMinimum;
+        }
+
+        if (!MaxPrice.HasValue)
+        {
+            MaxPrice = PriceMaximum;
+        }
+
+        if (MinPrice.HasValue && MaxPrice.HasValue && MinPrice > MaxPrice)
+        {
+            (MinPrice, MaxPrice) = (MaxPrice, MinPrice);
+        }
+    }
+
+    private CourseFilterContext BuildFilterContext()
+    {
+        if (PageNumber < 1)
+        {
+            PageNumber = 1;
+        }
+
+        var normalizedSearch = string.IsNullOrWhiteSpace(SearchString)
+            ? null
+            : SearchString.Trim();
+
+        var normIds = SelectedTagIds?.Distinct().OrderBy(id => id).ToArray() ?? Array.Empty<int>();
+        var cityIds = SelectedCityTagIds?.Distinct().OrderBy(id => id).ToArray() ?? Array.Empty<int>();
+        var levelValues = SelectedLevels?.Distinct().OrderBy(l => l).ToArray() ?? Array.Empty<CourseLevel>();
+        var typeValues = SelectedTypes?.Distinct().OrderBy(t => t).ToArray() ?? Array.Empty<CourseType>();
+
+        var minPrice = MinPrice;
+        var maxPrice = MaxPrice;
+        if (minPrice.HasValue && maxPrice.HasValue && minPrice > maxPrice)
+        {
+            (minPrice, maxPrice) = (maxPrice, minPrice);
+            MinPrice = minPrice;
+            MaxPrice = maxPrice;
+        }
+
+        HasActiveFilters = !string.IsNullOrWhiteSpace(normalizedSearch)
+            || normIds.Length > 0
+            || cityIds.Length > 0
+            || levelValues.Length > 0
+            || typeValues.Length > 0
+            || (minPrice.HasValue && minPrice.Value > PriceMinimum)
+            || (maxPrice.HasValue && maxPrice.Value < PriceMaximum);
+
+        var clampedMin = ClampPrice(minPrice, PriceMinimum, PriceMaximum);
+        var clampedMax = ClampPrice(maxPrice, PriceMinimum, PriceMaximum);
+
+        if (clampedMin != minPrice)
+        {
+            MinPrice = clampedMin;
+        }
+
+        if (clampedMax != maxPrice)
+        {
+            MaxPrice = clampedMax;
+        }
+
+        return new CourseFilterContext(
+            PageNumber,
+            normalizedSearch,
+            normIds,
+            cityIds,
+            levelValues,
+            typeValues,
+            clampedMin,
+            clampedMax);
+    }
+
+    private static decimal? ClampPrice(decimal? value, decimal min, decimal max)
+    {
+        if (!value.HasValue)
+        {
+            return null;
+        }
+
+        var v = value.Value;
+        if (v < min)
+        {
+            return min;
+        }
+
+        if (v > max)
+        {
+            return max;
+        }
+
+        return v;
+    }
+
+    private Task<CourseListCacheEntry> LoadCoursesAsync(CourseFilterContext filterContext, string cacheKey)
+    {
+        return _cacheService.GetCourseListAsync(cacheKey, async () =>
+        {
+            var query = _context.Courses
+                .AsNoTracking()
+                .Include(c => c.CourseGroup)
+                .Include(c => c.CourseTags)
+                    .ThenInclude(ct => ct.Tag)
+                .Where(c => c.IsActive)
+                .AsQueryable();
+
+            if (!string.IsNullOrEmpty(filterContext.Search))
+            {
+                var pattern = $"%{filterContext.Search}%";
+                query = query.Where(c => EF.Functions.Like(c.Title, pattern));
+            }
+
+            if (filterContext.NormTagIds.Count > 0)
+            {
+                var tagIds = filterContext.NormTagIds;
+                query = query.Where(c => c.CourseTags.Any(ct => tagIds.Contains(ct.TagId)));
+            }
+
+            if (filterContext.CityTagIds.Count > 0)
+            {
+                var cityIds = filterContext.CityTagIds;
+                query = query.Where(c => c.CourseTags.Any(ct => cityIds.Contains(ct.TagId)));
+            }
+
+            if (filterContext.Levels.Count > 0)
+            {
+                var levels = filterContext.Levels;
+                query = query.Where(c => levels.Contains(c.Level));
+            }
+
+            if (filterContext.Types.Count > 0)
+            {
+                var types = filterContext.Types;
+                query = query.Where(c => types.Contains(c.Type));
+            }
+
+            if (filterContext.MinPrice.HasValue)
+            {
+                var minPrice = filterContext.MinPrice.Value;
+                query = query.Where(c => c.Price >= minPrice);
+            }
+
+            if (filterContext.MaxPrice.HasValue)
+            {
+                var maxPrice = filterContext.MaxPrice.Value;
+                query = query.Where(c => c.Price <= maxPrice);
+            }
+
+            query = query.OrderBy(c => c.Date);
+
+            var count = await query.CountAsync();
+            var totalPages = (int)Math.Ceiling(count / (double)PageSize);
+            var courses = await query
+                .Skip((filterContext.PageNumber - 1) * PageSize)
+                .Take(PageSize)
+                .ToListAsync();
+
+            return new CourseListCacheEntry(courses, totalPages, count);
+        });
+    }
+
+    private static string BuildCourseListCacheKey(CourseFilterContext filterContext)
+    {
+        var searchKey = string.IsNullOrWhiteSpace(filterContext.Search) ? "none" : Uri.EscapeDataString(filterContext.Search);
+        var normsKey = filterContext.NormTagIds.Count == 0 ? "none" : string.Join('-', filterContext.NormTagIds);
+        var citiesKey = filterContext.CityTagIds.Count == 0 ? "none" : string.Join('-', filterContext.CityTagIds);
+        var levelsKey = filterContext.Levels.Count == 0 ? "none" : string.Join('-', filterContext.Levels);
+        var typesKey = filterContext.Types.Count == 0 ? "none" : string.Join('-', filterContext.Types);
+        var minKey = filterContext.MinPrice?.ToString(CultureInfo.InvariantCulture) ?? "null";
+        var maxKey = filterContext.MaxPrice?.ToString(CultureInfo.InvariantCulture) ?? "null";
+
+        return $"page={filterContext.PageNumber}|search={searchKey}|norms={normsKey}|cities={citiesKey}|levels={levelsKey}|types={typesKey}|minPrice={minKey}|maxPrice={maxKey}";
+    }
+
+    private CourseSummary ToCourseSummary(Course course)
+    {
+        var culture = CultureInfo.CurrentCulture;
+        var dateDisplay = course.Date.ToString("d", culture);
+        var priceDisplay = course.Price.ToString("C", culture);
+        var durationDisplay = string.Format(culture, "{0} min", course.Duration);
+
+        var detailsUrl = Url.Page("/Courses/Details", new { id = course.Id }) ?? $"/Courses/Details/{course.Id}";
+        var addToCartUrl = Url.Page("/Courses/Index", pageHandler: "AddToCart") ?? "/Courses/Index?handler=AddToCart";
+
+        return new CourseSummary(
+            course.Id,
+            course.Title,
+            course.Description,
+            course.Level.ToString(),
+            course.Mode.ToString(),
+            course.Type.ToString(),
+            course.Duration,
+            durationDisplay,
+            dateDisplay,
+            course.Price,
+            priceDisplay,
+            course.CoverImageUrl,
+            course.PopoverHtml,
+            detailsUrl,
+            addToCartUrl);
+    }
+
+    private record CourseFilterContext(
+        int PageNumber,
+        string? Search,
+        IReadOnlyList<int> NormTagIds,
+        IReadOnlyList<int> CityTagIds,
+        IReadOnlyList<CourseLevel> Levels,
+        IReadOnlyList<CourseType> Types,
+        decimal? MinPrice,
+        decimal? MaxPrice);
+
+    public record FilterOption(int Id, string Name);
+
+    public record EnumOption(string Value, string Label);
+
+    private record CoursesResponse(
+        PaginationMetadata Pagination,
+        IReadOnlyList<CourseSummary> Courses,
+        PriceRange PriceRange);
+
+    private record PaginationMetadata(int PageNumber, int TotalPages, int TotalCount);
+
+    private record PriceRange(decimal Min, decimal Max);
+
+    private record CourseSummary(
+        int Id,
+        string Title,
+        string? Description,
+        string Level,
+        string Mode,
+        string Type,
+        int Duration,
+        string DurationDisplay,
+        string DateDisplay,
+        decimal Price,
+        string PriceDisplay,
+        string? CoverImageUrl,
+        string? PopoverHtml,
+        string DetailsUrl,
+        string AddToCartUrl);
 
     public async Task<IActionResult> OnPostAddToCartAsync(int courseId)
     {

--- a/Pages/Courses/_FiltersForm.cshtml
+++ b/Pages/Courses/_FiltersForm.cshtml
@@ -2,44 +2,44 @@
 @using Microsoft.AspNetCore.Mvc.Localization
 @inject IViewLocalizer Localizer
 
-<form method="get" class="mb-0" role="search" aria-label='@Localizer["FiltersAria"]'>
-    <div class="row g-2">
-        <div class="col-sm-6 col-lg-12">
-            <input type="text" asp-for="SearchString" placeholder='@Localizer["SearchPlaceholder"]' class="form-control" aria-label='@Localizer["SearchAria"]' />
-        </div>
-        <div class="col-sm-6 col-lg-12">
-            <select asp-for="CourseGroupId" asp-items="Model.CourseGroups" class="form-select" aria-label='@Localizer["CourseGroupAria"]'>
-                <option value="">@Localizer["CourseGroupAll"]</option>
-            </select>
-        </div>
-        <div class="col-sm-6 col-lg-12">
-            <select asp-for="Level" asp-items="Model.LevelOptions" class="form-select" aria-label='@Localizer["LevelAria"]'>
-                <option value="">@Localizer["LevelAll"]</option>
-            </select>
-        </div>
-        <div class="col-sm-6 col-lg-12">
-            <select asp-for="Mode" asp-items="Model.ModeOptions" class="form-select" aria-label='@Localizer["ModeAria"]'>
-                <option value="">@Localizer["ModeAll"]</option>
-            </select>
-        </div>
-        <div class="col-sm-6 col-lg-6">
-            <div class="input-group">
-                <span class="input-group-text" id="minDurationLabel">@Localizer["MinDuration"]</span>
-                <input type="number" asp-for="MinDuration" class="form-control" min="0" aria-labelledby="minDurationLabel" />
+<div class="filters-form" data-filter-container>
+    <div class="mb-3">
+        <label class="form-label">@Localizer["SearchLabel"]</label>
+        <input type="search" class="form-control" data-filter="search" placeholder="@Localizer["SearchPlaceholder"]" aria-label="@Localizer["SearchAria"]" />
+    </div>
+    <div class="mb-3">
+        <label class="form-label">@Localizer["NormsLabel"]</label>
+        <select class="form-select" multiple data-filter="norms" size="6" aria-label="@Localizer["NormsLabel"]"></select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">@Localizer["CitiesLabel"]</label>
+        <select class="form-select" multiple data-filter="cities" size="5" aria-label="@Localizer["CitiesLabel"]"></select>
+    </div>
+    <div class="mb-3">
+        <span class="form-label d-block">@Localizer["LevelsLabel"]</span>
+        <div class="d-flex flex-wrap gap-2" data-filter="levels" role="group" aria-label="@Localizer["LevelsLabel"]"></div>
+    </div>
+    <div class="mb-3">
+        <span class="form-label d-block">@Localizer["TypesLabel"]</span>
+        <div class="d-flex flex-wrap gap-2" data-filter="types" role="group" aria-label="@Localizer["TypesLabel"]"></div>
+    </div>
+    <div class="mb-4">
+        <label class="form-label">@Localizer["PriceRangeLabel"]</label>
+        <div class="price-range" data-filter="price-range">
+            <div class="d-flex align-items-center gap-2 mb-2">
+                <span class="badge bg-light text-dark" data-price-display="min"></span>
+                <span class="text-muted">–</span>
+                <span class="badge bg-light text-dark" data-price-display="max"></span>
             </div>
-        </div>
-        <div class="col-sm-6 col-lg-6">
-            <div class="input-group">
-                <span class="input-group-text" id="maxDurationLabel">@Localizer["MaxDuration"]</span>
-                <input type="number" asp-for="MaxDuration" class="form-control" min="0" aria-labelledby="maxDurationLabel" />
+            <div class="d-flex flex-column gap-2">
+                <input type="range" class="form-range" data-filter="price-min" min="0" max="0" step="1" aria-label="@Localizer["PriceMinLabel"]" />
+                <input type="range" class="form-range" data-filter="price-max" min="0" max="0" step="1" aria-label="@Localizer["PriceMaxLabel"]" />
             </div>
-        </div>
-        <div class="col-12">
-            <label class="form-label">@Localizer["TagsLabel"]</label>
-            <select asp-for="SelectedTagIds" asp-items="Model.TagOptions" class="form-select" multiple size="4" aria-label='@Localizer["TagsAria"]'></select>
-        </div>
-        <div class="col-12 text-end">
-            <button type="submit" class="btn btn-primary">@Localizer["Submit"]</button>
         </div>
     </div>
-</form>
+    <div class="d-flex flex-column gap-2">
+        <button type="button" class="btn btn-outline-primary" data-action="save-filters">@Localizer["SaveFilters"]</button>
+        <button type="button" class="btn btn-link text-decoration-none ps-0" data-action="reset-filters">@Localizer["ResetFilters"]</button>
+    </div>
+    <div class="visually-hidden" aria-live="polite" data-filter="feedback"></div>
+</div>

--- a/wwwroot/js/courseFilters.js
+++ b/wwwroot/js/courseFilters.js
@@ -1,0 +1,822 @@
+const dataElement = document.getElementById('courseFiltersData');
+if (!dataElement) {
+    console.warn('courseFilters: missing configuration element');
+} else {
+    const config = JSON.parse(dataElement.textContent || '{}');
+    const priceBounds = {
+        min: Number(config.price?.min ?? 0),
+        max: Number(config.price?.max ?? 0)
+    };
+    const resources = config.resources ?? {};
+    const culture = config.culture ?? {};
+    const initial = config.initial ?? {};
+    const filtersConfig = config.filters ?? {};
+
+    const state = {
+        pageNumber: Number(initial.pageNumber ?? 1),
+        totalPages: Number(initial.totalPages ?? 1),
+        totalCount: Number(initial.totalCount ?? 0),
+        search: initial.search ?? '',
+        norms: new Set((initial.norms ?? []).map(Number)),
+        cities: new Set((initial.cities ?? []).map(Number)),
+        levels: new Set((initial.levels ?? []).map(String)),
+        types: new Set((initial.types ?? []).map(String)),
+        minPrice: Number(initial.minPrice ?? priceBounds.min),
+        maxPrice: Number(initial.maxPrice ?? priceBounds.max)
+    };
+
+    const defaultFormatter = {
+        format(value) {
+            const symbol = resources.currencySymbol ?? '';
+            return `${value.toFixed(0)} ${symbol}`.trim();
+        }
+    };
+
+    let currencyFormatter = defaultFormatter;
+    try {
+        currencyFormatter = new Intl.NumberFormat(culture.name || undefined, {
+            style: 'currency',
+            currency: culture.currencyCode || 'CZK'
+        });
+    } catch {
+        currencyFormatter = defaultFormatter;
+    }
+
+    const controls = {
+        search: [],
+        norms: [],
+        cities: [],
+        levels: [],
+        types: [],
+        priceMin: [],
+        priceMax: [],
+        priceDisplayMin: [],
+        priceDisplayMax: [],
+        saveButtons: [],
+        resetButtons: [],
+        feedback: []
+    };
+
+    const compareSelection = new Set();
+
+    const resultCountElement = document.getElementById('resultCount');
+    const activeFiltersElement = document.getElementById('activeFilters');
+    const coursesGrid = document.getElementById('coursesGrid');
+    const noCoursesElement = document.getElementById('noCourses');
+    const courseErrorElement = document.getElementById('courseError');
+    const paginationElement = document.getElementById('coursePagination');
+    const paginationStatusElement = document.getElementById('paginationStatus');
+    const resetAllLink = document.querySelector('[data-action="reset-all"]');
+
+    const compareBar = document.getElementById('cmpBar');
+    const compareCountElement = document.getElementById('cmpCount');
+    const compareButton = document.getElementById('cmpGo');
+    const compareFormat = compareBar?.dataset.countFormat ?? '{0}';
+    const compareCta = compareBar?.dataset.ctaText ?? resources.compareLabel ?? '';
+    if (compareButton && compareCta) {
+        compareButton.textContent = compareCta;
+    }
+
+    const normOptions = new Map((filtersConfig.norms ?? []).map(opt => [String(opt.id), opt.name]));
+    const cityOptions = new Map((filtersConfig.cities ?? []).map(opt => [String(opt.id), opt.name]));
+    const levelOptions = filtersConfig.levels ?? [];
+    const typeOptions = filtersConfig.types ?? [];
+
+    const containers = document.querySelectorAll('[data-filter-container]');
+    containers.forEach(container => {
+        const search = container.querySelector('[data-filter="search"]');
+        if (search) controls.search.push(search);
+        const norms = container.querySelector('[data-filter="norms"]');
+        if (norms) controls.norms.push(norms);
+        const cities = container.querySelector('[data-filter="cities"]');
+        if (cities) controls.cities.push(cities);
+        const levels = container.querySelector('[data-filter="levels"]');
+        if (levels) controls.levels.push(levels);
+        const types = container.querySelector('[data-filter="types"]');
+        if (types) controls.types.push(types);
+        const priceMin = container.querySelector('[data-filter="price-min"]');
+        if (priceMin) controls.priceMin.push(priceMin);
+        const priceMax = container.querySelector('[data-filter="price-max"]');
+        if (priceMax) controls.priceMax.push(priceMax);
+        const priceMinDisplay = container.querySelector('[data-price-display="min"]');
+        if (priceMinDisplay) controls.priceDisplayMin.push(priceMinDisplay);
+        const priceMaxDisplay = container.querySelector('[data-price-display="max"]');
+        if (priceMaxDisplay) controls.priceDisplayMax.push(priceMaxDisplay);
+        const saveButton = container.querySelector('[data-action="save-filters"]');
+        if (saveButton) controls.saveButtons.push(saveButton);
+        const resetButton = container.querySelector('[data-action="reset-filters"]');
+        if (resetButton) controls.resetButtons.push(resetButton);
+        const feedback = container.querySelector('[data-filter="feedback"]');
+        if (feedback) controls.feedback.push(feedback);
+    });
+
+    let checkboxIdCounter = 0;
+
+    function createInlineCheckbox(container, group, option) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'form-check form-check-inline';
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.className = 'form-check-input';
+        const id = `${group}_${checkboxIdCounter++}`;
+        input.id = id;
+        input.value = option.value;
+        input.dataset.filterOption = group;
+        const label = document.createElement('label');
+        label.className = 'form-check-label small';
+        label.htmlFor = id;
+        label.textContent = option.label;
+        wrapper.appendChild(input);
+        wrapper.appendChild(label);
+        container.appendChild(wrapper);
+        return input;
+    }
+
+    const levelInputs = [];
+    controls.levels.forEach(container => {
+        container.innerHTML = '';
+        levelOptions.forEach(option => {
+            const input = createInlineCheckbox(container, 'levels', option);
+            levelInputs.push(input);
+        });
+    });
+
+    const typeInputs = [];
+    controls.types.forEach(container => {
+        container.innerHTML = '';
+        typeOptions.forEach(option => {
+            const input = createInlineCheckbox(container, 'types', option);
+            typeInputs.push(input);
+        });
+    });
+
+    const priceSpan = priceBounds.max - priceBounds.min;
+    const priceStep = priceSpan > 0 ? Math.max(1, Math.round(priceSpan / 50)) : 1;
+
+    let syncing = false;
+
+    function formatCurrency(value) {
+        if (!Number.isFinite(value)) {
+            return currencyFormatter.format(0);
+        }
+
+        try {
+            return currencyFormatter.format(value);
+        } catch {
+            return defaultFormatter.format(value);
+        }
+    }
+
+    function syncControls() {
+        syncing = true;
+        controls.search.forEach(input => {
+            input.value = state.search ?? '';
+        });
+
+        controls.norms.forEach(select => {
+            select.innerHTML = '';
+            normOptions.forEach((name, id) => {
+                const option = document.createElement('option');
+                option.value = id;
+                option.textContent = name;
+                option.selected = state.norms.has(Number(id));
+                select.appendChild(option);
+            });
+        });
+
+        controls.cities.forEach(select => {
+            select.innerHTML = '';
+            cityOptions.forEach((name, id) => {
+                const option = document.createElement('option');
+                option.value = id;
+                option.textContent = name;
+                option.selected = state.cities.has(Number(id));
+                select.appendChild(option);
+            });
+        });
+
+        levelInputs.forEach(input => {
+            input.checked = state.levels.has(input.value);
+        });
+
+        typeInputs.forEach(input => {
+            input.checked = state.types.has(input.value);
+        });
+
+        controls.priceMin.forEach(input => {
+            input.min = priceBounds.min;
+            input.max = priceBounds.max;
+            input.step = priceStep;
+            input.value = Math.max(priceBounds.min, Math.min(state.minPrice, priceBounds.max));
+            input.disabled = priceBounds.max <= priceBounds.min;
+        });
+
+        controls.priceMax.forEach(input => {
+            input.min = priceBounds.min;
+            input.max = priceBounds.max;
+            input.step = priceStep;
+            input.value = Math.max(priceBounds.min, Math.min(state.maxPrice, priceBounds.max));
+            input.disabled = priceBounds.max <= priceBounds.min;
+        });
+
+        const minDisplayValue = Math.max(priceBounds.min, Math.min(state.minPrice, priceBounds.max));
+        const maxDisplayValue = Math.max(priceBounds.min, Math.min(state.maxPrice, priceBounds.max));
+
+        controls.priceDisplayMin.forEach(span => {
+            span.textContent = formatCurrency(minDisplayValue);
+        });
+        controls.priceDisplayMax.forEach(span => {
+            span.textContent = formatCurrency(maxDisplayValue);
+        });
+
+        syncing = false;
+    }
+
+    function clampPrice(value) {
+        if (!Number.isFinite(value)) {
+            return priceBounds.min;
+        }
+        return Math.max(priceBounds.min, Math.min(priceBounds.max, value));
+    }
+
+    function updateResultCount(count) {
+        if (!resultCountElement) {
+            return;
+        }
+        const template = resultCountElement.dataset.countTemplate || resources.resultCountTemplate || '{0}';
+        resultCountElement.textContent = template.replace('{0}', count.toString());
+    }
+
+    function updatePagination(meta) {
+        state.pageNumber = Number(meta.pageNumber ?? state.pageNumber);
+        state.totalPages = Number(meta.totalPages ?? state.totalPages);
+        state.totalCount = Number(meta.totalCount ?? state.totalCount);
+
+        updateResultCount(state.totalCount);
+
+        if (paginationElement) {
+            const shouldHide = !Number.isFinite(state.totalPages) || state.totalPages <= 1;
+            paginationElement.classList.toggle('d-none', shouldHide);
+
+            const prevButton = paginationElement.querySelector('[data-action="prev-page"]');
+            const nextButton = paginationElement.querySelector('[data-action="next-page"]');
+            const prevItem = prevButton?.closest('.page-item');
+            const nextItem = nextButton?.closest('.page-item');
+
+            if (prevItem) {
+                prevItem.classList.toggle('disabled', state.pageNumber <= 1);
+            }
+            if (nextItem) {
+                nextItem.classList.toggle('disabled', state.pageNumber >= state.totalPages);
+            }
+
+            if (paginationStatusElement) {
+                const template = resources.pageStatusTemplate || '{0}/{1}';
+                paginationStatusElement.textContent = template
+                    .replace('{0}', state.pageNumber.toString())
+                    .replace('{1}', Math.max(state.totalPages, 1).toString());
+            }
+        }
+    }
+
+    function escapeHtml(value) {
+        return (value ?? '').replace(/[&<>"]/g, ch => {
+            switch (ch) {
+                case '&': return '&amp;';
+                case '<': return '&lt;';
+                case '>': return '&gt;';
+                case '"': return '&quot;';
+                default: return ch;
+            }
+        });
+    }
+
+    function escapeAttribute(value) {
+        return (value ?? '').replace(/[&"]g, ch => (ch == '&' ? '&amp;' : '&quot;'));
+    }
+
+    function createCourseCard(course) {
+        const wrapper = document.createElement('div');
+        const id = Number(course.id);
+        const checkboxId = `cmp_${id}`;
+        const description = escapeHtml(course.description ?? '');
+        const title = escapeHtml(course.title ?? '');
+        const level = escapeHtml(course.level ?? '');
+        const mode = escapeHtml(course.mode ?? '');
+        const type = escapeHtml(course.type ?? '');
+        const durationDisplay = escapeHtml(course.durationDisplay ?? '');
+        const dateDisplay = escapeHtml(course.dateDisplay ?? '');
+        const priceDisplay = escapeHtml(course.priceDisplay ?? '');
+        const detailsUrl = escapeAttribute(course.detailsUrl ?? `#/course/${id}`);
+        const addToCartUrl = escapeAttribute(course.addToCartUrl ?? '/Courses/Index?handler=AddToCart');
+        const coverImageUrl = course.coverImageUrl ? escapeAttribute(course.coverImageUrl) : null;
+        const popoverHtml = course.popoverHtml ? escapeAttribute(course.popoverHtml) : null;
+
+        const coverHtml = coverImageUrl
+            ? `<img src="${coverImageUrl}" alt="${title}" class="img-fluid rounded mb-2" loading="lazy" decoding="async">`
+            : '';
+
+        const popoverLink = popoverHtml
+            ? `<a tabindex="0" role="button" class="ms-1 text-decoration-dotted" data-bs-toggle="popover" data-bs-html="true" data-bs-content="${popoverHtml}">
+                    <i class="bi bi-info-circle"></i>
+               </a>`
+            : '';
+
+        wrapper.innerHTML = `
+        <div class="feature-card h-100 p-3 d-flex flex-column justify-content-between">
+            <div class="d-flex flex-column gap-2">
+                ${coverHtml}
+                <h3 class="h5 mb-1">${title}</h3>
+                ${description ? `<p class="text-muted small mb-2">${description}</p>` : ''}
+                <div class="d-flex flex-wrap gap-2 align-items-center small">
+                    <span class="badge badge-soft-primary"><i class="bi bi-bar-chart me-1"></i>${level}</span>
+                    <span class="badge badge-soft-primary"><i class="bi bi-laptop me-1"></i>${mode}</span>
+                    <span class="badge badge-soft-accent"><i class="bi bi-geo-alt me-1"></i>${type}</span>
+                    <span class="badge badge-soft-accent"><i class="bi bi-clock me-1"></i>${durationDisplay}</span>
+                </div>
+            </div>
+            <div class="d-flex justify-content-between align-items-end mt-3">
+                <div class="small text-muted">
+                    <div class="d-flex align-items-center">
+                        <i class="bi bi-calendar2 me-2"></i>
+                        <small class="text-muted">${dateDisplay}${popoverLink}</small>
+                    </div>
+                    <div class="fw-semibold">${priceDisplay}</div>
+                </div>
+                <div class="d-flex flex-column align-items-end gap-2">
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input cmp-check" type="checkbox" value="${id}" id="${checkboxId}">
+                        <label class="form-check-label small" for="${checkboxId}">${resources.compareLabel ?? 'Porovnat'}</label>
+                    </div>
+                    <div class="d-flex gap-2">
+                        <a class="btn btn-outline-secondary" href="${detailsUrl}">${resources.detailsLabel ?? 'Detail'}</a>
+                        <form method="post" action="${addToCartUrl}" class="d-inline">
+                            <input type="hidden" name="courseId" value="${id}">
+                            <button type="submit" class="btn btn-primary">${resources.enrollLabel ?? 'Přihlásit'}</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>`;
+
+        const card = wrapper.firstElementChild;
+        if (card) {
+            coursesGrid?.appendChild(card);
+        }
+    }
+
+    function initPopovers(scope) {
+        if (!window.bootstrap || !scope) {
+            return;
+        }
+        const triggers = scope.querySelectorAll('[data-bs-toggle="popover"]');
+        triggers.forEach(trigger => {
+            window.bootstrap.Popover.getOrCreateInstance(trigger);
+        });
+    }
+
+    function renderCourses(courses) {
+        if (!coursesGrid) {
+            return;
+        }
+        coursesGrid.innerHTML = '';
+        (courses ?? []).forEach(course => createCourseCard(course));
+
+        const checkboxes = coursesGrid.querySelectorAll('.cmp-check');
+        checkboxes.forEach(checkbox => {
+            const value = checkbox.value;
+            checkbox.checked = compareSelection.has(value);
+            checkbox.addEventListener('change', () => {
+                if (checkbox.checked) {
+                    compareSelection.add(value);
+                } else {
+                    compareSelection.delete(value);
+                }
+                updateCompareBar();
+            });
+        });
+
+        initPopovers(coursesGrid);
+
+        if (noCoursesElement) {
+            noCoursesElement.classList.toggle('d-none', (courses ?? []).length > 0);
+        }
+    }
+
+    function updateCompareBar() {
+        if (!compareBar || !compareCountElement) {
+            return;
+        }
+        const selected = compareSelection.size;
+        compareCountElement.textContent = compareFormat.replace('{0}', selected.toString());
+
+        if (!compareButton) {
+            return;
+        }
+
+        if (selected >= 2 && selected <= 3) {
+            compareBar.classList.remove('d-none');
+            compareButton.classList.remove('disabled');
+            compareButton.removeAttribute('aria-disabled');
+            compareButton.href = `/Courses/Compare?ids=${Array.from(compareSelection).join(',')}`;
+        } else {
+            compareButton.classList.add('disabled');
+            compareButton.setAttribute('aria-disabled', 'true');
+            compareButton.removeAttribute('href');
+            if (selected === 0) {
+                compareBar.classList.add('d-none');
+            } else {
+                compareBar.classList.remove('d-none');
+            }
+        }
+    }
+
+    function clearChildren(element) {
+        while (element?.firstChild) {
+            element.removeChild(element.firstChild);
+        }
+    }
+
+    function createChip(label, type, value) {
+        const chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'chip chip-light';
+        chip.dataset.removeType = type;
+        if (value !== undefined) {
+            chip.dataset.removeValue = String(value);
+        }
+        chip.innerHTML = `${label} <span class="ms-1" aria-hidden="true">&times;</span>`;
+        chip.setAttribute('aria-label', `${resources.removeLabel ?? 'Odebrat filtr'} ${label}`);
+        chip.addEventListener('click', () => {
+            removeFilter(type, value);
+        });
+        return chip;
+    }
+
+    function updateChips() {
+        if (!activeFiltersElement) {
+            return;
+        }
+        clearChildren(activeFiltersElement);
+
+        if (state.search) {
+            activeFiltersElement.appendChild(createChip(`${resources.searchLabel ?? 'Hledat'}: ${state.search}`, 'search'));
+        }
+
+        state.norms.forEach(id => {
+            const name = normOptions.get(String(id));
+            if (name) {
+                activeFiltersElement.appendChild(createChip(name, 'norms', id));
+            }
+        });
+
+        state.cities.forEach(id => {
+            const name = cityOptions.get(String(id));
+            if (name) {
+                activeFiltersElement.appendChild(createChip(name, 'cities', id));
+            }
+        });
+
+        state.levels.forEach(level => {
+            const option = levelOptions.find(opt => opt.value === level);
+            if (option) {
+                activeFiltersElement.appendChild(createChip(option.label, 'levels', level));
+            }
+        });
+
+        state.types.forEach(type => {
+            const option = typeOptions.find(opt => opt.value === type);
+            if (option) {
+                activeFiltersElement.appendChild(createChip(option.label, 'types', type));
+            }
+        });
+
+        if (priceBounds.max > priceBounds.min) {
+            const minVal = clampPrice(state.minPrice);
+            const maxVal = clampPrice(state.maxPrice);
+            if (minVal > priceBounds.min || maxVal < priceBounds.max) {
+                const label = `${resources.priceLabel ?? 'Cena'}: ${formatCurrency(minVal)} – ${formatCurrency(maxVal)}`;
+                activeFiltersElement.appendChild(createChip(label, 'price'));
+            }
+        }
+    }
+
+    function removeFilter(type, value) {
+        switch (type) {
+            case 'search':
+                state.search = '';
+                break;
+            case 'norms':
+                state.norms.delete(Number(value));
+                break;
+            case 'cities':
+                state.cities.delete(Number(value));
+                break;
+            case 'levels':
+                state.levels.delete(String(value));
+                break;
+            case 'types':
+                state.types.delete(String(value));
+                break;
+            case 'price':
+                state.minPrice = priceBounds.min;
+                state.maxPrice = priceBounds.max;
+                break;
+        }
+        state.pageNumber = 1;
+        syncControls();
+        updateChips();
+        scheduleFetch();
+    }
+
+    function showFeedback(message) {
+        controls.feedback.forEach(el => {
+            el.textContent = message;
+        });
+        if (message) {
+            setTimeout(() => {
+                controls.feedback.forEach(el => {
+                    el.textContent = '';
+                });
+            }, 3000);
+        }
+    }
+
+    function saveFilters() {
+        try {
+            const payload = {
+                search: state.search,
+                norms: Array.from(state.norms),
+                cities: Array.from(state.cities),
+                levels: Array.from(state.levels),
+                types: Array.from(state.types),
+                minPrice: clampPrice(state.minPrice),
+                maxPrice: clampPrice(state.maxPrice)
+            };
+            window.localStorage?.setItem('sysjaky.courses.filters', JSON.stringify(payload));
+            showFeedback(resources.savedMessage ?? 'Filtry byly uloženy.');
+        } catch (error) {
+            console.warn('courseFilters: unable to save filters', error);
+        }
+    }
+
+    function loadSavedFilters() {
+        try {
+            const raw = window.localStorage?.getItem('sysjaky.courses.filters');
+            if (!raw) {
+                return null;
+            }
+            return JSON.parse(raw);
+        } catch (error) {
+            console.warn('courseFilters: unable to load filters', error);
+            return null;
+        }
+    }
+
+    function resetState() {
+        state.search = '';
+        state.norms.clear();
+        state.cities.clear();
+        state.levels.clear();
+        state.types.clear();
+        state.minPrice = priceBounds.min;
+        state.maxPrice = priceBounds.max;
+        state.pageNumber = 1;
+    }
+
+    function resetFilters(triggerFetch = true) {
+        resetState();
+        syncControls();
+        updateChips();
+        if (triggerFetch) {
+            scheduleFetch();
+        }
+    }
+
+    const debounce = (fn, delay) => {
+        let timer;
+        return (...args) => {
+            clearTimeout(timer);
+            timer = setTimeout(() => fn(...args), delay);
+        };
+    };
+
+    const scheduleFetch = debounce(() => fetchCourses(), 250);
+
+    let currentRequest = null;
+
+    function buildQuery() {
+        const params = new URLSearchParams();
+        params.set('PageNumber', String(state.pageNumber));
+        if (state.search) {
+            params.set('SearchString', state.search);
+        }
+        state.norms.forEach(id => params.append('SelectedTagIds', String(id)));
+        state.cities.forEach(id => params.append('SelectedCityTagIds', String(id)));
+        state.levels.forEach(level => params.append('SelectedLevels', level));
+        state.types.forEach(type => params.append('SelectedTypes', type));
+
+        if (priceBounds.max > priceBounds.min) {
+            const minPrice = clampPrice(state.minPrice);
+            const maxPrice = clampPrice(state.maxPrice);
+            const separator = culture.decimalSeparator || '.';
+            params.set('MinPrice', minPrice.toString().replace('.', separator));
+            params.set('MaxPrice', maxPrice.toString().replace('.', separator));
+        }
+
+        return params;
+    }
+
+    async function fetchCourses() {
+        if (!coursesGrid) {
+            return;
+        }
+
+        const params = buildQuery();
+        if (currentRequest) {
+            currentRequest.abort();
+        }
+        currentRequest = new AbortController();
+        const signal = currentRequest.signal;
+        const url = `/Courses/Index?handler=Courses&${params.toString()}`;
+        try {
+            if (courseErrorElement) {
+                courseErrorElement.classList.add('d-none');
+                courseErrorElement.textContent = '';
+            }
+            const response = await fetch(url, {
+                headers: { 'Accept': 'application/json' },
+                signal
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const data = await response.json();
+            renderCourses(data.courses ?? []);
+            updatePagination(data.pagination ?? {});
+            updateChips();
+            updateCompareBar();
+        } catch (error) {
+            if (error.name === 'AbortError') {
+                return;
+            }
+            console.error('courseFilters: fetch failed', error);
+            if (courseErrorElement) {
+                courseErrorElement.textContent = resources.fetchError ?? resources.noResults ?? 'Nepodařilo se načíst kurzy.';
+                courseErrorElement.classList.remove('d-none');
+            }
+        }
+    }
+
+    function attachEventHandlers() {
+        controls.search.forEach(input => {
+            input.addEventListener('input', () => {
+                if (syncing) {
+                    return;
+                }
+                state.search = input.value.trim();
+                state.pageNumber = 1;
+                updateChips();
+                scheduleFetch();
+            });
+        });
+
+        const handleSelectChange = (set, values) => {
+            set.clear();
+            values.forEach(value => set.add(Number(value)));
+            state.pageNumber = 1;
+            syncControls();
+            updateChips();
+            scheduleFetch();
+        };
+
+        controls.norms.forEach(select => {
+            select.addEventListener('change', event => {
+                if (syncing) {
+                    return;
+                }
+                const selected = Array.from(event.target.selectedOptions).map(opt => opt.value);
+                handleSelectChange(state.norms, selected);
+            });
+        });
+
+        controls.cities.forEach(select => {
+            select.addEventListener('change', event => {
+                if (syncing) {
+                    return;
+                }
+                const selected = Array.from(event.target.selectedOptions).map(opt => opt.value);
+                handleSelectChange(state.cities, selected);
+            });
+        });
+
+        levelInputs.forEach(input => {
+            input.addEventListener('change', () => {
+                if (input.checked) {
+                    state.levels.add(input.value);
+                } else {
+                    state.levels.delete(input.value);
+                }
+                state.pageNumber = 1;
+                syncControls();
+                updateChips();
+                scheduleFetch();
+            });
+        });
+
+        typeInputs.forEach(input => {
+            input.addEventListener('change', () => {
+                if (input.checked) {
+                    state.types.add(input.value);
+                } else {
+                    state.types.delete(input.value);
+                }
+                state.pageNumber = 1;
+                syncControls();
+                updateChips();
+                scheduleFetch();
+            });
+        });
+
+        const handlePriceInput = (isMin, input) => {
+            input.addEventListener('input', () => {
+                if (syncing) {
+                    return;
+                }
+                const value = clampPrice(Number(input.value));
+                if (isMin) {
+                    state.minPrice = Math.min(value, state.maxPrice);
+                } else {
+                    state.maxPrice = Math.max(value, state.minPrice);
+                }
+                state.pageNumber = 1;
+                syncControls();
+                updateChips();
+                scheduleFetch();
+            });
+        };
+
+        controls.priceMin.forEach(input => handlePriceInput(true, input));
+        controls.priceMax.forEach(input => handlePriceInput(false, input));
+
+        controls.saveButtons.forEach(button => {
+            button.addEventListener('click', () => saveFilters());
+        });
+
+        controls.resetButtons.forEach(button => {
+            button.addEventListener('click', () => resetFilters());
+        });
+
+        if (resetAllLink) {
+            resetAllLink.addEventListener('click', event => {
+                event.preventDefault();
+                resetFilters();
+            });
+        }
+
+        if (paginationElement) {
+            const prev = paginationElement.querySelector('[data-action="prev-page"]');
+            const next = paginationElement.querySelector('[data-action="next-page"]');
+            prev?.addEventListener('click', () => {
+                if (state.pageNumber > 1) {
+                    state.pageNumber -= 1;
+                    fetchCourses();
+                }
+            });
+            next?.addEventListener('click', () => {
+                if (state.pageNumber < state.totalPages) {
+                    state.pageNumber += 1;
+                    fetchCourses();
+                }
+            });
+        }
+    }
+
+    function initialise() {
+        syncControls();
+        attachEventHandlers();
+
+        const saved = !initial.hasFilters ? loadSavedFilters() : null;
+        if (saved) {
+            state.search = saved.search ?? state.search;
+            state.norms = new Set((saved.norms ?? []).map(Number));
+            state.cities = new Set((saved.cities ?? []).map(Number));
+            state.levels = new Set((saved.levels ?? []).map(String));
+            state.types = new Set((saved.types ?? []).map(String));
+            state.minPrice = clampPrice(Number(saved.minPrice ?? priceBounds.min));
+            state.maxPrice = clampPrice(Number(saved.maxPrice ?? priceBounds.max));
+            state.pageNumber = 1;
+            syncControls();
+            updateChips();
+            fetchCourses();
+        } else {
+            syncControls();
+            updateChips();
+            renderCourses(initial.courses ?? []);
+            updatePagination(initial);
+            updateCompareBar();
+        }
+    }
+
+    initialise();
+}


### PR DESCRIPTION
## Summary
- add a JSON endpoint to the courses index page and expand the backing model with multi-select filters, price range support, and metadata for the UI
- refresh the courses index Razor page and filter partial to host the interactive controls, active-filter chips, pagination updates, and compare bar
- add a courseFilters.js module that powers live searching, price slider handling, localStorage persistence, and comparison selection via fetch API

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf0ae66d083218ef6bea078d6df61