### PR TITLE
Add internal StyleGuide page with live design system examples

### DIFF
--- a/Pages/StyleGuide/Index.cshtml
+++ b/Pages/StyleGuide/Index.cshtml
@@ -1,0 +1,380 @@
+@page "/StyleGuide"
+@using SysJaky_N.Authorization
+@attribute [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
+@{
+    ViewData["Title"] = "Design systém";
+}
+
+<div class="container-xxl py-5">
+    <header class="mb-5 pb-4 border-bottom">
+        <p class="text-uppercase text-muted small fw-semibold mb-2">Pouze pro interní použití</p>
+        <h1 class="display-5 fw-semibold mb-3">Style Guide &amp; design systém</h1>
+        <p class="lead mb-0">Aktuální živá dokumentace základních prvků front-end knihovny SysJaky. Stránka je dostupná pouze správcům a používá reálné komponenty z produkčního projektu.</p>
+    </header>
+
+    <section id="colors" class="mb-5">
+        <h2 class="h3 mb-4">1. Barevná paleta</h2>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4">
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #0b7bb3;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Primary</h3>
+                        <p class="text-muted small mb-2">#0B7BB3</p>
+                        <p class="mb-0">Hlavní CTA barva (tlačítka, odkazy, zvýraznění).</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #075f8a;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Primary Dark</h3>
+                        <p class="text-muted small mb-2">#075F8A</p>
+                        <p class="mb-0">Hover/focus varianty, sekundární CTA, aktivní stavy.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #f59e0b;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Accent</h3>
+                        <p class="text-muted small mb-2">#F59E0B</p>
+                        <p class="mb-0">Důležité upozornění, badge, zvýraznění přístupnosti.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #0b1120;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Ink</h3>
+                        <p class="text-muted small mb-2">#0B1120</p>
+                        <p class="mb-0">Primární text, nadpisy, ikony na světlém pozadí.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4 mt-1">
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #e6f6fc;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Primary 50</h3>
+                        <p class="text-muted small mb-2">#E6F6FC</p>
+                        <p class="mb-0">Sekundární pozadí, infoboxy, bannery.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #e2e8f0;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Neutral 300</h3>
+                        <p class="text-muted small mb-2">#E2E8F0</p>
+                        <p class="mb-0">Ohraničení, tabulky, oddělovací linie.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #475569;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Neutral 500</h3>
+                        <p class="text-muted small mb-2">#475569</p>
+                        <p class="mb-0">Sekundární text, ikonografie na světlém pozadí.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="border rounded-3 h-100">
+                    <div class="ratio ratio-16x9 rounded-top" style="background-color: #ffffff; border: 1px solid #e2e8f0;"></div>
+                    <div class="p-3">
+                        <h3 class="h5 mb-1">Neutral 100</h3>
+                        <p class="text-muted small mb-2">#FFFFFF</p>
+                        <p class="mb-0">Výchozí pozadí, karty, modální okna.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="typography" class="mb-5">
+        <h2 class="h3 mb-4">2. Typografie (Roboto)</h2>
+        <div class="row g-4">
+            <div class="col-lg-6">
+                <div class="p-4 bg-white border rounded-3 h-100">
+                    <h3 class="h5">Ukázka hierarchie</h3>
+                    <p class="text-muted small">Font-family: 'Roboto', sans-serif</p>
+                    <h1 class="display-5 mb-2">Display 5 – 48px / 1.2 / 600</h1>
+                    <h2 class="h1 mb-2">H1 – 40px / 1.25 / 600</h2>
+                    <h3 class="h2 mb-2">H2 – 32px / 1.3 / 600</h3>
+                    <h4 class="h3 mb-2">H3 – 28px / 1.3 / 500</h4>
+                    <p class="fs-5 mb-2">Lead – 20px / 1.6 / 400</p>
+                    <p class="mb-2">Body – 16px / 1.6 / 400</p>
+                    <p class="text-muted mb-0"><small>Caption – 14px / 1.4 / 500</small></p>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="p-4 bg-white border rounded-3 h-100">
+                    <h3 class="h5">Pravidla použití</h3>
+                    <ul class="mb-0">
+                        <li><strong>Velké nadpisy</strong> (display/h1) pro vstupní sekce a marketingové hero bloky.</li>
+                        <li><strong>H2–H4</strong> pro strukturovaný obsah a sekce na podstránkách.</li>
+                        <li><strong>Lead text</strong> zvýrazňuje úvodní odstavec (class <code>.lead</code>).</li>
+                        <li><strong>Body text</strong> je výchozí velikost 16px, line-height 1.6.</li>
+                        <li><strong>Váhy</strong>: 400 (regular), 500 (medium), 600 (semibold) dle potřeby kontrastu.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="components" class="mb-5">
+        <h2 class="h3 mb-4">3. Komponenty</h2>
+
+        <article class="mb-5">
+            <header class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+                <div>
+                    <h3 class="h4 mb-1">Buttons</h3>
+                    <p class="text-muted mb-0">Používejte <code>.btn</code> se stavovými variantami pro konzistentní CTA.</p>
+                </div>
+                <div class="d-flex flex-wrap gap-2">
+                    <button type="button" class="btn btn-primary">Primary button</button>
+                    <button type="button" class="btn btn-outline-primary">Secondary button</button>
+                    <button type="button" class="btn btn-link text-decoration-none">Ghost button</button>
+                </div>
+            </header>
+            <pre class="bg-dark text-white p-3 rounded-3 overflow-auto"><code>&lt;button type=&quot;button&quot; class=&quot;btn btn-primary&quot;&gt;Primary button&lt;/button&gt;
+&lt;button type=&quot;button&quot; class=&quot;btn btn-outline-primary&quot;&gt;Secondary button&lt;/button&gt;
+&lt;button type=&quot;button&quot; class=&quot;btn btn-link text-decoration-none&quot;&gt;Ghost button&lt;/button&gt;</code></pre>
+        </article>
+
+        <article class="mb-5">
+            <header class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+                <div>
+                    <h3 class="h4 mb-1">Cards</h3>
+                    <p class="text-muted mb-0">Karty používají <code>.card</code> pro základ a <code>.card-hover</code> pro jemnou animaci.</p>
+                </div>
+            </header>
+            <div class="row g-4 mb-3">
+                <div class="col-md-6">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-body">
+                            <h4 class="card-title">Základní karta</h4>
+                            <p class="card-text">Text těla karty používá výchozí typografii a odstup tříd <code>.card</code>.</p>
+                            <a href="#" class="btn btn-primary btn-sm">Akce</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="card card-hover h-100">
+                        <div class="card-body">
+                            <h4 class="card-title">Hover varianta</h4>
+                            <p class="card-text">Třída <code>.card-hover</code> přidává zvýšení stínu a posun při hover/focus.</p>
+                            <a href="#" class="btn btn-outline-primary btn-sm">Více</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <pre class="bg-dark text-white p-3 rounded-3 overflow-auto"><code>&lt;div class=&quot;card&quot;&gt;
+    &lt;div class=&quot;card-body&quot;&gt;
+        &lt;h4 class=&quot;card-title&quot;&gt;Základní karta&lt;/h4&gt;
+        &lt;p class=&quot;card-text&quot;&gt;...&lt;/p&gt;
+        &lt;a href=&quot;#&quot; class=&quot;btn btn-primary btn-sm&quot;&gt;Akce&lt;/a&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;card card-hover&quot;&gt;
+    &lt;div class=&quot;card-body&quot;&gt;
+        &lt;h4 class=&quot;card-title&quot;&gt;Hover varianta&lt;/h4&gt;
+        &lt;p class=&quot;card-text&quot;&gt;...&lt;/p&gt;
+        &lt;a href=&quot;#&quot; class=&quot;btn btn-outline-primary btn-sm&quot;&gt;Více&lt;/a&gt;
+    &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+        </article>
+
+        <article class="mb-5">
+            <header class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+                <div>
+                    <h3 class="h4 mb-1">Forms</h3>
+                    <p class="text-muted mb-0">Výchozí vstupy používají <code>.form-control</code> a selekty <code>.form-select</code>.</p>
+                </div>
+            </header>
+            <form class="row g-3 mb-3" novalidate>
+                <div class="col-md-6">
+                    <label for="styleGuideInput" class="form-label">Text input</label>
+                    <input type="text" class="form-control" id="styleGuideInput" placeholder="Sem napište text" />
+                </div>
+                <div class="col-md-6">
+                    <label for="styleGuideSelect" class="form-label">Select input</label>
+                    <select class="form-select" id="styleGuideSelect">
+                        <option>Možnost 1</option>
+                        <option>Možnost 2</option>
+                        <option>Možnost 3</option>
+                    </select>
+                </div>
+            </form>
+            <pre class="bg-dark text-white p-3 rounded-3 overflow-auto"><code>&lt;label for=&quot;inputId&quot; class=&quot;form-label&quot;&gt;Text input&lt;/label&gt;
+&lt;input type=&quot;text&quot; class=&quot;form-control&quot; id=&quot;inputId&quot; placeholder=&quot;...&quot; /&gt;
+
+&lt;label for=&quot;selectId&quot; class=&quot;form-label&quot;&gt;Select input&lt;/label&gt;
+&lt;select class=&quot;form-select&quot; id=&quot;selectId&quot;&gt;
+    &lt;option&gt;Možnost 1&lt;/option&gt;
+&lt;/select&gt;</code></pre>
+        </article>
+
+        <article class="mb-5">
+            <header class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+                <div>
+                    <h3 class="h4 mb-1">Chips</h3>
+                    <p class="text-muted mb-0">Mini CTA používají <code>.chip</code>; světlá varianta <code>.chip-light</code> na tmavém pozadí.</p>
+                </div>
+                <div class="d-flex flex-wrap gap-2">
+                    <a class="chip" href="#">Chip</a>
+                    <a class="chip chip-light" href="#">Chip light</a>
+                </div>
+            </header>
+            <pre class="bg-dark text-white p-3 rounded-3 overflow-auto"><code>&lt;a class=&quot;chip&quot; href=&quot;#&quot;&gt;Chip&lt;/a&gt;
+&lt;a class=&quot;chip chip-light&quot; href=&quot;#&quot;&gt;Chip light&lt;/a&gt;</code></pre>
+        </article>
+
+        <article class="mb-5">
+            <header class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-3">
+                <div>
+                    <h3 class="h4 mb-1">Icons</h3>
+                    <p class="text-muted mb-0">Bootstrap Icons z CDN – používejte <code>&lt;i class=&quot;bi bi-*&quot;&gt;</code>.</p>
+                </div>
+                <div class="d-flex flex-wrap align-items-center gap-3 fs-3 text-primary">
+                    <i class="bi bi-lightning-charge-fill" aria-hidden="true"></i>
+                    <i class="bi bi-people-fill" aria-hidden="true"></i>
+                    <i class="bi bi-mortarboard-fill" aria-hidden="true"></i>
+                </div>
+            </header>
+            <pre class="bg-dark text-white p-3 rounded-3 overflow-auto"><code>&lt;i class=&quot;bi bi-lightning-charge-fill&quot; aria-hidden=&quot;true&quot;&gt;&lt;/i&gt;</code></pre>
+        </article>
+    </section>
+
+    <section id="spacing" class="mb-5">
+        <h2 class="h3 mb-4">4. Spacing scale</h2>
+        <p class="text-muted">Vychází z Bootstrap spacing utilit <code>.m|p-{breakpoint}-{0-5}</code>.</p>
+        <div class="table-responsive">
+            <table class="table table-sm align-middle">
+                <thead>
+                    <tr>
+                        <th>Token</th>
+                        <th>Rem</th>
+                        <th>Příklad</th>
+                        <th>Popis</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>0</code></td>
+                        <td>0</td>
+                        <td><code>.p-0</code></td>
+                        <td>Bez vnitřního/venkovního odsazení.</td>
+                    </tr>
+                    <tr>
+                        <td><code>1</code></td>
+                        <td>0.25rem</td>
+                        <td><code>.px-1</code></td>
+                        <td>Mikro odsazení pro skupiny prvků.</td>
+                    </tr>
+                    <tr>
+                        <td><code>2</code></td>
+                        <td>0.5rem</td>
+                        <td><code>.my-2</code></td>
+                        <td>Výchozí mezerování mezi komponentami.</td>
+                    </tr>
+                    <tr>
+                        <td><code>3</code></td>
+                        <td>1rem</td>
+                        <td><code>.p-3</code></td>
+                        <td>Standardní padding karet a sekcí.</td>
+                    </tr>
+                    <tr>
+                        <td><code>4</code></td>
+                        <td>1.5rem</td>
+                        <td><code>.pt-4</code></td>
+                        <td>Větší oddělení bloků/sekcí.</td>
+                    </tr>
+                    <tr>
+                        <td><code>5</code></td>
+                        <td>3rem</td>
+                        <td><code>.py-5</code></td>
+                        <td>Hero sekce, vertikální rytmus stránky.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section id="breakpoints" class="mb-5">
+        <h2 class="h3 mb-4">5. Breakpoints &amp; responsive behavior</h2>
+        <div class="table-responsive mb-3">
+            <table class="table table-sm align-middle">
+                <thead>
+                    <tr>
+                        <th>Breakpoint</th>
+                        <th>Šířka</th>
+                        <th>Příklad použití</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><code>xs</code></td>
+                        <td>&lt;576px</td>
+                        <td>Stackované sloupce, full-width CTA.</td>
+                    </tr>
+                    <tr>
+                        <td><code>sm</code></td>
+                        <td>≥576px</td>
+                        <td><code>.row-cols-sm-2</code> pro dvousloupcové layouty.</td>
+                    </tr>
+                    <tr>
+                        <td><code>md</code></td>
+                        <td>≥768px</td>
+                        <td>Navigace v řádku, formuláře ve dvou sloupcích.</td>
+                    </tr>
+                    <tr>
+                        <td><code>lg</code></td>
+                        <td>≥992px</td>
+                        <td>Vícesloupcové karty, layout <code>.container-lg</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>xl</code></td>
+                        <td>≥1200px</td>
+                        <td>Rozšířená mřížka, maximální šířka marketingových sekcí.</td>
+                    </tr>
+                    <tr>
+                        <td><code>xxl</code></td>
+                        <td>≥1400px</td>
+                        <td>Hero bloky s margin auto, jemné prázdné okraje.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <p class="mb-0">Mřížka Bootstrapu umožňuje přidávat breakpointový suffix (např. <code>.col-md-6</code>). U komponent jako karty a formuláře kombinujte <code>.row</code>, <code>.col</code> a spacing utility.</p>
+    </section>
+
+    <section id="accessibility" class="mb-5">
+        <h2 class="h3 mb-4">6. Accessibility guidelines</h2>
+        <ul class="list-group list-group-flush">
+            <li class="list-group-item">Dodržujte kontrastní poměry: hlavní text vs. pozadí minimálně 4.5:1 (paleta výše).</li>
+            <li class="list-group-item">Vždy nastavujte <code>aria-label</code>/<code>aria-describedby</code> pro ikonická tlačítka a formuláře.</li>
+            <li class="list-group-item">Používejte <code>:focus-visible</code> styly ze <code>site.css</code> – neodstraňovat outline.</li>
+            <li class="list-group-item">Skupiny ovládacích prvků popisujte nadpisy (např. <code>&lt;legend&gt;</code>, <code>&lt;h2&gt;</code>).</li>
+            <li class="list-group-item">Interaktivní prvky (chip, card-hover) musí mít <code>role</code> a <code>tabindex</code>, pokud nejsou odkazem/tlačítkem.</li>
+        </ul>
+    </section>
+
+    <section id="code" class="mb-4">
+        <h2 class="h3 mb-3">7. Code snippets</h2>
+        <p class="mb-3">Pro rychlé znovupoužití můžete kopírovat kód výše uvedený v blocích. Doporučujeme udržovat komponenty v partial view (<code>Pages/Shared</code>) pro znovupoužitelnost.</p>
+        <div class="alert alert-info mb-0" role="note">
+            <strong>Tip:</strong> Při úpravách komponent vždy kontrolujte dostupnost v tmavém i světlém kontextu a testujte focus states.
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- add an admin-only StyleGuide Razor page that documents the color palette, typography, spacing, breakpoints, and accessibility guidelines for the design system
- include living examples and reusable code snippets for buttons, cards, forms, chips, and Bootstrap icon usage

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd05aa66e883218edc7bcb92b1633a