### PR TITLE
Implement corporate inquiry multi-step wizard

### DIFF
--- a/Pages/CorporateInquiry.cshtml
+++ b/Pages/CorporateInquiry.cshtml
@@ -1,0 +1,501 @@
+@page
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
+@model SysJaky_N.Pages.CorporateInquiryModel
+@{
+    ViewData["Title"] = Localizer["Title"];
+    var shouldResetStorage = TempData.Peek("Success") is string;
+    var modeLabels = new System.Collections.Generic.Dictionary<string, string>();
+    foreach (var option in Model.ModeOptions)
+    {
+        modeLabels[option] = Localizer[$"ModeOption_{option}"].Value;
+    }
+    var modeLabelsJson = System.Text.Json.JsonSerializer.Serialize(modeLabels);
+}
+
+<h1 class="mb-4">@Localizer["Title"]</h1>
+<p class="text-muted mb-5">@Localizer["Intro"]</p>
+
+<noscript>
+    <div class="alert alert-warning" role="alert">@Localizer["EnableJavaScriptWarning"]</div>
+</noscript>
+
+<div class="progress mb-4" aria-label="@Localizer["ProgressAriaLabel"]">
+    <div id="wizardProgressBar" class="progress-bar" role="progressbar" style="width:25%;" aria-valuenow="1" aria-valuemin="1" aria-valuemax="4">1 / 4</div>
+</div>
+
+@if (TempData["Success"] is string success && !string.IsNullOrEmpty(success))
+{
+    <div class="alert alert-success" role="alert" id="successAlert">@success</div>
+}
+
+<form method="post"
+      id="corporateInquiryForm"
+      data-initial-step="@Model.InitialStep"
+      data-reset-storage="@shouldResetStorage.ToString().ToLowerInvariant()"
+      data-base-price="@Model.BaseTrainingPrice"
+      data-participant-price="@Model.ParticipantPrice"
+      data-mode-multipliers='@Html.Raw(Model.ModeMultipliersJson)'
+      data-mode-labels='@Html.Raw(modeLabelsJson)'
+      data-summary-placeholder="@Localizer["SummaryPlaceholder"]"
+      data-price-unavailable="@Localizer["PriceUnavailable"]"
+      data-validation-step1="@Localizer["ValidationStep1"]"
+      data-validation-participant-required="@Localizer["ValidationParticipantRequired"]"
+      data-validation-participant-range="@Localizer["ValidationParticipantRange"]"
+      data-validation-date-required="@Localizer["ValidationDateRequired"]"
+      data-validation-mode-required="@Localizer["ValidationModeRequired"]"
+      data-validation-company-id-required="@Localizer["ValidationCompanyIdRequired"]"
+      data-validation-company-name-required="@Localizer["ValidationCompanyNameRequired"]"
+      data-validation-contact-person-required="@Localizer["ValidationContactPersonRequired"]"
+      data-validation-contact-email-required="@Localizer["ValidationContactEmailRequired"]"
+      data-validation-contact-email-invalid="@Localizer["ValidationContactEmailInvalid"]"
+      data-validation-contact-phone-required="@Localizer["ValidationContactPhoneRequired"]"
+      data-validation-contact-phone-invalid="@Localizer["ValidationContactPhoneInvalid"]"
+      novalidate>
+    <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+
+    <div class="wizard-step" data-step="1">
+        <partial name="CorporateInquiry/Partials/_StepTraining" model="Model" />
+    </div>
+
+    <div class="wizard-step d-none" data-step="2">
+        <partial name="CorporateInquiry/Partials/_StepDetails" model="Model" />
+    </div>
+
+    <div class="wizard-step d-none" data-step="3">
+        <partial name="CorporateInquiry/Partials/_StepCompany" model="Model" />
+    </div>
+
+    <div class="wizard-step d-none" data-step="4">
+        <partial name="CorporateInquiry/Partials/_StepSummary" model="Model" />
+    </div>
+
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mt-4">
+        <button type="button" class="btn btn-outline-secondary" id="wizardPrev">@Localizer["Back"]</button>
+        <div class="d-flex flex-column flex-md-row align-items-md-center gap-3 ms-md-auto">
+            <div class="fw-semibold" id="priceEstimateContainer">
+                @Localizer["EstimatedPriceLabel"]: <span id="priceEstimateValue">@Localizer["EstimatedPricePlaceholder"]</span>
+            </div>
+            <div class="d-flex gap-2">
+                <button type="button" class="btn btn-primary" id="wizardNext">@Localizer["Next"]</button>
+                <button type="submit" class="btn btn-success d-none" id="wizardSubmit">@Localizer["Submit"]</button>
+            </div>
+        </div>
+    </div>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script>
+        (function () {
+            const form = document.getElementById('corporateInquiryForm');
+            if (!form) {
+                return;
+            }
+
+            const steps = Array.from(document.querySelectorAll('.wizard-step'));
+            const progressBar = document.getElementById('wizardProgressBar');
+            const prevButton = document.getElementById('wizardPrev');
+            const nextButton = document.getElementById('wizardNext');
+            const submitButton = document.getElementById('wizardSubmit');
+            const priceValue = document.getElementById('priceEstimateValue');
+            const storageKey = 'corporateInquiryDraft';
+            const isoCheckboxes = Array.from(form.querySelectorAll('input[name="Input.TrainingTypes"]'));
+            const participantInput = form.querySelector('[name="Input.ParticipantCount"]');
+            const dateInput = form.querySelector('[name="Input.PreferredDate"]');
+            const modeSelect = form.querySelector('[name="Input.Mode"]');
+            const companyIdInput = form.querySelector('[name="Input.CompanyId"]');
+            const companyNameInput = form.querySelector('[name="Input.CompanyName"]');
+            const contactPersonInput = form.querySelector('[name="Input.ContactPerson"]');
+            const contactEmailInput = form.querySelector('[name="Input.ContactEmail"]');
+            const contactPhoneInput = form.querySelector('[name="Input.ContactPhone"]');
+            const step1Error = document.getElementById('step1-error');
+            const summaryElements = {
+                trainingTypes: document.getElementById('summary-training-types'),
+                participantCount: document.getElementById('summary-participant-count'),
+                preferredDate: document.getElementById('summary-preferred-date'),
+                mode: document.getElementById('summary-mode'),
+                companyId: document.getElementById('summary-company-id'),
+                companyName: document.getElementById('summary-company-name'),
+                contactPerson: document.getElementById('summary-contact-person'),
+                contactEmail: document.getElementById('summary-contact-email'),
+                contactPhone: document.getElementById('summary-contact-phone'),
+                price: document.getElementById('summary-price')
+            };
+
+            const validationMessages = {
+                step1: form.dataset.validationStep1,
+                participantCountRequired: form.dataset.validationParticipantRequired,
+                participantCountRange: form.dataset.validationParticipantRange,
+                preferredDateRequired: form.dataset.validationDateRequired,
+                modeRequired: form.dataset.validationModeRequired,
+                companyIdRequired: form.dataset.validationCompanyIdRequired,
+                companyNameRequired: form.dataset.validationCompanyNameRequired,
+                contactPersonRequired: form.dataset.validationContactPersonRequired,
+                contactEmailRequired: form.dataset.validationContactEmailRequired,
+                contactEmailInvalid: form.dataset.validationContactEmailInvalid,
+                contactPhoneRequired: form.dataset.validationContactPhoneRequired,
+                contactPhoneInvalid: form.dataset.validationContactPhoneInvalid
+            };
+
+            const modeLabels = JSON.parse(form.dataset.modeLabels || '{}');
+            const basePrice = Number(form.dataset.basePrice || 0);
+            const participantPrice = Number(form.dataset.participantPrice || 0);
+            const modeMultipliers = JSON.parse(form.dataset.modeMultipliers || '{}');
+            const totalSteps = steps.length;
+            const dateFormatter = new Intl.DateTimeFormat(document.documentElement.lang || undefined, { dateStyle: 'medium' });
+            const currencyFormatter = new Intl.NumberFormat(document.documentElement.lang || undefined, { style: 'currency', currency: 'CZK', maximumFractionDigits: 0 });
+
+            const initialStepFromServer = Number(form.dataset.initialStep || '1');
+            let currentStep = Number.isNaN(initialStepFromServer) || initialStepFromServer < 1 || initialStepFromServer > totalSteps
+                ? 1
+                : initialStepFromServer;
+
+            if (form.dataset.resetStorage === 'true') {
+                try {
+                    localStorage.removeItem(storageKey);
+                } catch (error) {
+                    console.warn('Unable to reset corporate inquiry draft', error);
+                }
+            }
+
+            const savedState = loadState();
+            if (savedState) {
+                applyState(savedState);
+                if (initialStepFromServer > 1) {
+                    currentStep = Math.min(Math.max(initialStepFromServer, 1), totalSteps);
+                } else if (savedState.currentStep) {
+                    currentStep = Math.min(Math.max(savedState.currentStep, 1), totalSteps);
+                }
+            }
+
+            updateStep(currentStep);
+            updateSummary();
+            updatePrice();
+
+            prevButton.addEventListener('click', () => {
+                if (currentStep > 1) {
+                    currentStep -= 1;
+                    updateStep(currentStep);
+                    persistState();
+                }
+            });
+
+            nextButton.addEventListener('click', () => {
+                if (validateStep(currentStep)) {
+                    currentStep += 1;
+                    updateStep(currentStep);
+                    updateSummary();
+                    updatePrice();
+                    persistState();
+                }
+            });
+
+            form.addEventListener('submit', (event) => {
+                if (!validateStep(currentStep) || !validateAllSteps()) {
+                    event.preventDefault();
+                    return;
+                }
+                persistState();
+            });
+
+            const trackedFields = [participantInput, dateInput, modeSelect, companyIdInput, companyNameInput, contactPersonInput, contactEmailInput, contactPhoneInput];
+            trackedFields.forEach(field => {
+                if (!field) {
+                    return;
+                }
+                field.addEventListener('input', () => {
+                    showFieldError(field.name, '');
+                    updatePrice();
+                    updateSummary();
+                    persistState();
+                });
+                field.addEventListener('change', () => {
+                    showFieldError(field.name, '');
+                    updatePrice();
+                    updateSummary();
+                    persistState();
+                });
+            });
+
+            isoCheckboxes.forEach(checkbox => {
+                checkbox.addEventListener('change', () => {
+                    if (step1Error) {
+                        step1Error.textContent = '';
+                        step1Error.classList.add('d-none');
+                    }
+                    updatePrice();
+                    updateSummary();
+                    persistState();
+                });
+            });
+
+            function collectFormState() {
+                return {
+                    trainingTypes: isoCheckboxes.filter(c => c.checked).map(c => c.value),
+                    participantCount: participantInput ? participantInput.value : '',
+                    preferredDate: dateInput ? dateInput.value : '',
+                    mode: modeSelect ? modeSelect.value : '',
+                    companyId: companyIdInput ? companyIdInput.value : '',
+                    companyName: companyNameInput ? companyNameInput.value : '',
+                    contactPerson: contactPersonInput ? contactPersonInput.value : '',
+                    contactEmail: contactEmailInput ? contactEmailInput.value : '',
+                    contactPhone: contactPhoneInput ? contactPhoneInput.value : '',
+                    currentStep
+                };
+            }
+
+            function applyState(state) {
+                isoCheckboxes.forEach(checkbox => {
+                    checkbox.checked = Array.isArray(state.trainingTypes) && state.trainingTypes.includes(checkbox.value);
+                });
+                if (participantInput && state.participantCount !== undefined) {
+                    participantInput.value = state.participantCount;
+                }
+                if (dateInput && state.preferredDate !== undefined) {
+                    dateInput.value = state.preferredDate;
+                }
+                if (modeSelect && state.mode !== undefined) {
+                    modeSelect.value = state.mode;
+                }
+                if (companyIdInput && state.companyId !== undefined) {
+                    companyIdInput.value = state.companyId;
+                }
+                if (companyNameInput && state.companyName !== undefined) {
+                    companyNameInput.value = state.companyName;
+                }
+                if (contactPersonInput && state.contactPerson !== undefined) {
+                    contactPersonInput.value = state.contactPerson;
+                }
+                if (contactEmailInput && state.contactEmail !== undefined) {
+                    contactEmailInput.value = state.contactEmail;
+                }
+                if (contactPhoneInput && state.contactPhone !== undefined) {
+                    contactPhoneInput.value = state.contactPhone;
+                }
+            }
+
+            function loadState() {
+                try {
+                    const raw = localStorage.getItem(storageKey);
+                    return raw ? JSON.parse(raw) : null;
+                } catch (error) {
+                    console.warn('Unable to load corporate inquiry draft', error);
+                    return null;
+                }
+            }
+
+            function persistState() {
+                const state = collectFormState();
+                try {
+                    localStorage.setItem(storageKey, JSON.stringify(state));
+                } catch (error) {
+                    console.warn('Unable to persist corporate inquiry draft', error);
+                }
+            }
+
+            function updateStep(step) {
+                steps.forEach((element, index) => {
+                    const isActive = index === step - 1;
+                    element.classList.toggle('d-none', !isActive);
+                    element.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+                });
+
+                prevButton.classList.toggle('d-none', step === 1);
+                prevButton.disabled = step === 1;
+                nextButton.classList.toggle('d-none', step === totalSteps);
+                submitButton.classList.toggle('d-none', step !== totalSteps);
+
+                const progressPercent = Math.round((step / totalSteps) * 100);
+                progressBar.style.width = `${progressPercent}%`;
+                progressBar.setAttribute('aria-valuenow', String(step));
+                progressBar.textContent = `${step} / ${totalSteps}`;
+            }
+
+            function showFieldError(fieldName, message) {
+                const messageElement = form.querySelector(`[data-valmsg-for="${fieldName}"]`);
+                if (messageElement) {
+                    messageElement.textContent = message || '';
+                }
+                const field = form.querySelector(`[name="${fieldName}"]`);
+                if (field) {
+                    if (message) {
+                        field.classList.add('is-invalid');
+                        field.setAttribute('aria-invalid', 'true');
+                    } else {
+                        field.classList.remove('is-invalid');
+                        field.removeAttribute('aria-invalid');
+                    }
+                }
+            }
+
+            function validateStep(step) {
+                let isValid = true;
+                clearStepErrors(step);
+
+                if (step === 1) {
+                    const selected = isoCheckboxes.filter(c => c.checked);
+                    if (selected.length === 0) {
+                        isValid = false;
+                        const container = document.getElementById('step1-error');
+                        if (container) {
+                            container.textContent = validationMessages.step1 || '';
+                            container.classList.remove('d-none');
+                        }
+                    }
+                } else if (step === 2) {
+                    const participantValue = participantInput ? Number(participantInput.value) : 0;
+                    if (!participantInput || participantInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.ParticipantCount', validationMessages.participantCountRequired);
+                    } else if (Number.isNaN(participantValue) || participantValue < 1 || participantValue > 1000) {
+                        isValid = false;
+                        showFieldError('Input.ParticipantCount', validationMessages.participantCountRange);
+                    }
+
+                    if (!dateInput || dateInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.PreferredDate', validationMessages.preferredDateRequired);
+                    }
+
+                    if (!modeSelect || modeSelect.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.Mode', validationMessages.modeRequired);
+                    }
+                } else if (step === 3) {
+                    if (!companyIdInput || companyIdInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.CompanyId', validationMessages.companyIdRequired);
+                    }
+                    if (!companyNameInput || companyNameInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.CompanyName', validationMessages.companyNameRequired);
+                    }
+                    if (!contactPersonInput || contactPersonInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.ContactPerson', validationMessages.contactPersonRequired);
+                    }
+                    if (!contactEmailInput || contactEmailInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.ContactEmail', validationMessages.contactEmailRequired);
+                    } else if (!isValidEmail(contactEmailInput.value)) {
+                        isValid = false;
+                        showFieldError('Input.ContactEmail', validationMessages.contactEmailInvalid);
+                    }
+                    if (!contactPhoneInput || contactPhoneInput.value.trim() === '') {
+                        isValid = false;
+                        showFieldError('Input.ContactPhone', validationMessages.contactPhoneRequired);
+                    } else if (!isValidPhone(contactPhoneInput.value)) {
+                        isValid = false;
+                        showFieldError('Input.ContactPhone', validationMessages.contactPhoneInvalid);
+                    }
+                }
+
+                if (isValid && step === 1) {
+                    const container = document.getElementById('step1-error');
+                    if (container) {
+                        container.textContent = '';
+                        container.classList.add('d-none');
+                    }
+                }
+
+                return isValid;
+            }
+
+            function validateAllSteps() {
+                let valid = true;
+                for (let step = 1; step <= totalSteps - 1; step += 1) {
+                    if (!validateStep(step)) {
+                        valid = false;
+                        currentStep = step;
+                        updateStep(currentStep);
+                        updateSummary();
+                        updatePrice();
+                        break;
+                    }
+                }
+                return valid;
+            }
+
+            function clearStepErrors(step) {
+                if (step === 1) {
+                    const container = document.getElementById('step1-error');
+                    if (container) {
+                        container.textContent = '';
+                        container.classList.add('d-none');
+                    }
+                }
+
+                const fields = ['Input.ParticipantCount', 'Input.PreferredDate', 'Input.Mode', 'Input.CompanyId', 'Input.CompanyName', 'Input.ContactPerson', 'Input.ContactEmail', 'Input.ContactPhone'];
+                fields.forEach(fieldName => {
+                    showFieldError(fieldName, '');
+                });
+            }
+
+            function updateSummary() {
+                if (!summaryElements.trainingTypes) {
+                    return;
+                }
+                const selected = isoCheckboxes.filter(c => c.checked).map(checkbox => {
+                    const label = form.querySelector(`label[for="${checkbox.id}"]`);
+                    return label ? label.textContent.trim() : checkbox.value;
+                });
+                summaryElements.trainingTypes.textContent = selected.length ? selected.join(', ') : form.dataset.summaryPlaceholder;
+
+                summaryElements.participantCount.textContent = participantInput && participantInput.value ? participantInput.value : form.dataset.summaryPlaceholder;
+
+                if (dateInput && dateInput.value) {
+                    const date = new Date(dateInput.value);
+                    summaryElements.preferredDate.textContent = Number.isNaN(date.getTime()) ? form.dataset.summaryPlaceholder : dateFormatter.format(date);
+                } else {
+                    summaryElements.preferredDate.textContent = form.dataset.summaryPlaceholder;
+                }
+
+                const modeValue = modeSelect ? modeSelect.value : '';
+                summaryElements.mode.textContent = modeValue ? (modeLabels[modeValue] || modeValue) : form.dataset.summaryPlaceholder;
+
+                summaryElements.companyId.textContent = companyIdInput && companyIdInput.value ? companyIdInput.value : form.dataset.summaryPlaceholder;
+                summaryElements.companyName.textContent = companyNameInput && companyNameInput.value ? companyNameInput.value : form.dataset.summaryPlaceholder;
+                summaryElements.contactPerson.textContent = contactPersonInput && contactPersonInput.value ? contactPersonInput.value : form.dataset.summaryPlaceholder;
+                summaryElements.contactEmail.textContent = contactEmailInput && contactEmailInput.value ? contactEmailInput.value : form.dataset.summaryPlaceholder;
+                summaryElements.contactPhone.textContent = contactPhoneInput && contactPhoneInput.value ? contactPhoneInput.value : form.dataset.summaryPlaceholder;
+
+                const estimated = calculatePrice();
+                if (estimated > 0) {
+                    summaryElements.price.textContent = currencyFormatter.format(estimated);
+                } else {
+                    summaryElements.price.textContent = form.dataset.priceUnavailable;
+                }
+            }
+
+            function updatePrice() {
+                const estimated = calculatePrice();
+                if (estimated > 0) {
+                    priceValue.textContent = currencyFormatter.format(estimated);
+                } else {
+                    priceValue.textContent = form.dataset.priceUnavailable;
+                }
+            }
+
+            function calculatePrice() {
+                const trainingCount = isoCheckboxes.filter(c => c.checked).length;
+                const participants = participantInput ? Number(participantInput.value) : 0;
+                if (trainingCount === 0 || !participants) {
+                    return 0;
+                }
+                const baseTotal = basePrice * trainingCount;
+                const participantTotal = participantPrice * participants;
+                const multiplier = modeMultipliers[modeSelect ? modeSelect.value : ''] ?? 1;
+                return Math.round((baseTotal + participantTotal) * multiplier);
+            }
+
+            function isValidEmail(value) {
+                return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+            }
+
+            function isValidPhone(value) {
+                return /^\+?[0-9()\s-]{6,}$/.test(value.trim());
+            }
+        })();
+    </script>
+}

