### PR TITLE
Enhance course filtering UI interactions

### DIFF
--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -142,6 +142,7 @@
             savedMessage = Localizer["FiltersSaved"].Value ?? "Filtry byly uloženy.",
             clearFilters = Localizer["ResetFilters"].Value ?? "Resetovat",
             compareLabel = Localizer["Compare"].Value ?? "Porovnat",
+            compareLimit = Localizer["CompareLimit"].Value ?? "Můžete porovnat maximálně 3 kurzy.",
             detailsLabel = Localizer["Details"].Value ?? "Detail",
             enrollLabel = Localizer["Enroll"].Value ?? "Přihlásit",
             resultCountTemplate = Localizer["ResultCount", "{0}"].Value ?? "{0}",

--- a/Pages/Shared/Components/_CourseCard.cshtml
+++ b/Pages/Shared/Components/_CourseCard.cshtml
@@ -12,6 +12,7 @@
     <div class="d-flex flex-wrap gap-2 align-items-center small">
       <span class="badge badge-soft-primary"><i class="bi bi-bar-chart me-1"></i>@Model.Level</span>
       <span class="badge badge-soft-primary"><i class="bi bi-laptop me-1"></i>@Model.Mode</span>
+      <span class="badge badge-soft-accent"><i class="bi bi-geo-alt me-1"></i>@Model.Type</span>
       <span class="badge badge-soft-accent"><i class="bi bi-clock me-1"></i>@Model.Duration&nbsp;min</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- expose a localized compare-limit message and surface course type information in course cards
- harden the filtering script with safe attribute escaping and reusable course error messaging
- limit compare selections to three, clear fetch errors gracefully, and support compare bar feedback

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcf5046294832188c97591a92added