### PR TITLE
Rozšířit admin dashboard o analytické přehledy

### DIFF
--- a/Controllers/AnalyticsController.cs
+++ b/Controllers/AnalyticsController.cs
@@ -1,0 +1,195 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using OfficeOpenXml;
+using SysJaky_N.Authorization;
+using SysJaky_N.Services.Analytics;
+
+namespace SysJaky_N.Controllers;
+
+[ApiController]
+[Route("api/admin/analytics")]
+[Authorize(Policy = AuthorizationPolicies.AdminDashboardAccess)]
+public class AnalyticsController : ControllerBase
+{
+    private readonly DashboardAnalyticsService _analytics;
+
+    public AnalyticsController(DashboardAnalyticsService analytics)
+    {
+        _analytics = analytics;
+    }
+
+    [HttpGet("overview")]
+    public async Task<ActionResult<DashboardOverviewDto>> ZiskatPrehledAsync([FromQuery] FiltrAnalytiky dotaz, CancellationToken cancellationToken)
+    {
+        var filter = dotaz.ToFilter();
+        var data = await _analytics.GetOverviewAsync(filter, cancellationToken);
+        return Ok(data);
+    }
+
+    [HttpGet("realtime")]
+    public async Task<ActionResult<RealtimeStatsDto>> ZiskatRealtimeAsync([FromQuery] FiltrAnalytiky dotaz, CancellationToken cancellationToken)
+    {
+        var filter = dotaz.ToFilter();
+        var data = await _analytics.GetRealtimeStatsAsync(filter, cancellationToken);
+        return Ok(data);
+    }
+
+    [HttpGet("export")]
+    public async Task<IActionResult> ExportovatAsync([FromQuery] FiltrAnalytiky dotaz, CancellationToken cancellationToken)
+    {
+        var filter = dotaz.ToFilter();
+        var prehled = await _analytics.GetOverviewAsync(filter, cancellationToken);
+        var realtime = await _analytics.GetRealtimeStatsAsync(filter, cancellationToken);
+
+        using var paket = new ExcelPackage();
+
+        VytvoritListSouhrn(paket, filter, prehled, realtime);
+        VytvoritListProdeje(paket, prehled);
+        VytvoritListTopKurzy(paket, prehled.TopCourses);
+        VytvoritListKonverze(paket, prehled.Conversion);
+        VytvoritListHeatmapa(paket, prehled.Heatmap);
+
+        var soubor = paket.GetAsByteArray();
+        var nazev = $"dashboard-{DateTime.UtcNow:yyyyMMddHHmmss}.xlsx";
+        return File(soubor, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", nazev);
+    }
+
+    private static void VytvoritListSouhrn(ExcelPackage paket, AnalyticsFilter filter, DashboardOverviewDto prehled, RealtimeStatsDto realtime)
+    {
+        var list = paket.Workbook.Worksheets.Add("Souhrn");
+        list.Cells[1, 1].Value = "Období";
+        list.Cells[1, 2].Value = $"{filter.Od:dd.MM.yyyy} – {filter.Do:dd.MM.yyyy}";
+
+        list.Cells[2, 1].Value = "Celkové tržby";
+        list.Cells[2, 2].Value = prehled.Summary.CelkoveTrzby;
+
+        list.Cells[3, 1].Value = "Zaplacené objednávky";
+        list.Cells[3, 2].Value = prehled.Summary.PocetObjednavek;
+
+        list.Cells[4, 1].Value = "Průměrná objednávka";
+        list.Cells[4, 2].Value = prehled.Summary.PrumernaObjednavka;
+
+        list.Cells[5, 1].Value = "Unikátní zákazníci";
+        list.Cells[5, 2].Value = prehled.Summary.UnikatniZakaznici;
+
+        list.Cells[7, 1].Value = "Online účastníci";
+        list.Cells[7, 2].Value = realtime.OnlineUzivatele;
+
+        list.Cells[8, 1].Value = "Rozpracované košíky";
+        list.Cells[8, 2].Value = realtime.AktivniKosiky;
+
+        list.Cells[9, 1].Value = "Hodnota v košících";
+        list.Cells[9, 2].Value = realtime.HodnotaKosiku;
+
+        list.Cells[2, 2, 9, 2].Style.Numberformat.Format = "#,##0.00";
+        list.Cells.AutoFitColumns();
+    }
+
+    private static void VytvoritListProdeje(ExcelPackage paket, DashboardOverviewDto prehled)
+    {
+        var list = paket.Workbook.Worksheets.Add("Prodeje");
+        list.Cells[1, 1].Value = "Datum";
+        list.Cells[1, 2].Value = "Tržby";
+        list.Cells[1, 3].Value = "Objednávky";
+        list.Cells[1, 4].Value = "Průměrná objednávka";
+
+        for (var i = 0; i < prehled.Labels.Count; i++)
+        {
+            list.Cells[i + 2, 1].Value = prehled.Labels[i];
+            list.Cells[i + 2, 2].Value = prehled.Revenue[i];
+            list.Cells[i + 2, 3].Value = prehled.Orders[i];
+            list.Cells[i + 2, 4].Value = prehled.AverageOrder[i];
+        }
+
+        list.Cells[2, 2, prehled.Labels.Count + 1, 4].Style.Numberformat.Format = "#,##0.00";
+        list.Cells.AutoFitColumns();
+    }
+
+    private static void VytvoritListTopKurzy(ExcelPackage paket, IReadOnlyList<TopCourseDto> topKurzy)
+    {
+        var list = paket.Workbook.Worksheets.Add("Top kurzy");
+        list.Cells[1, 1].Value = "Kurz";
+        list.Cells[1, 2].Value = "Tržby";
+        list.Cells[1, 3].Value = "Prodáno";
+
+        for (var i = 0; i < topKurzy.Count; i++)
+        {
+            list.Cells[i + 2, 1].Value = topKurzy[i].Nazev;
+            list.Cells[i + 2, 2].Value = topKurzy[i].Trzba;
+            list.Cells[i + 2, 3].Value = topKurzy[i].Pocet;
+        }
+
+        list.Cells[2, 2, topKurzy.Count + 1, 2].Style.Numberformat.Format = "#,##0.00";
+        list.Cells.AutoFitColumns();
+    }
+
+    private static void VytvoritListKonverze(ExcelPackage paket, ConversionFunnelDto konverze)
+    {
+        var list = paket.Workbook.Worksheets.Add("Konverze");
+        list.Cells[1, 1].Value = "Návštěvy";
+        list.Cells[1, 2].Value = konverze.Navstevy;
+
+        list.Cells[2, 1].Value = "Registrace";
+        list.Cells[2, 2].Value = konverze.Registrace;
+
+        list.Cells[3, 1].Value = "Platby";
+        list.Cells[3, 2].Value = konverze.Platby;
+
+        list.Cells[5, 1].Value = "Míra návštěva → registrace";
+        list.Cells[5, 2].Value = konverze.MieraNavstevaRegistrace / 100d;
+
+        list.Cells[6, 1].Value = "Míra registrace → platba";
+        list.Cells[6, 2].Value = konverze.MieraRegistracePlatba / 100d;
+
+        list.Cells[7, 1].Value = "Celková míra";
+        list.Cells[7, 2].Value = konverze.CelkovaMiera / 100d;
+
+        list.Cells[5, 2, 7, 2].Style.Numberformat.Format = "0.00%";
+        list.Cells.AutoFitColumns();
+    }
+
+    private static void VytvoritListHeatmapa(ExcelPackage paket, HeatmapDto heatmapa)
+    {
+        var list = paket.Workbook.Worksheets.Add("Heatmapa");
+        list.Cells[1, 1].Value = "Den";
+        list.Cells[1, 2].Value = "Hodina";
+        list.Cells[1, 3].Value = "Průměrné zaplnění";
+
+        for (var i = 0; i < heatmapa.Bunky.Count; i++)
+        {
+            var bunka = heatmapa.Bunky[i];
+            var radek = i + 2;
+            list.Cells[radek, 1].Value = heatmapa.Dny[Math.Clamp(bunka.Den, 0, heatmapa.Dny.Count - 1)];
+            list.Cells[radek, 2].Value = $"{bunka.Hodina:00}:00";
+            list.Cells[radek, 3].Value = bunka.Hodnota / 100m;
+        }
+
+        list.Cells[2, 3, heatmapa.Bunky.Count + 1, 3].Style.Numberformat.Format = "0.00%";
+        list.Cells.AutoFitColumns();
+    }
+
+    public class FiltrAnalytiky
+    {
+        public DateTime? Od { get; set; }
+        public DateTime? Do { get; set; }
+        public List<int> Normy { get; set; } = new();
+        public List<int> Mesta { get; set; } = new();
+
+        public AnalyticsFilter ToFilter()
+        {
+            var dnes = DateOnly.FromDateTime(DateTime.UtcNow);
+            var od = Od.HasValue ? DateOnly.FromDateTime(Od.Value.ToUniversalTime()) : dnes.AddDays(-29);
+            var doDatum = Do.HasValue ? DateOnly.FromDateTime(Do.Value.ToUniversalTime()) : dnes;
+
+            if (od > doDatum)
+            {
+                (od, doDatum) = (doDatum, od);
+            }
+
+            var normy = Normy?.Distinct().ToList() ?? new List<int>();
+            var mesta = Mesta?.Distinct().ToList() ?? new List<int>();
+
+            return new AnalyticsFilter(od, doDatum, normy, mesta);
+        }
+    }
+}

--- a/Hubs/AnalyticsHub.cs
+++ b/Hubs/AnalyticsHub.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using SysJaky_N.Authorization;
+using SysJaky_N.Services.Analytics;
+using System.Collections.Generic;
+
+namespace SysJaky_N.Hubs;
+
+[Authorize(Policy = AuthorizationPolicies.AdminDashboardAccess)]
+public class AnalyticsHub : Hub
+{
+    private readonly DashboardAnalyticsService _analytics;
+
+    public AnalyticsHub(DashboardAnalyticsService analytics)
+    {
+        _analytics = analytics;
+    }
+
+    public async Task<RealtimeStatsDto> ZiskejOkamziteStatistiky(FiltrHubu? filtr, CancellationToken cancellationToken)
+    {
+        var filter = filtr?.ToFilter() ?? FiltrHubu.Vychozi();
+        return await _analytics.GetRealtimeStatsAsync(filter, cancellationToken);
+    }
+
+    public class FiltrHubu
+    {
+        public DateTime? Od { get; set; }
+        public DateTime? Do { get; set; }
+        public List<int> Normy { get; set; } = new();
+        public List<int> Mesta { get; set; } = new();
+
+        public AnalyticsFilter ToFilter()
+        {
+            var dnes = DateOnly.FromDateTime(DateTime.UtcNow);
+            var od = Od.HasValue ? DateOnly.FromDateTime(Od.Value.ToUniversalTime()) : dnes.AddDays(-29);
+            var doDatum = Do.HasValue ? DateOnly.FromDateTime(Do.Value.ToUniversalTime()) : dnes;
+
+            if (od > doDatum)
+            {
+                (od, doDatum) = (doDatum, od);
+            }
+
+            return new AnalyticsFilter(
+                od,
+                doDatum,
+                Normy?.Distinct().ToList() ?? new List<int>(),
+                Mesta?.Distinct().ToList() ?? new List<int>());
+        }
+
+        public static AnalyticsFilter Vychozi()
+        {
+            var dnes = DateOnly.FromDateTime(DateTime.UtcNow);
+            return new AnalyticsFilter(dnes.AddDays(-29), dnes, new List<int>(), new List<int>());
+        }
+    }
+}

--- a/Middleware/ContentSecurityPolicyMiddleware.cs
+++ b/Middleware/ContentSecurityPolicyMiddleware.cs
@@ -27,7 +27,7 @@ public class ContentSecurityPolicyMiddleware
 
         return
             "default-src 'self'; " +
-            "script-src 'self' 'unsafe-inline'; " +
+            "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; " +
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; " +
             "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net data:; " +
             "img-src 'self' data:; " +

--- a/Pages/Admin/Dashboard/Index.cshtml
+++ b/Pages/Admin/Dashboard/Index.cshtml
@@ -1,164 +1,239 @@
 @page
 @model SysJaky_N.Pages.Admin.Dashboard.IndexModel
+@using System.Text.Json
 @{
-    ViewData["Title"] = "Přehled";
+    ViewData["Title"] = "Analytický přehled";
+
+    var konfigurace = new
+    {
+        vychoziOd = Model.VychoziOd.ToString("yyyy-MM-dd"),
+        vychoziDo = Model.VychoziDo.ToString("yyyy-MM-dd"),
+        normy = Model.VolbyNorem.Select(v => new { id = v.Id, nazev = v.Nazev }),
+        mesta = Model.VolbyMest.Select(v => new { id = v.Id, nazev = v.Nazev }),
+        endpointy = new
+        {
+            prehled = Url.Content("~/api/admin/analytics/overview"),
+            realtime = Url.Content("~/api/admin/analytics/realtime"),
+            export = Url.Content("~/api/admin/analytics/export")
+        },
+        hub = Url.Content("~/hubs/analytics"),
+        intervalAktualizace = 15000
+    };
+
+    var konfiguraceJson = JsonSerializer.Serialize(konfigurace);
 }
 
-<h1>Přehled</h1>
+<div class="container-fluid">
+    <div class="d-flex flex-wrap align-items-center justify-content-between mb-4 gap-3">
+        <div>
+            <h1 class="h3 mb-1">Analytický přehled kurzů</h1>
+            <p class="text-muted mb-0">Komplexní statistiky pro rychlé řízení nabídky a výkonu kurzů.</p>
+        </div>
+        <button type="button" class="btn btn-success" id="export-do-excelu">
+            <i class="bi bi-file-earmark-spreadsheet"></i>
+            Export do Excelu
+        </button>
+    </div>
 
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">Počet objednávek</h5>
-                <p class="card-text display-6">@Model.OrderCount</p>
-            </div>
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-white">
+            <h2 class="h5 mb-0">Filtrace dat</h2>
+        </div>
+        <div class="card-body">
+            <form id="formular-filtru" class="row gy-3 gx-3 align-items-end">
+                <div class="col-12 col-md-3">
+                    <label for="filter-od" class="form-label">Od</label>
+                    <input type="date" class="form-control" id="filter-od" name="od" required />
+                </div>
+                <div class="col-12 col-md-3">
+                    <label for="filter-do" class="form-label">Do</label>
+                    <input type="date" class="form-control" id="filter-do" name="do" required />
+                </div>
+                <div class="col-12 col-md-3">
+                    <label for="filter-normy" class="form-label">Norma</label>
+                    <select class="form-select" id="filter-normy" name="normy" multiple size="4"></select>
+                    <div class="form-text">Podržením CTRL vyberete více norem.</div>
+                </div>
+                <div class="col-12 col-md-3">
+                    <label for="filter-mesta" class="form-label">Město</label>
+                    <select class="form-select" id="filter-mesta" name="mesta" multiple size="4"></select>
+                </div>
+                <div class="col-12 d-flex justify-content-end gap-2">
+                    <button type="reset" class="btn btn-outline-secondary" id="vynulovat-filtry">Vymazat</button>
+                    <button type="submit" class="btn btn-primary" id="aplikovat-filtry">Použít</button>
+                </div>
+            </form>
         </div>
     </div>
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">Celkové tržby</h5>
-                <p class="card-text display-6">@Model.TotalRevenue.ToString("C")</p>
+
+    <div class="row g-3 mb-4" id="souhrn-panel">
+        <div class="col-12 col-lg-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <p class="text-muted text-uppercase fw-semibold mb-1">Celkové tržby</p>
+                    <p class="display-6 mb-0" data-souhrn="trzby">—</p>
+                </div>
             </div>
         </div>
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-md-6">
-        <h3>Nejprodávanější kurzy</h3>
-        <canvas id="topCoursesChart"></canvas>
-    </div>
-    <div class="col-md-6">
-        <h3>Denní statistiky prodeje</h3>
-        <canvas id="revenueChart"></canvas>
-    </div>
-</div>
-
-<div class="row mt-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-body">
-                <h3 class="card-title">Nástroje</h3>
-                <div class="d-flex flex-wrap gap-2">
-                    <a class="btn btn-outline-primary" asp-page="/Instructor/Attendance">
-                        <i class="bi bi-qr-code-scan"></i> Docházka (QR)
-                    </a>
+        <div class="col-12 col-lg-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <p class="text-muted text-uppercase fw-semibold mb-1">Zaplacené objednávky</p>
+                    <p class="display-6 mb-0" data-souhrn="objednavky">—</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <p class="text-muted text-uppercase fw-semibold mb-1">Průměrná objednávka</p>
+                    <p class="display-6 mb-0" data-souhrn="prumer">—</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-3">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <p class="text-muted text-uppercase fw-semibold mb-1">Unikátní zákazníci</p>
+                    <p class="display-6 mb-0" data-souhrn="zakaznici">—</p>
                 </div>
             </div>
         </div>
     </div>
+
+    <div class="row g-4">
+        <div class="col-12 col-xl-8">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                    <h2 class="h5 mb-0">Vývoj tržeb a objednávek</h2>
+                    <span class="badge text-bg-light" data-rozsah></span>
+                </div>
+                <div class="card-body">
+                    <canvas id="graf-prodeju" aria-label="Graf vývoje tržeb" role="img"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white">
+                    <h2 class="h5 mb-0">Aktuální aktivita</h2>
+                </div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-7">Online účastníci</dt>
+                        <dd class="col-5 text-end fs-4" data-realtime="online">—</dd>
+                        <dt class="col-7">Rozpracované košíky</dt>
+                        <dd class="col-5 text-end fs-4" data-realtime="kosiky">—</dd>
+                        <dt class="col-7">Potenciál v košících</dt>
+                        <dd class="col-5 text-end fs-6" data-realtime="hodnota">—</dd>
+                    </dl>
+                    <p class="text-muted small mt-3 mb-0">Hodnoty se automaticky obnovují každých 15 sekund.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4 mt-1">
+        <div class="col-12 col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white">
+                    <h2 class="h5 mb-0">Top kurzy podle tržeb</h2>
+                </div>
+                <div class="card-body">
+                    <canvas id="graf-top-kurzy" aria-label="Žebříček kurzů" role="img"></canvas>
+                    <div class="table-responsive mt-4">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Název</th>
+                                    <th class="text-end">Tržby</th>
+                                    <th class="text-end">Prodáno</th>
+                                </tr>
+                            </thead>
+                            <tbody id="top-kurzy-tabulka">
+                                <tr>
+                                    <td colspan="3" class="text-center text-muted">Načítání…</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-xl-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white">
+                    <h2 class="h5 mb-0">Konverzní trychtýř</h2>
+                </div>
+                <div class="card-body">
+                    <canvas id="graf-konverzi" aria-label="Konverzní trychtýř" role="img"></canvas>
+                    <ul class="list-unstyled mt-3 mb-0" id="konverzni-souhrn">
+                        <li class="text-muted">Načítání…</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mt-4">
+        <div class="card-header bg-white d-flex flex-wrap align-items-center justify-content-between gap-2">
+            <h2 class="h5 mb-0">Heatmapa oblíbenosti termínů</h2>
+            <span class="text-muted small">Průměrné zaplnění v % dle dne a hodiny</span>
+        </div>
+        <div class="card-body">
+            <div id="heatmapa" class="heatmapa"></div>
+            <p class="text-muted small mb-0" id="heatmapa-popisek">Vybírané období zatím neobsahuje žádná data.</p>
+        </div>
+    </div>
 </div>
 
+<style>
+    #heatmapa {
+        display: grid;
+        gap: 4px;
+        overflow-x: auto;
+    }
+
+    #heatmapa .heatmapa-legend {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        align-items: center;
+        margin-top: 12px;
+    }
+
+    .heatmapa-bunka {
+        min-width: 48px;
+        min-height: 36px;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #212529;
+    }
+
+    .heatmapa-den {
+        writing-mode: vertical-rl;
+        transform: rotate(180deg);
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #6c757d;
+    }
+
+    .heatmapa-hodina {
+        font-size: 0.8rem;
+        color: #6c757d;
+        text-align: center;
+    }
+</style>
+
 @section Scripts {
-    <script src="~/lib/chart.js/chart.js" asp-append-version="true"></script>
     <script>
-        const topCourseLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TopCourseLabels));
-        const topCourseData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TopCourseValues));
-
-        const topCoursesCanvas = document.getElementById('topCoursesChart');
-        if (topCoursesCanvas) {
-            new Chart(topCoursesCanvas, {
-                type: 'bar',
-                data: {
-                    labels: topCourseLabels,
-                    datasets: [{
-                        label: 'Počet prodaných kusů',
-                        data: topCourseData,
-                        backgroundColor: 'rgba(54, 162, 235, 0.5)'
-                    }]
-                }
-            });
-        }
-
-        const revenueLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueLabels));
-        const revenueData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueValues));
-        const orderCounts = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.OrderCounts));
-        const averageOrderValues = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.AverageOrderValues));
-
-        const revenueCanvas = document.getElementById('revenueChart');
-        if (revenueCanvas) {
-            new Chart(revenueCanvas, {
-                type: 'bar',
-                data: {
-                    labels: revenueLabels,
-                    datasets: [
-                        {
-                            type: 'bar',
-                            label: 'Počet objednávek',
-                            data: orderCounts,
-                            backgroundColor: 'rgba(54, 162, 235, 0.5)',
-                            borderColor: 'rgba(54, 162, 235, 1)',
-                            borderWidth: 1,
-                            yAxisID: 'yOrders'
-                        },
-                        {
-                            type: 'line',
-                            label: 'Tržby',
-                            data: revenueData,
-                            borderColor: 'rgba(75, 192, 192, 1)',
-                            backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                            fill: true,
-                            tension: 0.3,
-                            yAxisID: 'yRevenue'
-                        },
-                        {
-                            type: 'line',
-                            label: 'Průměrná hodnota objednávky',
-                            data: averageOrderValues,
-                            borderColor: 'rgba(255, 159, 64, 1)',
-                            backgroundColor: 'rgba(255, 159, 64, 0.2)',
-                            tension: 0.3,
-                            borderDash: [5, 5],
-                            yAxisID: 'yAverage'
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    interaction: {
-                        mode: 'index',
-                        intersect: false
-                    },
-                    stacked: false,
-                    scales: {
-                        yOrders: {
-                            type: 'linear',
-                            position: 'left',
-                            beginAtZero: true,
-                            title: {
-                                display: true,
-                                text: 'Objednávky'
-                            }
-                        },
-                        yRevenue: {
-                            type: 'linear',
-                            position: 'right',
-                            beginAtZero: true,
-                            grid: {
-                                drawOnChartArea: false
-                            },
-                            title: {
-                                display: true,
-                                text: 'Tržby'
-                            }
-                        },
-                        yAverage: {
-                            type: 'linear',
-                            position: 'right',
-                            beginAtZero: true,
-                            grid: {
-                                drawOnChartArea: false
-                            },
-                            title: {
-                                display: true,
-                                text: 'Průměrná hodnota'
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        window.dashboardKonfigurace = @Html.Raw(konfiguraceJson);
     </script>
+    <script src="~/lib/chart.js/chart.js" asp-append-version="true"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/microsoft-signalr/7.0.5/signalr.min.js" integrity="sha512-PgpTjWyd4InENcy+XUG6uHgnIY7qDpiRnbV0wOYAV/QXpVZl8vGeOawx2UY8ailqXFz3vGN9VOGBev5nYeD1aw==" crossorigin="anonymous"></script>
+    <script src="~/js/admin/dashboard.js" asp-append-version="true"></script>
 }

--- a/Program.cs
+++ b/Program.cs
@@ -6,6 +6,8 @@ using SysJaky_N.Data;
 using SysJaky_N.Models;
 using SysJaky_N.Services;
 using SysJaky_N.Services.Calendar;
+using SysJaky_N.Services.Analytics;
+using SysJaky_N.Hubs;
 using System.Linq;
 using DinkToPdf;
 using DinkToPdf.Contracts;
@@ -166,6 +168,7 @@ try
                 factory.Create(typeof(SysJaky_N.Resources.SharedResources));
         });
     builder.Services.AddControllers();
+    builder.Services.AddSignalR();
     builder.Services.Configure<RequestLocalizationOptions>(options =>
     {
         var supportedCultures = new[] { "cs", "en" };
@@ -225,6 +228,7 @@ try
     builder.Services.AddSingleton<IIcsCalendarBuilderFactory, IcsCalendarBuilderFactory>();
     builder.Services.Configure<AltchaOptions>(builder.Configuration.GetSection("Altcha"));
     builder.Services.AddSingleton<IAltchaService, AltchaService>();
+    builder.Services.AddSingleton<DashboardAnalyticsService>();
 
     builder.Services.Configure<ForwardedHeadersOptions>(opts =>
     {
@@ -360,6 +364,7 @@ try
         name: "default",
         pattern: "{controller}/{action=Index}/{id?}");
     app.MapControllers();
+    app.MapHub<AnalyticsHub>("/hubs/analytics");
     // Přesměrování na jednotné místo „Můj účet“
     app.MapGet("/Account/Dashboard", () => Results.Redirect("/Account/Manage", true));
     app.MapGet("/Orders", () => Results.Redirect("/Account/Manage#orders", true));

--- a/Services/Analytics/DashboardAnalyticsService.cs
+++ b/Services/Analytics/DashboardAnalyticsService.cs
@@ -1,0 +1,425 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Services.Analytics;
+
+public class DashboardAnalyticsService
+{
+    internal static readonly string[] DnyVTydnu =
+    {
+        "Pondělí",
+        "Úterý",
+        "Středa",
+        "Čtvrtek",
+        "Pátek",
+        "Sobota",
+        "Neděle"
+    };
+
+    private readonly IDbContextFactory<ApplicationDbContext> _contextFactory;
+
+    public DashboardAnalyticsService(IDbContextFactory<ApplicationDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<DashboardOverviewDto> GetOverviewAsync(AnalyticsFilter filter, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var (odUtc, doUtcExclusive) = filter.ToUtcRange();
+        var kurzovyFiltr = await ResolveCourseFilterAsync(context, filter, cancellationToken);
+
+        if (kurzovyFiltr?.Count == 0)
+        {
+            return DashboardOverviewDto.Empty(filter);
+        }
+
+        var zaplaceneObjednavky = context.Orders
+            .AsNoTracking()
+            .Where(o => o.Status == OrderStatus.Paid && o.CreatedAt >= odUtc && o.CreatedAt < doUtcExclusive);
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            zaplaceneObjednavky = zaplaceneObjednavky
+                .Where(o => o.Items.Any(i => kurzovyFiltr.Contains(i.CourseId)));
+        }
+
+        var denniStatistiky = await zaplaceneObjednavky
+            .GroupBy(o => o.CreatedAt.Date)
+            .Select(g => new
+            {
+                Datum = g.Key,
+                Trzby = g.Sum(o => o.Total),
+                Objednavky = g.Count(),
+                Prumer = g.Average(o => o.Total)
+            })
+            .ToListAsync(cancellationToken);
+
+        var statyPodleData = denniStatistiky.ToDictionary(
+            x => DateOnly.FromDateTime(x.Datum),
+            x => new Dennistat(x.Trzby, x.Objednavky, x.Prumer));
+
+        var popisky = new List<string>();
+        var trzby = new List<decimal>();
+        var objednavky = new List<int>();
+        var prumerneObjednavky = new List<decimal>();
+
+        for (var datum = filter.Od; datum <= filter.Do; datum = datum.AddDays(1))
+        {
+            popisky.Add(datum.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            if (statyPodleData.TryGetValue(datum, out var stat))
+            {
+                trzby.Add(Math.Round(stat.Trzby, 2));
+                objednavky.Add(stat.Objednavky);
+                prumerneObjednavky.Add(Math.Round(stat.PrumernaObjednavka, 2));
+            }
+            else
+            {
+                trzby.Add(0m);
+                objednavky.Add(0);
+                prumerneObjednavky.Add(0m);
+            }
+        }
+
+        var topKurzy = await context.OrderItems
+            .AsNoTracking()
+            .Where(oi => oi.Order != null && oi.Order.Status == OrderStatus.Paid)
+            .Where(oi => oi.Order!.CreatedAt >= odUtc && oi.Order.CreatedAt < doUtcExclusive)
+            .Where(oi => kurzovyFiltr == null || kurzovyFiltr.Contains(oi.CourseId))
+            .GroupBy(oi => new { oi.CourseId, Nazev = oi.Course != null ? oi.Course.Title : null })
+            .Select(g => new TopCourseDto(
+                g.Key.CourseId,
+                g.Key.Nazev ?? $"Kurz #{g.Key.CourseId}",
+                Math.Round(g.Sum(i => i.Total), 2),
+                g.Sum(i => i.Quantity)))
+            .OrderByDescending(k => k.Trzba)
+            .ThenBy(k => k.Nazev)
+            .Take(10)
+            .ToListAsync(cancellationToken);
+
+        var navstevy = await VypocitatNavstevyAsync(context, odUtc, doUtcExclusive, kurzovyFiltr, cancellationToken);
+
+        var registrace = context.WaitlistEntries
+            .AsNoTracking()
+            .Where(w => w.CreatedAtUtc >= odUtc && w.CreatedAtUtc < doUtcExclusive);
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            registrace = registrace.Where(w => w.CourseTerm != null && kurzovyFiltr.Contains(w.CourseTerm.CourseId));
+        }
+
+        var pocetRegistraci = await registrace.CountAsync(cancellationToken);
+        var pocetPlateb = await zaplaceneObjednavky.CountAsync(cancellationToken);
+
+        var konverze = new ConversionFunnelDto(
+            navstevy,
+            pocetRegistraci,
+            pocetPlateb,
+            navstevy == 0 ? 0 : Math.Round((double)pocetRegistraci / navstevy * 100d, 2),
+            pocetRegistraci == 0 ? 0 : Math.Round((double)pocetPlateb / pocetRegistraci * 100d, 2),
+            navstevy == 0 ? 0 : Math.Round((double)pocetPlateb / navstevy * 100d, 2));
+
+        var heatmapa = await VytvoritHeatmapuAsync(context, filter, kurzovyFiltr, odUtc, doUtcExclusive, cancellationToken);
+
+        var souhrn = await VytvoritSouhrnAsync(zaplaceneObjednavky, trzby, objednavky, cancellationToken);
+
+        return new DashboardOverviewDto(popisky, trzby, objednavky, prumerneObjednavky, topKurzy, konverze, heatmapa, souhrn);
+    }
+
+    public async Task<RealtimeStatsDto> GetRealtimeStatsAsync(AnalyticsFilter filter, CancellationToken cancellationToken = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+        var kurzovyFiltr = await ResolveCourseFilterAsync(context, filter, cancellationToken);
+
+        if (kurzovyFiltr?.Count == 0)
+        {
+            return new RealtimeStatsDto(0, 0, 0m);
+        }
+
+        var hraniceOnline = DateTime.UtcNow.AddMinutes(-10);
+        var dotazProgres = context.LessonProgresses
+            .AsNoTracking()
+            .Where(lp => lp.LastSeenUtc >= hraniceOnline);
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            dotazProgres = dotazProgres.Where(lp => kurzovyFiltr.Contains(lp.Lesson.CourseId));
+        }
+
+        var onlineUzivatele = await dotazProgres
+            .Select(lp => lp.UserId)
+            .Distinct()
+            .CountAsync(cancellationToken);
+
+        var hraniceKosiku = DateTime.UtcNow.AddHours(-2);
+        var cekajiciObjednavky = context.Orders
+            .AsNoTracking()
+            .Where(o => o.Status == OrderStatus.Pending && o.CreatedAt >= hraniceKosiku);
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            cekajiciObjednavky = cekajiciObjednavky
+                .Where(o => o.Items.Any(i => kurzovyFiltr.Contains(i.CourseId)));
+        }
+
+        var pocetKosiku = await cekajiciObjednavky.CountAsync(cancellationToken);
+        var hodnotaKosiku = await cekajiciObjednavky.SumAsync(o => (decimal?)o.Total, cancellationToken) ?? 0m;
+
+        return new RealtimeStatsDto(onlineUzivatele, pocetKosiku, Math.Round(hodnotaKosiku, 2));
+    }
+
+    private static async Task<List<int>?> ResolveCourseFilterAsync(ApplicationDbContext context, AnalyticsFilter filter, CancellationToken cancellationToken)
+    {
+        if (filter.Normy.Count == 0 && filter.Mesta.Count == 0)
+        {
+            return null;
+        }
+
+        var kurzy = context.Courses.AsNoTracking().AsQueryable();
+
+        if (filter.Normy.Count > 0)
+        {
+            kurzy = kurzy.Where(c => c.CourseTags.Any(ct => filter.Normy.Contains(ct.TagId)));
+        }
+
+        if (filter.Mesta.Count > 0)
+        {
+            kurzy = kurzy.Where(c => c.CourseTags.Any(ct => filter.Mesta.Contains(ct.TagId)));
+        }
+
+        var vysledek = await kurzy.Select(c => c.Id).Distinct().ToListAsync(cancellationToken);
+        return vysledek;
+    }
+
+    private static async Task<int> VypocitatNavstevyAsync(
+        ApplicationDbContext context,
+        DateTime odUtc,
+        DateTime doUtcExclusive,
+        IReadOnlyCollection<int>? kurzovyFiltr,
+        CancellationToken cancellationToken)
+    {
+        var logy = await context.LogEntries
+            .AsNoTracking()
+            .Where(l => l.Timestamp >= odUtc && l.Timestamp < doUtcExclusive)
+            .Where(l => l.Properties != null || l.Message != null)
+            .Select(l => new { l.Properties, l.Message })
+            .ToListAsync(cancellationToken);
+
+        if (logy.Count == 0)
+        {
+            return 0;
+        }
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            return logy.Count(zaznam => ObsahujeKurzovouStopu(zaznam.Properties, zaznam.Message, kurzovyFiltr));
+        }
+
+        return logy.Count(zaznam => ObsahujeKurzovouStopu(zaznam.Properties, zaznam.Message, null));
+    }
+
+    private static async Task<HeatmapDto> VytvoritHeatmapuAsync(
+        ApplicationDbContext context,
+        AnalyticsFilter filter,
+        IReadOnlyCollection<int>? kurzovyFiltr,
+        DateTime odUtc,
+        DateTime doUtcExclusive,
+        CancellationToken cancellationToken)
+    {
+        var terminy = context.CourseTerms
+            .AsNoTracking()
+            .Where(t => t.StartUtc >= odUtc && t.StartUtc < doUtcExclusive);
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            terminy = terminy.Where(t => kurzovyFiltr.Contains(t.CourseId));
+        }
+
+        var zaznamy = await terminy
+            .Select(t => new { t.StartUtc, t.Capacity, t.SeatsTaken })
+            .ToListAsync(cancellationToken);
+
+        if (zaznamy.Count == 0)
+        {
+            return HeatmapDto.Empty;
+        }
+
+        var agregace = new Dictionary<(int Den, int Hodina), (decimal Soucet, int Pocet)>();
+        var hodiny = new HashSet<int>();
+
+        foreach (var z in zaznamy)
+        {
+            var den = PrevedDen(z.StartUtc.DayOfWeek);
+            var hodina = z.StartUtc.Hour;
+            var kapacita = Math.Max(z.Capacity, 0);
+            var obsazeni = kapacita == 0 ? 0m : Math.Clamp((decimal)z.SeatsTaken / kapacita * 100m, 0m, 100m);
+
+            hodiny.Add(hodina);
+
+            var klic = (den, hodina);
+            if (agregace.TryGetValue(klic, out var akumulace))
+            {
+                agregace[klic] = (akumulace.Soucet + obsazeni, akumulace.Pocet + 1);
+            }
+            else
+            {
+                agregace[klic] = (obsazeni, 1);
+            }
+        }
+
+        var bunky = new List<HeatmapCellDto>();
+        decimal maximum = 0m;
+
+        foreach (var (klic, hodnota) in agregace)
+        {
+            var prumer = hodnota.Pocet == 0 ? 0m : Math.Round(hodnota.Soucet / hodnota.Pocet, 2);
+            maximum = Math.Max(maximum, prumer);
+            bunky.Add(new HeatmapCellDto(klic.Den, klic.Hodina, prumer));
+        }
+
+        bunky.Sort((a, b) =>
+        {
+            var denPorovnani = a.Den.CompareTo(b.Den);
+            return denPorovnani != 0 ? denPorovnani : a.Hodina.CompareTo(b.Hodina);
+        });
+
+        var hodinySeznam = hodiny.OrderBy(h => h).ToArray();
+        return new HeatmapDto(DnyVTydnu, hodinySeznam, bunky, maximum);
+    }
+
+    private static async Task<SummaryDto> VytvoritSouhrnAsync(
+        IQueryable<Order> zaplaceneObjednavky,
+        IReadOnlyCollection<decimal> trzby,
+        IReadOnlyCollection<int> objednavky,
+        CancellationToken cancellationToken)
+    {
+        var celkoveTrzby = Math.Round(trzby.Sum(), 2);
+        var celkemObjednavek = objednavky.Sum();
+        var prumernaObjednavka = celkemObjednavek == 0 ? 0m : Math.Round(celkoveTrzby / celkemObjednavek, 2);
+
+        var unikatiZakaznici = await zaplaceneObjednavky
+            .Where(o => o.UserId != null)
+            .Select(o => o.UserId!)
+            .Distinct()
+            .CountAsync(cancellationToken);
+
+        return new SummaryDto(celkoveTrzby, celkemObjednavek, prumernaObjednavka, unikatiZakaznici);
+    }
+
+    private static bool ObsahujeKurzovouStopu(string? vlastnosti, string? zprava, IReadOnlyCollection<int>? kurzovyFiltr)
+    {
+        if (string.IsNullOrWhiteSpace(vlastnosti) && string.IsNullOrWhiteSpace(zprava))
+        {
+            return false;
+        }
+
+        if (kurzovyFiltr is { Count: > 0 })
+        {
+            foreach (var id in kurzovyFiltr)
+            {
+                var hledany = $"/Courses/Details/{id}";
+                if ((vlastnosti?.Contains(hledany, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (zprava?.Contains(hledany, StringComparison.OrdinalIgnoreCase) ?? false))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return (vlastnosti?.Contains("/Courses", StringComparison.OrdinalIgnoreCase) ?? false)
+            || (zprava?.Contains("/Courses", StringComparison.OrdinalIgnoreCase) ?? false);
+    }
+
+    private static int PrevedDen(DayOfWeek dayOfWeek)
+    {
+        return dayOfWeek switch
+        {
+            DayOfWeek.Monday => 0,
+            DayOfWeek.Tuesday => 1,
+            DayOfWeek.Wednesday => 2,
+            DayOfWeek.Thursday => 3,
+            DayOfWeek.Friday => 4,
+            DayOfWeek.Saturday => 5,
+            _ => 6
+        };
+    }
+
+    private readonly record struct Dennistat(decimal Trzby, int Objednavky, decimal PrumernaObjednavka);
+}
+
+public sealed record AnalyticsFilter(DateOnly Od, DateOnly Do, IReadOnlyList<int> Normy, IReadOnlyList<int> Mesta)
+{
+    public (DateTime OdUtc, DateTime DoUtcExclusive) ToUtcRange()
+    {
+        var od = DateTime.SpecifyKind(Od.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
+        var doValue = DateTime.SpecifyKind(Do.AddDays(1).ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
+        return (od, doValue);
+    }
+}
+
+public sealed record DashboardOverviewDto(
+    IReadOnlyList<string> Labels,
+    IReadOnlyList<decimal> Revenue,
+    IReadOnlyList<int> Orders,
+    IReadOnlyList<decimal> AverageOrder,
+    IReadOnlyList<TopCourseDto> TopCourses,
+    ConversionFunnelDto Conversion,
+    HeatmapDto Heatmap,
+    SummaryDto Summary)
+{
+    public static DashboardOverviewDto Empty(AnalyticsFilter filter)
+    {
+        var popisky = new List<string>();
+        var trzby = new List<decimal>();
+        var objednavky = new List<int>();
+        var prumery = new List<decimal>();
+
+        for (var datum = filter.Od; datum <= filter.Do; datum = datum.AddDays(1))
+        {
+            popisky.Add(datum.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            trzby.Add(0m);
+            objednavky.Add(0);
+            prumery.Add(0m);
+        }
+
+        return new DashboardOverviewDto(
+            popisky,
+            trzby,
+            objednavky,
+            prumery,
+            Array.Empty<TopCourseDto>(),
+            new ConversionFunnelDto(0, 0, 0, 0, 0, 0),
+            HeatmapDto.Empty,
+            new SummaryDto(0m, 0, 0m, 0));
+    }
+}
+
+public sealed record TopCourseDto(int CourseId, string Nazev, decimal Trzba, int Pocet);
+
+public sealed record ConversionFunnelDto(
+    int Navstevy,
+    int Registrace,
+    int Platby,
+    double MieraNavstevaRegistrace,
+    double MieraRegistracePlatba,
+    double CelkovaMiera);
+
+public sealed record HeatmapDto(
+    IReadOnlyList<string> Dny,
+    IReadOnlyList<int> Hodiny,
+    IReadOnlyList<HeatmapCellDto> Bunky,
+    decimal Maximum)
+{
+    public static HeatmapDto Empty => new(DashboardAnalyticsService.DnyVTydnu, Array.Empty<int>(), Array.Empty<HeatmapCellDto>(), 0m);
+}
+
+public sealed record HeatmapCellDto(int Den, int Hodina, decimal Hodnota);
+
+public sealed record SummaryDto(decimal CelkoveTrzby, int PocetObjednavek, decimal PrumernaObjednavka, int UnikatniZakaznici);
+
+public sealed record RealtimeStatsDto(int OnlineUzivatele, int AktivniKosiky, decimal HodnotaKosiku);

--- a/wwwroot/js/admin/dashboard.js
+++ b/wwwroot/js/admin/dashboard.js
@@ -1,0 +1,552 @@
+(function () {
+    const konfigurace = window.dashboardKonfigurace ?? {};
+    const form = document.getElementById('formular-filtru');
+    const inputOd = document.getElementById('filter-od');
+    const inputDo = document.getElementById('filter-do');
+    const selectNormy = document.getElementById('filter-normy');
+    const selectMesta = document.getElementById('filter-mesta');
+    const tlacitkoReset = document.getElementById('vynulovat-filtry');
+    const souhrnPrvky = {
+        trzby: document.querySelector('[data-souhrn="trzby"]'),
+        objednavky: document.querySelector('[data-souhrn="objednavky"]'),
+        prumer: document.querySelector('[data-souhrn="prumer"]'),
+        zakaznici: document.querySelector('[data-souhrn="zakaznici"]'),
+        rozsah: document.querySelector('[data-rozsah]')
+    };
+    const realtimePrvky = {
+        online: document.querySelector('[data-realtime="online"]'),
+        kosiky: document.querySelector('[data-realtime="kosiky"]'),
+        hodnota: document.querySelector('[data-realtime="hodnota"]')
+    };
+    const tabulkaTopKurzy = document.getElementById('top-kurzy-tabulka');
+    const seznamKonverzi = document.getElementById('konverzni-souhrn');
+    const heatmapaWrapper = document.getElementById('heatmapa');
+    const heatmapaPopisek = document.getElementById('heatmapa-popisek');
+    const exportTlacitko = document.getElementById('export-do-excelu');
+
+    const mena = new Intl.NumberFormat('cs-CZ', { style: 'currency', currency: 'CZK' });
+    const celeCislo = new Intl.NumberFormat('cs-CZ');
+    const procenta = new Intl.NumberFormat('cs-CZ', { style: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 });
+
+    let grafProdeju;
+    let grafTopKurzu;
+    let grafKonverzi;
+    let hubConnection;
+    let realtimeIntervalId;
+
+    inicializovatFormular();
+    pripojitUdalosti();
+    nactiPrehled();
+    inicializovatRealtime();
+
+    function inicializovatFormular() {
+        if (inputOd && konfigurace.vychoziOd) {
+            inputOd.value = konfigurace.vychoziOd;
+        }
+        if (inputDo && konfigurace.vychoziDo) {
+            inputDo.value = konfigurace.vychoziDo;
+        }
+
+        naplnitSelect(selectNormy, konfigurace.normy ?? []);
+        naplnitSelect(selectMesta, konfigurace.mesta ?? []);
+    }
+
+    function pripojitUdalosti() {
+        if (form) {
+            form.addEventListener('submit', function (event) {
+                event.preventDefault();
+                nactiPrehled();
+            });
+        }
+
+        if (tlacitkoReset) {
+            tlacitkoReset.addEventListener('click', function () {
+                if (inputOd && konfigurace.vychoziOd) {
+                    inputOd.value = konfigurace.vychoziOd;
+                }
+                if (inputDo && konfigurace.vychoziDo) {
+                    inputDo.value = konfigurace.vychoziDo;
+                }
+                vynulovatVyber(selectNormy);
+                vynulovatVyber(selectMesta);
+            });
+        }
+
+        if (exportTlacitko) {
+            exportTlacitko.addEventListener('click', function () {
+                const url = vytvorUrl(konfigurace.endpointy?.export);
+                if (url) {
+                    window.location.href = url;
+                }
+            });
+        }
+    }
+
+    function naplnitSelect(select, volby) {
+        if (!select) {
+            return;
+        }
+
+        select.innerHTML = '';
+        volby.forEach(function (volba) {
+            const option = document.createElement('option');
+            option.value = String(volba.id);
+            option.textContent = volba.nazev;
+            select.appendChild(option);
+        });
+    }
+
+    function vynulovatVyber(select) {
+        if (!select) {
+            return;
+        }
+        Array.from(select.options).forEach(function (opt) {
+            opt.selected = false;
+        });
+    }
+
+    async function nactiPrehled() {
+        const url = vytvorUrl(konfigurace.endpointy?.prehled);
+        if (!url) {
+            return;
+        }
+
+        try {
+            nastavStavNacitani(true);
+            const response = await fetch(url);
+            if (!response.ok) {
+                throw new Error('Nepodařilo se načíst data analytiky.');
+            }
+
+            const data = await response.json();
+            vykreslitSouhrn(data);
+            vykreslitGrafProdeju(data);
+            vykreslitTopKurzy(data);
+            vykreslitKonverze(data);
+            vykreslitHeatmapu(data);
+            obnovitRealtime();
+        } catch (error) {
+            console.error(error);
+            upozorneni('Nastala chyba při načítání dat. Zkuste to prosím znovu.');
+        } finally {
+            nastavStavNacitani(false);
+        }
+    }
+
+    function nastavStavNacitani(prubeh) {
+        if (prubeh) {
+            document.body.classList.add('dashboard-loading');
+        } else {
+            document.body.classList.remove('dashboard-loading');
+        }
+    }
+
+    function vykreslitSouhrn(data) {
+        if (!data || !data.summary) {
+            return;
+        }
+
+        const souhrn = data.summary;
+        if (souhrnPrvky.trzby) {
+            souhrnPrvky.trzby.textContent = mena.format(souhrn.celkoveTrzby ?? 0);
+        }
+        if (souhrnPrvky.objednavky) {
+            souhrnPrvky.objednavky.textContent = celeCislo.format(souhrn.pocetObjednavek ?? 0);
+        }
+        if (souhrnPrvky.prumer) {
+            souhrnPrvky.prumer.textContent = mena.format(souhrn.prumernaObjednavka ?? 0);
+        }
+        if (souhrnPrvky.zakaznici) {
+            souhrnPrvky.zakaznici.textContent = celeCislo.format(souhrn.unikatniZakaznici ?? 0);
+        }
+        if (souhrnPrvky.rozsah) {
+            const od = inputOd?.value ?? '';
+            const doDatum = inputDo?.value ?? '';
+            souhrnPrvky.rozsah.textContent = od && doDatum ? `${od} – ${doDatum}` : '';
+        }
+    }
+
+    function vykreslitGrafProdeju(data) {
+        const platnaData = Array.isArray(data?.labels) && Array.isArray(data?.revenue);
+        const platnaObjednavky = Array.isArray(data?.orders);
+        if (!platnaData || !platnaObjednavky) {
+            return;
+        }
+
+        const context = document.getElementById('graf-prodeju');
+        if (!context) {
+            return;
+        }
+
+        const datasetTrzby = {
+            type: 'line',
+            label: 'Tržby',
+            data: data.revenue,
+            borderColor: 'rgba(75, 192, 192, 1)',
+            backgroundColor: 'rgba(75, 192, 192, 0.25)',
+            tension: 0.25,
+            fill: true,
+            yAxisID: 'y1'
+        };
+
+        const datasetObjednavky = {
+            type: 'bar',
+            label: 'Objednávky',
+            data: data.orders,
+            backgroundColor: 'rgba(54, 162, 235, 0.6)',
+            borderColor: 'rgba(54, 162, 235, 1)',
+            yAxisID: 'y2'
+        };
+
+        const datasetPrumer = Array.isArray(data?.averageOrder)
+            ? {
+                type: 'line',
+                label: 'Průměrná objednávka',
+                data: data.averageOrder,
+                borderColor: 'rgba(255, 159, 64, 1)',
+                backgroundColor: 'rgba(255, 159, 64, 0.2)',
+                borderDash: [6, 4],
+                tension: 0.3,
+                yAxisID: 'y1'
+            }
+            : null;
+
+        const datasets = datasetPrumer ? [datasetObjednavky, datasetTrzby, datasetPrumer] : [datasetObjednavky, datasetTrzby];
+
+        if (grafProdeju) {
+            grafProdeju.data.labels = data.labels;
+            grafProdeju.data.datasets = datasets;
+            grafProdeju.update();
+            return;
+        }
+
+        grafProdeju = new Chart(context, {
+            data: {
+                labels: data.labels,
+                datasets
+            },
+            options: {
+                responsive: true,
+                interaction: { mode: 'index', intersect: false },
+                scales: {
+                    y1: {
+                        position: 'left',
+                        beginAtZero: true,
+                        ticks: {
+                            callback: hodnot => mena.format(hodnot ?? 0)
+                        }
+                    },
+                    y2: {
+                        position: 'right',
+                        beginAtZero: true,
+                        grid: { drawOnChartArea: false }
+                    }
+                },
+                plugins: {
+                    legend: { position: 'top' }
+                }
+            }
+        });
+    }
+
+    function vykreslitTopKurzy(data) {
+        const seznam = Array.isArray(data?.topCourses) ? data.topCourses : [];
+        const context = document.getElementById('graf-top-kurzy');
+
+        if (tabulkaTopKurzy) {
+            tabulkaTopKurzy.innerHTML = '';
+            if (seznam.length === 0) {
+                const radek = document.createElement('tr');
+                const bunka = document.createElement('td');
+                bunka.colSpan = 3;
+                bunka.className = 'text-center text-muted';
+                bunka.textContent = 'Žádná data pro daný filtr.';
+                radek.appendChild(bunka);
+                tabulkaTopKurzy.appendChild(radek);
+            } else {
+                seznam.forEach(function (polozka) {
+                    const radek = document.createElement('tr');
+                    const nazev = document.createElement('td');
+                    nazev.textContent = polozka.nazev;
+                    const trzba = document.createElement('td');
+                    trzba.className = 'text-end';
+                    trzba.textContent = mena.format(polozka.trzba ?? 0);
+                    const pocet = document.createElement('td');
+                    pocet.className = 'text-end';
+                    pocet.textContent = celeCislo.format(polozka.pocet ?? 0);
+                    radek.appendChild(nazev);
+                    radek.appendChild(trzba);
+                    radek.appendChild(pocet);
+                    tabulkaTopKurzy.appendChild(radek);
+                });
+            }
+        }
+
+        if (!context) {
+            return;
+        }
+
+        const labels = seznam.map(item => item.nazev);
+        const hodnoty = seznam.map(item => item.trzba ?? 0);
+
+        if (grafTopKurzu) {
+            grafTopKurzu.data.labels = labels;
+            grafTopKurzu.data.datasets[0].data = hodnoty;
+            grafTopKurzu.update();
+            return;
+        }
+
+        grafTopKurzu = new Chart(context, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Tržby',
+                    data: hodnoty,
+                    backgroundColor: 'rgba(99, 102, 241, 0.6)',
+                    borderRadius: 6
+                }]
+            },
+            options: {
+                indexAxis: 'y',
+                plugins: { legend: { display: false } },
+                responsive: true,
+                scales: {
+                    x: {
+                        ticks: {
+                            callback: hodnot => mena.format(hodnot ?? 0)
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    function vykreslitKonverze(data) {
+        const konverze = data?.conversion;
+        const context = document.getElementById('graf-konverzi');
+        if (!konverze || !context) {
+            return;
+        }
+
+        const hodnoty = [konverze.navstevy ?? 0, konverze.registrace ?? 0, konverze.platby ?? 0];
+        const popisky = ['Návštěvy', 'Registrace', 'Platby'];
+
+        if (grafKonverzi) {
+            grafKonverzi.data.labels = popisky;
+            grafKonverzi.data.datasets[0].data = hodnoty;
+            grafKonverzi.update();
+        } else {
+            grafKonverzi = new Chart(context, {
+                type: 'bar',
+                data: {
+                    labels: popisky,
+                    datasets: [{
+                        data: hodnoty,
+                        backgroundColor: ['#38bdf8', '#fb923c', '#22c55e'],
+                        borderRadius: 8
+                    }]
+                },
+                options: {
+                    plugins: { legend: { display: false } },
+                    responsive: true,
+                    scales: {
+                        y: { beginAtZero: true }
+                    }
+                }
+            });
+        }
+
+        if (seznamKonverzi) {
+            seznamKonverzi.innerHTML = '';
+            const polozky = [
+                `Míra návštěva → registrace: ${procenta.format((konverze.mieraNavstevaRegistrace ?? 0) / 100)}`,
+                `Míra registrace → platba: ${procenta.format((konverze.mieraRegistracePlatba ?? 0) / 100)}`,
+                `Celková míra dokončení: ${procenta.format((konverze.celkovaMiera ?? 0) / 100)}`
+            ];
+
+            polozky.forEach(function (text) {
+                const li = document.createElement('li');
+                li.textContent = text;
+                seznamKonverzi.appendChild(li);
+            });
+        }
+    }
+
+    function vykreslitHeatmapu(data) {
+        const heatmapa = data?.heatmap;
+        if (!heatmapaWrapper || !heatmapa) {
+            return;
+        }
+
+        heatmapaWrapper.innerHTML = '';
+        const dny = Array.isArray(heatmapa.dny) ? heatmapa.dny : [];
+        const hodiny = Array.isArray(heatmapa.hodiny) ? heatmapa.hodiny : [];
+        const bunky = Array.isArray(heatmapa.bunky) ? heatmapa.bunky : [];
+        const maximum = typeof heatmapa.maximum === 'number' ? heatmapa.maximum : 0;
+
+        if (bunky.length === 0 || dny.length === 0 || hodiny.length === 0) {
+            heatmapaPopisek?.classList.remove('d-none');
+            return;
+        }
+
+        heatmapaPopisek?.classList.add('d-none');
+
+        heatmapaWrapper.style.gridTemplateColumns = `repeat(${hodiny.length + 1}, minmax(60px, auto))`;
+
+        const hlavicka = document.createElement('div');
+        hlavicka.className = 'heatmapa-hodina';
+        heatmapaWrapper.appendChild(hlavicka);
+
+        hodiny.forEach(function (hodina) {
+            const bunka = document.createElement('div');
+            bunka.className = 'heatmapa-hodina fw-semibold';
+            bunka.textContent = `${String(hodina).padStart(2, '0')}:00`;
+            heatmapaWrapper.appendChild(bunka);
+        });
+
+        dny.forEach(function (den, indexDne) {
+            const popisekDne = document.createElement('div');
+            popisekDne.className = 'heatmapa-den';
+            popisekDne.textContent = den;
+            heatmapaWrapper.appendChild(popisekDne);
+
+            hodiny.forEach(function (hodina) {
+                const bunka = document.createElement('div');
+                bunka.className = 'heatmapa-bunka';
+                const nalezena = bunky.find(cell => cell.den === indexDne && cell.hodina === hodina);
+                const hodnota = nalezena ? nalezena.hodnota : 0;
+                bunka.textContent = `${Math.round(hodnota)}%`;
+                bunka.style.background = vypocitatBarvu(hodnota, maximum);
+                heatmapaWrapper.appendChild(bunka);
+            });
+        });
+    }
+
+    function vypocitatBarvu(hodnota, maximum) {
+        if (!maximum || maximum <= 0) {
+            return 'linear-gradient(135deg, #f8f9fa, #e9ecef)';
+        }
+
+        const pomer = Math.min(hodnota / maximum, 1);
+        const sytost = 50 + pomer * 40;
+        const svetlost = 92 - pomer * 40;
+        return `hsl(${120 - pomer * 40}, ${sytost}%, ${svetlost}%)`;
+    }
+
+    function vytvorUrl(zaklad) {
+        if (!zaklad) {
+            return null;
+        }
+        const url = new URL(zaklad, window.location.origin);
+        const params = url.searchParams;
+        const vybrany = ziskejFiltr();
+
+        if (vybrany.od) {
+            params.set('od', vybrany.od);
+        }
+        if (vybrany.do) {
+            params.set('do', vybrany.do);
+        }
+
+        vybrany.normy.forEach(id => params.append('normy', String(id)));
+        vybrany.mesta.forEach(id => params.append('mesta', String(id)));
+
+        return url.toString();
+    }
+
+    function ziskejFiltr() {
+        const vybraneNormy = selectNormy ? Array.from(selectNormy.selectedOptions).map(opt => Number(opt.value)) : [];
+        const vybranaMesta = selectMesta ? Array.from(selectMesta.selectedOptions).map(opt => Number(opt.value)) : [];
+
+        return {
+            od: inputOd?.value ?? '',
+            do: inputDo?.value ?? '',
+            normy: vybraneNormy.filter(Number.isFinite),
+            mesta: vybranaMesta.filter(Number.isFinite)
+        };
+    }
+
+    function upozorneni(zprava) {
+        window.alert(zprava);
+    }
+
+    function inicializovatRealtime() {
+        if (typeof signalR === 'undefined' || !konfigurace.hub) {
+            console.warn('SignalR není dostupný, realtime statistiky budou aktualizovány pouze ručně.');
+            return;
+        }
+
+        hubConnection = new signalR.HubConnectionBuilder()
+            .withUrl(konfigurace.hub)
+            .withAutomaticReconnect()
+            .build();
+
+        hubConnection.onreconnected(obnovitRealtime);
+        hubConnection.onreconnecting(() => nastavitRealtimeText('…'));
+
+        hubConnection
+            .start()
+            .then(obnovitRealtime)
+            .catch(err => {
+                console.error('Nepodařilo se připojit k SignalR hubu.', err);
+            });
+
+        const interval = Number(konfigurace.intervalAktualizace) || 15000;
+        realtimeIntervalId = window.setInterval(() => {
+            if (hubConnection && hubConnection.state === signalR.HubConnectionState.Connected) {
+                obnovitRealtime();
+            }
+        }, interval);
+    }
+
+    function nastavitRealtimeText(text) {
+        if (realtimePrvky.online) {
+            realtimePrvky.online.textContent = text;
+        }
+        if (realtimePrvky.kosiky) {
+            realtimePrvky.kosiky.textContent = text;
+        }
+        if (realtimePrvky.hodnota) {
+            realtimePrvky.hodnota.textContent = text;
+        }
+    }
+
+    async function obnovitRealtime() {
+        if (!hubConnection || hubConnection.state !== signalR.HubConnectionState.Connected) {
+            return;
+        }
+
+        try {
+            const filtr = ziskejFiltr();
+            const data = await hubConnection.invoke('ZiskejOkamziteStatistiky', filtr);
+            aktualizovatRealtime(data);
+        } catch (error) {
+            console.error('Nepodařilo se aktualizovat realtime statistiky.', error);
+        }
+    }
+
+    function aktualizovatRealtime(data) {
+        if (!data) {
+            return;
+        }
+        if (realtimePrvky.online) {
+            realtimePrvky.online.textContent = celeCislo.format(data.onlineUzivatele ?? 0);
+        }
+        if (realtimePrvky.kosiky) {
+            realtimePrvky.kosiky.textContent = celeCislo.format(data.aktivniKosiky ?? 0);
+        }
+        if (realtimePrvky.hodnota) {
+            realtimePrvky.hodnota.textContent = mena.format(data.hodnotaKosiku ?? 0);
+        }
+    }
+
+    window.addEventListener('beforeunload', function () {
+        if (realtimeIntervalId) {
+            window.clearInterval(realtimeIntervalId);
+        }
+        if (hubConnection) {
+            hubConnection.stop();
+        }
+    });
+})();


### PR DESCRIPTION
## Shrnutí
- přidán API controller a analytická služba pro agregaci statistik a export do Excelu
- přepracovaná stránka administrátorského dashboardu s filtry, grafy, heatmapou a novým JavaScriptem
- doplněn SignalR hub a konfigurace pro živé statistiky online účastníků a košíků

## Testování
- `dotnet build` *(selhalo: příkaz `dotnet` není v prostředí k dispozici)*

------
https://chatgpt.com/codex/tasks/task_e_68dd059b1c1c8321bff6a4751d7f9e62