--- a/Pages/CorporateInquiry.cshtml.cs
+++ b/Pages/CorporateInquiry.cshtml.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Localization;
+using SysJaky_N.Resources;
+
+namespace SysJaky_N.Pages;
+
+public class CorporateInquiryModel : PageModel
+{
+    private static readonly string[] Step1TrainingKeys = new[] { "ISO9001", "ISO14001", "ISO27001", "ISO45001" };
+    private static readonly string[] ModeValues = new[] { "InPerson", "Online", "Hybrid" };
+    private readonly IStringLocalizer<CorporateInquiryModel> _localizer;
+
+    public CorporateInquiryModel(IStringLocalizer<CorporateInquiryModel> localizer)
+    {
+        _localizer = localizer;
+    }
+
+    [BindProperty]
+    public InputModel Input { get; set; } = new();
+
+    public int InitialStep { get; private set; } = 1;
+
+    public IReadOnlyList<string> IsoTrainingOptionKeys => Step1TrainingKeys;
+
+    public IReadOnlyList<string> ModeOptions => ModeValues;
+
+    public decimal BaseTrainingPrice => 8500m;
+
+    public decimal ParticipantPrice => 950m;
+
+    public string ModeMultipliersJson => JsonSerializer.Serialize(new Dictionary<string, decimal>
+    {
+        ["InPerson"] = 1.25m,
+        ["Online"] = 1m,
+        ["Hybrid"] = 1.4m
+    });
+
+    public class InputModel
+    {
+        [Display(Name = nameof(CorporateInquiryResources.TrainingTypesLabel), ResourceType = typeof(CorporateInquiryResources))]
+        public List<string> TrainingTypes { get; set; } = new();
+
+        [Display(Name = nameof(CorporateInquiryResources.ParticipantCountLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [Range(1, 1000, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.Range))]
+        public int? ParticipantCount { get; set; }
+
+        [Display(Name = nameof(CorporateInquiryResources.PreferredDateLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [DataType(DataType.Date)]
+        public DateTime? PreferredDate { get; set; }
+
+        [Display(Name = nameof(CorporateInquiryResources.ModeLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        public string Mode { get; set; } = string.Empty;
+
+        [Display(Name = nameof(CorporateInquiryResources.CompanyIdLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [StringLength(32, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.StringLength))]
+        public string CompanyId { get; set; } = string.Empty;
+
+        [Display(Name = nameof(CorporateInquiryResources.CompanyNameLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [StringLength(200, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.StringLength))]
+        public string CompanyName { get; set; } = string.Empty;
+
+        [Display(Name = nameof(CorporateInquiryResources.ContactPersonLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [StringLength(120, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.StringLength))]
+        public string ContactPerson { get; set; } = string.Empty;
+
+        [Display(Name = nameof(CorporateInquiryResources.ContactEmailLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [EmailAddress(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.EmailAddressInvalid))]
+        [StringLength(200, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.StringLength))]
+        public string ContactEmail { get; set; } = string.Empty;
+
+        [Display(Name = nameof(CorporateInquiryResources.ContactPhoneLabel), ResourceType = typeof(CorporateInquiryResources))]
+        [Required(ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.FieldRequired))]
+        [Phone(ErrorMessageResourceType = typeof(CorporateInquiryResources), ErrorMessageResourceName = nameof(CorporateInquiryResources.PhoneInvalid))]
+        [StringLength(50, ErrorMessageResourceType = typeof(SharedResources), ErrorMessageResourceName = nameof(SharedResources.StringLength))]
+        public string ContactPhone { get; set; } = string.Empty;
+    }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        Input.TrainingTypes ??= new List<string>();
+
+        if (!Input.TrainingTypes.Any())
+        {
+            ModelState.AddModelError("Input.TrainingTypes", _localizer["ValidationStep1"]);
+        }
+
+        if (!ModelState.IsValid)
+        {
+            InitialStep = DetermineFirstInvalidStep();
+            return Page();
+        }
+
+        TempData["Success"] = _localizer["SuccessMessage"];
+        InitialStep = 1;
+        return RedirectToPage();
+    }
+
+    private int DetermineFirstInvalidStep()
+    {
+        foreach (var entry in ModelState)
+        {
+            if (entry.Value.Errors.Count == 0)
+            {
+                continue;
+            }
+
+            if (entry.Key.StartsWith("Input.TrainingTypes", StringComparison.Ordinal))
+            {
+                return 1;
+            }
+            if (entry.Key.StartsWith("Input.ParticipantCount", StringComparison.Ordinal) ||
+                entry.Key.StartsWith("Input.PreferredDate", StringComparison.Ordinal) ||
+                entry.Key.StartsWith("Input.Mode", StringComparison.Ordinal))
+            {
+                return 2;
+            }
+            if (entry.Key.StartsWith("Input.CompanyId", StringComparison.Ordinal) ||
+                entry.Key.StartsWith("Input.CompanyName", StringComparison.Ordinal) ||
+                entry.Key.StartsWith("Input.ContactPerson", StringComparison.Ordinal) ||
+                entry.Key.StartsWith("Input.ContactEmail", StringComparison.Ordinal) ||
+                entry.Key.StartsWith("Input.ContactPhone", StringComparison.Ordinal))
+            {
+                return 3;
+            }
+        }
+
+        return 1;
+    }
+}

--- a/Pages/CorporateInquiry/Partials/_StepCompany.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepCompany.cshtml
@@ -1,0 +1,33 @@
+@model SysJaky_N.Pages.CorporateInquiryModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+<h2 class="h4 mb-3">@Localizer["Step3Title"]</h2>
+<p class="text-muted mb-4">@Localizer["Step3Description"]</p>
+
+<div class="row g-3">
+    <div class="col-md-6">
+        <label asp-for="Input.CompanyId" class="form-label"></label>
+        <input asp-for="Input.CompanyId" class="form-control" />
+        <span asp-validation-for="Input.CompanyId" class="invalid-feedback"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="Input.CompanyName" class="form-label"></label>
+        <input asp-for="Input.CompanyName" class="form-control" />
+        <span asp-validation-for="Input.CompanyName" class="invalid-feedback"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="Input.ContactPerson" class="form-label"></label>
+        <input asp-for="Input.ContactPerson" class="form-control" />
+        <span asp-validation-for="Input.ContactPerson" class="invalid-feedback"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="Input.ContactEmail" class="form-label"></label>
+        <input asp-for="Input.ContactEmail" class="form-control" />
+        <span asp-validation-for="Input.ContactEmail" class="invalid-feedback"></span>
+    </div>
+    <div class="col-md-6">
+        <label asp-for="Input.ContactPhone" class="form-label"></label>
+        <input asp-for="Input.ContactPhone" class="form-control" />
+        <span asp-validation-for="Input.ContactPhone" class="invalid-feedback"></span>
+    </div>
+</div>

--- a/Pages/CorporateInquiry/Partials/_StepDetails.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepDetails.cshtml
@@ -1,0 +1,29 @@
+@model SysJaky_N.Pages.CorporateInquiryModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+<h2 class="h4 mb-3">@Localizer["Step2Title"]</h2>
+<p class="text-muted mb-4">@Localizer["Step2Description"]</p>
+
+<div class="mb-3">
+    <label asp-for="Input.ParticipantCount" class="form-label"></label>
+    <input asp-for="Input.ParticipantCount" class="form-control" min="1" max="1000" />
+    <span asp-validation-for="Input.ParticipantCount" class="invalid-feedback"></span>
+</div>
+
+<div class="mb-3">
+    <label asp-for="Input.PreferredDate" class="form-label"></label>
+    <input asp-for="Input.PreferredDate" class="form-control" type="date" />
+    <span asp-validation-for="Input.PreferredDate" class="invalid-feedback"></span>
+</div>
+
+<div class="mb-3">
+    <label asp-for="Input.Mode" class="form-label"></label>
+    <select asp-for="Input.Mode" class="form-select">
+        <option value="">@Localizer["ModePlaceholder"]</option>
+        @foreach (var option in Model.ModeOptions)
+        {
+            <option value="@option" @(Model.Input.Mode == option ? "selected" : null)>@Localizer[$"ModeOption_{option}"]</option>
+        }
+    </select>
+    <span asp-validation-for="Input.Mode" class="invalid-feedback"></span>
+</div>

--- a/Pages/CorporateInquiry/Partials/_StepSummary.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepSummary.cshtml
@@ -1,0 +1,42 @@
+@model SysJaky_N.Pages.CorporateInquiryModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+<h2 class="h4 mb-3">@Localizer["Step4Title"]</h2>
+<p class="text-muted mb-4">@Localizer["Step4Description"]</p>
+
+<div class="card">
+    <div class="card-body">
+        <h3 class="h5 mb-3">@Localizer["SummaryTitle"]</h3>
+        <dl class="row mb-0">
+            <dt class="col-sm-4">@Localizer["SummaryTrainingTypes"]</dt>
+            <dd class="col-sm-8" id="summary-training-types">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryParticipantCount"]</dt>
+            <dd class="col-sm-8" id="summary-participant-count">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryPreferredDate"]</dt>
+            <dd class="col-sm-8" id="summary-preferred-date">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryMode"]</dt>
+            <dd class="col-sm-8" id="summary-mode">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryCompanyId"]</dt>
+            <dd class="col-sm-8" id="summary-company-id">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryCompanyName"]</dt>
+            <dd class="col-sm-8" id="summary-company-name">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryContactPerson"]</dt>
+            <dd class="col-sm-8" id="summary-contact-person">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryContactEmail"]</dt>
+            <dd class="col-sm-8" id="summary-contact-email">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryContactPhone"]</dt>
+            <dd class="col-sm-8" id="summary-contact-phone">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryPrice"]</dt>
+            <dd class="col-sm-8" id="summary-price">@Localizer["PriceUnavailable"]</dd>
+        </dl>
+    </div>
+</div>

--- a/Pages/CorporateInquiry/Partials/_StepTraining.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepTraining.cshtml
@@ -1,0 +1,25 @@
+@model SysJaky_N.Pages.CorporateInquiryModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+<h2 class="h4 mb-3">@Localizer["Step1Title"]</h2>
+<p class="text-muted mb-4">@Localizer["Step1Description"]</p>
+
+<div class="mb-3" role="group" aria-labelledby="trainingTypesLabel">
+    <span id="trainingTypesLabel" class="form-label d-block fw-semibold">@Localizer["TrainingTypesLabel"]</span>
+    @for (var index = 0; index < Model.IsoTrainingOptionKeys.Count; index++)
+    {
+        var key = Model.IsoTrainingOptionKeys[index];
+        var inputId = $"iso-option-{index}";
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="@inputId" name="Input.TrainingTypes" value="@key" @(Model.Input.TrainingTypes.Contains(key) ? "checked" : null) />
+            <label class="form-check-label" for="@inputId">@Localizer[key]</label>
+        </div>
+    }
+    @{
+        var trainingError = ViewData.ModelState.TryGetValue("Input.TrainingTypes", out var trainingState) && trainingState.Errors.Count > 0
+            ? trainingState.Errors[0].ErrorMessage
+            : null;
+        var errorClass = string.IsNullOrEmpty(trainingError) ? "d-none" : string.Empty;
+    }
+    <div id="step1-error" class="text-danger small mt-2 @errorClass">@trainingError</div>
+</div>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -52,7 +52,7 @@
                             <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(currentPage == "/Articles/Index" ? "page" : null)">@Localizer["NavArticles"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Contact" aria-current="@(currentPage == "/Contact" ? "page" : null)">@Localizer["NavCorporateInquiry"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/CorporateInquiry" aria-current="@(currentPage == "/CorporateInquiry" ? "page" : null)">@Localizer["NavCorporateInquiry"]</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">@Localizer["NavPrivacy"]</a>

--- a/Resources/CorporateInquiryResources.cs
+++ b/Resources/CorporateInquiryResources.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Resources;
+
+namespace SysJaky_N.Resources;
+
+/// <summary>
+/// Provides strongly-typed access to corporate inquiry localization resources.
+/// </summary>
+[SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Wrapper around localized resources")]
+public static class CorporateInquiryResources
+{
+    private static readonly ResourceManager ResourceManager = new(
+        "SysJaky_N.Resources.CorporateInquiryResources",
+        typeof(CorporateInquiryResources).GetTypeInfo().Assembly);
+
+    private static string GetString(string name) => ResourceManager.GetString(name) ?? string.Empty;
+
+    public static string TrainingTypesLabel => GetString(nameof(TrainingTypesLabel));
+    public static string ParticipantCountLabel => GetString(nameof(ParticipantCountLabel));
+    public static string PreferredDateLabel => GetString(nameof(PreferredDateLabel));
+    public static string ModeLabel => GetString(nameof(ModeLabel));
+    public static string CompanyIdLabel => GetString(nameof(CompanyIdLabel));
+    public static string CompanyNameLabel => GetString(nameof(CompanyNameLabel));
+    public static string ContactPersonLabel => GetString(nameof(ContactPersonLabel));
+    public static string ContactEmailLabel => GetString(nameof(ContactEmailLabel));
+    public static string ContactPhoneLabel => GetString(nameof(ContactPhoneLabel));
+    public static string PhoneInvalid => GetString(nameof(PhoneInvalid));
+}

--- a/Resources/CorporateInquiryResources.en.resx
+++ b/Resources/CorporateInquiryResources.en.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TrainingTypesLabel" xml:space="preserve">
+    <value>Select desired ISO standards</value>
+  </data>
+  <data name="ParticipantCountLabel" xml:space="preserve">
+    <value>Number of participants</value>
+  </data>
+  <data name="PreferredDateLabel" xml:space="preserve">
+    <value>Preferred date</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Preferred training mode</value>
+  </data>
+  <data name="CompanyIdLabel" xml:space="preserve">
+    <value>Company ID</value>
+  </data>
+  <data name="CompanyNameLabel" xml:space="preserve">
+    <value>Company name</value>
+  </data>
+  <data name="ContactPersonLabel" xml:space="preserve">
+    <value>Contact person</value>
+  </data>
+  <data name="ContactEmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="ContactPhoneLabel" xml:space="preserve">
+    <value>Phone</value>
+  </data>
+  <data name="PhoneInvalid" xml:space="preserve">
+    <value>Please enter a valid phone number.</value>
+  </data>
+</root>

--- a/Resources/CorporateInquiryResources.resx
+++ b/Resources/CorporateInquiryResources.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TrainingTypesLabel" xml:space="preserve">
+    <value>Vyberte požadované ISO normy</value>
+  </data>
+  <data name="ParticipantCountLabel" xml:space="preserve">
+    <value>Počet účastníků</value>
+  </data>
+  <data name="PreferredDateLabel" xml:space="preserve">
+    <value>Preferovaný termín</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Preferovaný režim školení</value>
+  </data>
+  <data name="CompanyIdLabel" xml:space="preserve">
+    <value>IČO</value>
+  </data>
+  <data name="CompanyNameLabel" xml:space="preserve">
+    <value>Název společnosti</value>
+  </data>
+  <data name="ContactPersonLabel" xml:space="preserve">
+    <value>Kontaktní osoba</value>
+  </data>
+  <data name="ContactEmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="ContactPhoneLabel" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="PhoneInvalid" xml:space="preserve">
+    <value>Zadejte platné telefonní číslo.</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.en.resx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Corporate training inquiry</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Tell us which ISO standards you need to cover and we will prepare a tailored training offer for your company.</value>
+  </data>
+  <data name="EnableJavaScriptWarning" xml:space="preserve">
+    <value>JavaScript is required to submit this inquiry.</value>
+  </data>
+  <data name="ProgressAriaLabel" xml:space="preserve">
+    <value>Inquiry progress</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Back</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Continue</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Send inquiry</value>
+  </data>
+  <data name="EstimatedPriceLabel" xml:space="preserve">
+    <value>Estimated price</value>
+  </data>
+  <data name="EstimatedPricePlaceholder" xml:space="preserve">
+    <value>—</value>
+  </data>
+  <data name="Step1Title" xml:space="preserve">
+    <value>Select ISO standards</value>
+  </data>
+  <data name="Step1Description" xml:space="preserve">
+    <value>Choose which standards should be included in the training.</value>
+  </data>
+  <data name="Step2Title" xml:space="preserve">
+    <value>Training details</value>
+  </data>
+  <data name="Step2Description" xml:space="preserve">
+    <value>Provide the core details of the training you require.</value>
+  </data>
+  <data name="Step3Title" xml:space="preserve">
+    <value>Company information</value>
+  </data>
+  <data name="Step3Description" xml:space="preserve">
+    <value>Let us know who we will be working with.</value>
+  </data>
+  <data name="Step4Title" xml:space="preserve">
+    <value>Summary</value>
+  </data>
+  <data name="Step4Description" xml:space="preserve">
+    <value>Review your details before sending.</value>
+  </data>
+  <data name="SummaryTitle" xml:space="preserve">
+    <value>Inquiry summary</value>
+  </data>
+  <data name="SummaryTrainingTypes" xml:space="preserve">
+    <value>ISO standards</value>
+  </data>
+  <data name="SummaryParticipantCount" xml:space="preserve">
+    <value>Participants</value>
+  </data>
+  <data name="SummaryPreferredDate" xml:space="preserve">
+    <value>Preferred date</value>
+  </data>
+  <data name="SummaryMode" xml:space="preserve">
+    <value>Mode</value>
+  </data>
+  <data name="SummaryCompanyId" xml:space="preserve">
+    <value>Company ID</value>
+  </data>
+  <data name="SummaryCompanyName" xml:space="preserve">
+    <value>Company name</value>
+  </data>
+  <data name="SummaryContactPerson" xml:space="preserve">
+    <value>Contact person</value>
+  </data>
+  <data name="SummaryContactEmail" xml:space="preserve">
+    <value>Contact e-mail</value>
+  </data>
+  <data name="SummaryContactPhone" xml:space="preserve">
+    <value>Contact phone</value>
+  </data>
+  <data name="SummaryPrice" xml:space="preserve">
+    <value>Estimated price</value>
+  </data>
+  <data name="SummaryPlaceholder" xml:space="preserve">
+    <value>Not provided</value>
+  </data>
+  <data name="PriceUnavailable" xml:space="preserve">
+    <value>Enter details</value>
+  </data>
+  <data name="ModePlaceholder" xml:space="preserve">
+    <value>Select mode</value>
+  </data>
+  <data name="ModeOption_InPerson" xml:space="preserve">
+    <value>In person</value>
+  </data>
+  <data name="ModeOption_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="ModeOption_Hybrid" xml:space="preserve">
+    <value>Hybrid</value>
+  </data>
+  <data name="ISO9001" xml:space="preserve">
+    <value>ISO 9001 — Quality management</value>
+  </data>
+  <data name="ISO14001" xml:space="preserve">
+    <value>ISO 14001 — Environmental management</value>
+  </data>
+  <data name="ISO27001" xml:space="preserve">
+    <value>ISO/IEC 27001 — Information security</value>
+  </data>
+  <data name="ISO45001" xml:space="preserve">
+    <value>ISO 45001 — Occupational health &amp; safety</value>
+  </data>
+  <data name="ValidationStep1" xml:space="preserve">
+    <value>Select at least one ISO standard.</value>
+  </data>
+  <data name="ValidationParticipantRequired" xml:space="preserve">
+    <value>Please enter the number of participants.</value>
+  </data>
+  <data name="ValidationParticipantRange" xml:space="preserve">
+    <value>The number of participants must be between 1 and 1000.</value>
+  </data>
+  <data name="ValidationDateRequired" xml:space="preserve">
+    <value>Please select a preferred date.</value>
+  </data>
+  <data name="ValidationModeRequired" xml:space="preserve">
+    <value>Please choose your preferred training mode.</value>
+  </data>
+  <data name="ValidationCompanyIdRequired" xml:space="preserve">
+    <value>Please enter your company ID.</value>
+  </data>
+  <data name="ValidationCompanyNameRequired" xml:space="preserve">
+    <value>Please enter your company name.</value>
+  </data>
+  <data name="ValidationContactPersonRequired" xml:space="preserve">
+    <value>Please provide a contact person.</value>
+  </data>
+  <data name="ValidationContactEmailRequired" xml:space="preserve">
+    <value>Please provide a contact e-mail.</value>
+  </data>
+  <data name="ValidationContactEmailInvalid" xml:space="preserve">
+    <value>Please enter a valid e-mail address.</value>
+  </data>
+  <data name="ValidationContactPhoneRequired" xml:space="preserve">
+    <value>Please provide a contact phone number.</value>
+  </data>
+  <data name="ValidationContactPhoneInvalid" xml:space="preserve">
+    <value>Please enter a valid phone number.</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.resx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Firemní školení na míru</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Pomůžeme vám s přípravou firemního školení dle požadovaných ISO norem. Vyplňte poptávku a my se vám ozveme s přesnou nabídkou.</value>
+  </data>
+  <data name="EnableJavaScriptWarning" xml:space="preserve">
+    <value>Pro odeslání poptávky je nutné mít povolený JavaScript.</value>
+  </data>
+  <data name="ProgressAriaLabel" xml:space="preserve">
+    <value>Průběh vyplňování poptávky</value>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Zpět</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Pokračovat</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Odeslat poptávku</value>
+  </data>
+  <data name="EstimatedPriceLabel" xml:space="preserve">
+    <value>Odhad ceny</value>
+  </data>
+  <data name="EstimatedPricePlaceholder" xml:space="preserve">
+    <value>—</value>
+  </data>
+  <data name="Step1Title" xml:space="preserve">
+    <value>Vyberte ISO normy</value>
+  </data>
+  <data name="Step1Description" xml:space="preserve">
+    <value>Zvolte, které normy chcete zahrnout do školení.</value>
+  </data>
+  <data name="Step2Title" xml:space="preserve">
+    <value>Detaily školení</value>
+  </data>
+  <data name="Step2Description" xml:space="preserve">
+    <value>Uveďte základní parametry plánovaného školení.</value>
+  </data>
+  <data name="Step3Title" xml:space="preserve">
+    <value>Informace o společnosti</value>
+  </data>
+  <data name="Step3Description" xml:space="preserve">
+    <value>Vyplňte údaje o firmě a kontaktní osobě.</value>
+  </data>
+  <data name="Step4Title" xml:space="preserve">
+    <value>Shrnutí</value>
+  </data>
+  <data name="Step4Description" xml:space="preserve">
+    <value>Zkontrolujte zadané údaje a odešlete poptávku.</value>
+  </data>
+  <data name="SummaryTitle" xml:space="preserve">
+    <value>Rekapitulace poptávky</value>
+  </data>
+  <data name="SummaryTrainingTypes" xml:space="preserve">
+    <value>ISO normy</value>
+  </data>
+  <data name="SummaryParticipantCount" xml:space="preserve">
+    <value>Počet účastníků</value>
+  </data>
+  <data name="SummaryPreferredDate" xml:space="preserve">
+    <value>Preferovaný termín</value>
+  </data>
+  <data name="SummaryMode" xml:space="preserve">
+    <value>Režim</value>
+  </data>
+  <data name="SummaryCompanyId" xml:space="preserve">
+    <value>IČO</value>
+  </data>
+  <data name="SummaryCompanyName" xml:space="preserve">
+    <value>Název společnosti</value>
+  </data>
+  <data name="SummaryContactPerson" xml:space="preserve">
+    <value>Kontaktní osoba</value>
+  </data>
+  <data name="SummaryContactEmail" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="SummaryContactPhone" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="SummaryPrice" xml:space="preserve">
+    <value>Odhadovaná cena</value>
+  </data>
+  <data name="SummaryPlaceholder" xml:space="preserve">
+    <value>Nezadáno</value>
+  </data>
+  <data name="PriceUnavailable" xml:space="preserve">
+    <value>Doplnit údaje</value>
+  </data>
+  <data name="ModePlaceholder" xml:space="preserve">
+    <value>Vyberte režim</value>
+  </data>
+  <data name="ModeOption_InPerson" xml:space="preserve">
+    <value>Prezenčně</value>
+  </data>
+  <data name="ModeOption_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="ModeOption_Hybrid" xml:space="preserve">
+    <value>Hybridně</value>
+  </data>
+  <data name="ISO9001" xml:space="preserve">
+    <value>ISO 9001 — Systém managementu kvality</value>
+  </data>
+  <data name="ISO14001" xml:space="preserve">
+    <value>ISO 14001 — Environmentální management</value>
+  </data>
+  <data name="ISO27001" xml:space="preserve">
+    <value>ISO/IEC 27001 — Bezpečnost informací</value>
+  </data>
+  <data name="ISO45001" xml:space="preserve">
+    <value>ISO 45001 — BOZP</value>
+  </data>
+  <data name="ValidationStep1" xml:space="preserve">
+    <value>Vyberte alespoň jednu ISO normu.</value>
+  </data>
+  <data name="ValidationParticipantRequired" xml:space="preserve">
+    <value>Zadejte počet účastníků.</value>
+  </data>
+  <data name="ValidationParticipantRange" xml:space="preserve">
+    <value>Počet účastníků musí být mezi 1 a 1000.</value>
+  </data>
+  <data name="ValidationDateRequired" xml:space="preserve">
+    <value>Zadejte preferovaný termín.</value>
+  </data>
+  <data name="ValidationModeRequired" xml:space="preserve">
+    <value>Vyberte preferovaný režim školení.</value>
+  </data>
+  <data name="ValidationCompanyIdRequired" xml:space="preserve">
+    <value>Vyplňte IČO společnosti.</value>
+  </data>
+  <data name="ValidationCompanyNameRequired" xml:space="preserve">
+    <value>Zadejte název společnosti.</value>
+  </data>
+  <data name="ValidationContactPersonRequired" xml:space="preserve">
+    <value>Uveďte kontaktní osobu.</value>
+  </data>
+  <data name="ValidationContactEmailRequired" xml:space="preserve">
+    <value>Zadejte kontaktní e-mail.</value>
+  </data>
+  <data name="ValidationContactEmailInvalid" xml:space="preserve">
+    <value>Zadejte platný e-mail.</value>
+  </data>
+  <data name="ValidationContactPhoneRequired" xml:space="preserve">
+    <value>Zadejte kontaktní telefon.</value>
+  </data>
+  <data name="ValidationContactPhoneInvalid" xml:space="preserve">
+    <value>Zadejte platné telefonní číslo.</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiryModel.cs.en.resx
+++ b/Resources/Pages.CorporateInquiryModel.cs.en.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ValidationStep1" xml:space="preserve">
+    <value>Please select at least one ISO standard.</value>
+  </data>
+  <data name="SuccessMessage" xml:space="preserve">
+    <value>Thank you, we will contact you shortly with an offer.</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiryModel.cs.resx
+++ b/Resources/Pages.CorporateInquiryModel.cs.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ValidationStep1" xml:space="preserve">
+    <value>Vyberte alespoň jednu ISO normu.</value>
+  </data>
+  <data name="SuccessMessage" xml:space="preserve">
+    <value>Děkujeme, ozveme se vám co nejdříve s nabídkou.</value>
+  </data>
+</root>

--- a/Resources/SharedResources.cs
+++ b/Resources/SharedResources.cs
@@ -18,6 +18,7 @@ public static class SharedResources
 
     public static string FieldRequired => GetString(nameof(FieldRequired));
     public static string StringLength => GetString(nameof(StringLength));
+    public static string Range => GetString(nameof(Range));
     public static string EmailAddressInvalid => GetString(nameof(EmailAddressInvalid));
     public static string ContactNameLabel => GetString(nameof(ContactNameLabel));
     public static string ContactEmailLabel => GetString(nameof(ContactEmailLabel));

--- a/Resources/SharedResources.en.resx
+++ b/Resources/SharedResources.en.resx
@@ -30,4 +30,7 @@
   <data name="ContactMessageLabel" xml:space="preserve">
     <value>Message</value>
   </data>
+  <data name="Range" xml:space="preserve">
+    <value>The field {0} must be between {1} and {2}.</value>
+  </data>
 </root>

--- a/Resources/SharedResources.resx
+++ b/Resources/SharedResources.resx
@@ -30,4 +30,7 @@
   <data name="ContactMessageLabel" xml:space="preserve">
     <value>Zpráva</value>
   </data>
+  <data name="Range" xml:space="preserve">
+    <value>Pole {0} musí být mezi {1} a {2}.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add a new corporate inquiry Razor page that implements a four-step wizard with progress tracking, client-side validation, localStorage persistence, and live price estimation
- split the wizard UI into localized partial views for ISO selection, training details, company data, and submission summary while wiring the navigation link to the new page
- introduce page model logic and supporting localization resources, including shared range messaging, to validate submissions and keep the wizard multilingual

## Testing
- ⚠️ `dotnet build` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0210ee28832180cf3e0270723d70