### PR TITLE
Rozšířit admin dashboard o analytiku a real-time statistiky

### DIFF
--- a/Controllers/AnalyticsController.cs
+++ b/Controllers/AnalyticsController.cs
@@ -1,0 +1,581 @@
+using System.Globalization;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using OfficeOpenXml;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Controllers;
+
+[Authorize(Policy = AuthorizationPolicies.AdminDashboardAccess)]
+[ApiController]
+[Route("api/[controller]")]
+public class AnalyticsController : ControllerBase
+{
+    private static readonly TimeZoneInfo PragueTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Prague");
+    private static readonly string[] KnownCityNames =
+    {
+        "Praha",
+        "Brno",
+        "Ostrava",
+        "Plzeň",
+        "Liberec",
+        "Olomouc",
+        "Hradec Králové",
+        "Pardubice",
+        "České Budějovice",
+        "Zlín"
+    };
+
+    private readonly ApplicationDbContext _context;
+    public AnalyticsController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet("filters")]
+    public async Task<ActionResult<FilterResponse>> GetFilters(CancellationToken cancellationToken)
+    {
+        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, PragueTimeZone);
+        var defaultTo = DateOnly.FromDateTime(nowLocal.Date);
+        var defaultFrom = defaultTo.AddDays(-29);
+
+        var tags = await _context.Tags
+            .AsNoTracking()
+            .OrderBy(t => t.Name)
+            .Select(t => new FilterOption(t.Id, t.Name))
+            .ToListAsync(cancellationToken);
+
+        var normy = tags
+            .Where(t => t.Name.Contains("ISO", StringComparison.OrdinalIgnoreCase)
+                || t.Name.Contains("ČSN", StringComparison.OrdinalIgnoreCase)
+                || t.Name.Contains("EN", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (normy.Count == 0)
+        {
+            normy = tags;
+        }
+
+        var knownCitySet = new HashSet<string>(KnownCityNames, StringComparer.OrdinalIgnoreCase);
+        var mesta = tags
+            .Where(t => knownCitySet.Contains(t.Name))
+            .ToList();
+
+        return Ok(new FilterResponse(defaultFrom, defaultTo, normy, mesta));
+    }
+
+    [HttpGet("dashboard")]
+    public async Task<ActionResult<DashboardResponse>> GetDashboard([FromQuery] AnalyticsQuery query, CancellationToken cancellationToken)
+    {
+        var dashboard = await BuildDashboardAsync(query, cancellationToken);
+        return Ok(dashboard);
+    }
+
+    [HttpGet("export")]
+    public async Task<IActionResult> Export([FromQuery] AnalyticsQuery query, CancellationToken cancellationToken)
+    {
+        var dashboard = await BuildDashboardAsync(query, cancellationToken);
+
+        using var package = new ExcelPackage();
+        var summarySheet = package.Workbook.Worksheets.Add("Přehled");
+
+        summarySheet.Cells[1, 1].Value = "Období";
+        summarySheet.Cells[1, 2].Value = $"{dashboard.ObdobiOd:yyyy-MM-dd} – {dashboard.ObdobiDo:yyyy-MM-dd}";
+
+        summarySheet.Cells[3, 1].Value = "Souhrn";
+        summarySheet.Cells[4, 1].Value = "Tržby celkem";
+        summarySheet.Cells[4, 2].Value = dashboard.Souhrn.CelkoveTrzby;
+        summarySheet.Cells[5, 1].Value = "Změna tržeb";
+        summarySheet.Cells[5, 2].Value = dashboard.Souhrn.ZmenaTrzebProcenta / 100d;
+        summarySheet.Cells[5, 2].Style.Numberformat.Format = "0.00%";
+        summarySheet.Cells[6, 1].Value = "Objednávky";
+        summarySheet.Cells[6, 2].Value = dashboard.Souhrn.Objednavky;
+        summarySheet.Cells[7, 1].Value = "Průměrná hodnota objednávky";
+        summarySheet.Cells[7, 2].Value = dashboard.Souhrn.PrumernaObjednavka;
+        summarySheet.Cells[8, 1].Value = "Prodáno míst";
+        summarySheet.Cells[8, 2].Value = dashboard.Souhrn.ProdanaMista;
+        summarySheet.Cells[9, 1].Value = "Průměrná obsazenost";
+        summarySheet.Cells[9, 2].Value = dashboard.Souhrn.PrumernaObsazenost / 100d;
+        summarySheet.Cells[9, 2].Style.Numberformat.Format = "0.00%";
+        summarySheet.Cells[10, 1].Value = "Aktivní zákazníci";
+        summarySheet.Cells[10, 2].Value = dashboard.Souhrn.AktivniZakaznici;
+        summarySheet.Cells[11, 1].Value = "Noví zákazníci";
+        summarySheet.Cells[11, 2].Value = dashboard.Souhrn.NoviZakaznici;
+
+        summarySheet.Cells[4, 2].Style.Numberformat.Format = "#,##0.00";
+        summarySheet.Cells[7, 2].Style.Numberformat.Format = "#,##0.00";
+
+        summarySheet.Cells[13, 1].Value = "Top kurzy podle tržeb";
+        summarySheet.Cells[14, 1].Value = "Kurz";
+        summarySheet.Cells[14, 2].Value = "Tržby";
+        summarySheet.Cells[14, 3].Value = "Prodáno míst";
+
+        var topRow = 15;
+        foreach (var kurz in dashboard.TopKurzy)
+        {
+            summarySheet.Cells[topRow, 1].Value = kurz.Nazev;
+            summarySheet.Cells[topRow, 2].Value = kurz.Trzba;
+            summarySheet.Cells[topRow, 3].Value = kurz.Mnozstvi;
+            summarySheet.Cells[topRow, 2].Style.Numberformat.Format = "#,##0.00";
+            topRow++;
+        }
+
+        summarySheet.Cells[topRow + 1, 1].Value = "Vývoj tržeb";
+        summarySheet.Cells[topRow + 2, 1].Value = "Datum";
+        summarySheet.Cells[topRow + 2, 2].Value = "Tržby";
+        summarySheet.Cells[topRow + 2, 3].Value = "Objednávky";
+        summarySheet.Cells[topRow + 2, 4].Value = "Průměrná objednávka";
+
+        var trendRow = topRow + 3;
+        foreach (var bod in dashboard.Trend)
+        {
+            summarySheet.Cells[trendRow, 1].Value = bod.Datum.ToDateTime(TimeOnly.MinValue);
+            summarySheet.Cells[trendRow, 1].Style.Numberformat.Format = "yyyy-mm-dd";
+            summarySheet.Cells[trendRow, 2].Value = bod.Trzba;
+            summarySheet.Cells[trendRow, 2].Style.Numberformat.Format = "#,##0.00";
+            summarySheet.Cells[trendRow, 3].Value = bod.Objednavky;
+            summarySheet.Cells[trendRow, 4].Value = bod.PrumernaObjednavka;
+            summarySheet.Cells[trendRow, 4].Style.Numberformat.Format = "#,##0.00";
+            trendRow++;
+        }
+
+        summarySheet.Cells.AutoFitColumns();
+
+        var fileName = $"report-{DateTime.UtcNow:yyyyMMdd-HHmm}.xlsx";
+        return File(package.GetAsByteArray(),
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            fileName);
+    }
+
+    private async Task<DashboardResponse> BuildDashboardAsync(AnalyticsQuery query, CancellationToken cancellationToken)
+    {
+        var filter = await BuildFilterContextAsync(query, cancellationToken);
+        if (filter.HasCourseFilter && filter.CourseIds.Count == 0)
+        {
+            return DashboardResponse.Empty(filter.From, filter.To);
+        }
+
+        var fromUtc = filter.FromUtc;
+        var toUtc = filter.ToUtc;
+
+        var orderItemsQuery = _context.OrderItems
+            .AsNoTracking()
+            .Where(oi => oi.Order != null && oi.Order.Status == OrderStatus.Paid)
+            .Where(oi => oi.Order!.CreatedAt >= fromUtc && oi.Order.CreatedAt <= toUtc)
+            .Where(oi => oi.Course != null);
+
+        if (filter.CourseIds.Count > 0)
+        {
+            orderItemsQuery = orderItemsQuery.Where(oi => filter.CourseIds.Contains(oi.CourseId));
+        }
+
+        var orderItemData = await orderItemsQuery
+            .Select(oi => new OrderItemSnapshot(
+                oi.OrderId,
+                oi.Order!.CreatedAt,
+                oi.Order.UserId,
+                oi.Total,
+                oi.Quantity,
+                oi.CourseId,
+                oi.Course!.Title))
+            .ToListAsync(cancellationToken);
+
+        var trend = BuildTrend(orderItemData);
+        var topCourses = BuildTopCourses(orderItemData);
+
+        var termSnapshots = await LoadTermSnapshotsAsync(filter, cancellationToken);
+        var heatmap = BuildHeatmap(termSnapshots);
+
+        var summary = await BuildSummaryAsync(orderItemData, termSnapshots, filter, cancellationToken);
+
+        var conversions = await BuildConversionAsync(orderItemData, filter, cancellationToken);
+
+        return new DashboardResponse(filter.From, filter.To, summary, trend, topCourses, conversions, heatmap);
+    }
+
+    private async Task<SummaryDto> BuildSummaryAsync(
+        IReadOnlyCollection<OrderItemSnapshot> orderItems,
+        IReadOnlyCollection<TermSnapshot> terms,
+        FilterContext filter,
+        CancellationToken cancellationToken)
+    {
+        var totalRevenue = orderItems.Sum(item => item.Total);
+        var orderIds = orderItems.Select(item => item.OrderId).Distinct().ToList();
+        var totalOrders = orderIds.Count;
+        var averageOrder = totalOrders > 0 ? totalRevenue / totalOrders : 0m;
+        var seatsSold = orderItems.Sum(item => item.Quantity);
+        var occupancyAverage = terms.Count > 0
+            ? terms.Average(term => term.Occupancy)
+            : 0d;
+
+        var customerIds = orderItems
+            .Where(item => !string.IsNullOrWhiteSpace(item.UserId))
+            .Select(item => item.UserId!)
+            .Distinct()
+            .ToList();
+
+        var previousCustomers = customerIds.Count == 0
+            ? new HashSet<string>()
+            : (await _context.Orders
+                .AsNoTracking()
+                .Where(o => o.Status == OrderStatus.Paid)
+                .Where(o => o.UserId != null)
+                .Where(o => customerIds.Contains(o.UserId!))
+                .Where(o => o.CreatedAt < filter.FromUtc)
+                .Select(o => o.UserId!)
+                .Distinct()
+                .ToListAsync(cancellationToken))
+                .ToHashSet();
+
+        var newCustomers = customerIds.Count(id => !previousCustomers.Contains(id));
+
+        var previousRevenue = await CalculateRevenueAsync(filter.PreviousFrom, filter.PreviousTo, filter.CourseIds, cancellationToken);
+        var revenueChangePercent = previousRevenue > 0m
+            ? (double)((totalRevenue - previousRevenue) / previousRevenue) * 100d
+            : totalRevenue > 0m ? 100d : 0d;
+
+        var periodLength = Math.Max(1, filter.To.DayNumber - filter.From.DayNumber + 1);
+
+        return new SummaryDto(
+            Math.Round(totalRevenue, 2),
+            Math.Round(previousRevenue, 2),
+            revenueChangePercent,
+            totalOrders,
+            Math.Round(averageOrder, 2),
+            seatsSold,
+            Math.Round(occupancyAverage * 100d, 2),
+            customerIds.Count,
+            newCustomers,
+            periodLength);
+    }
+
+    private async Task<ConversionDto> BuildConversionAsync(
+        IReadOnlyCollection<OrderItemSnapshot> orderItems,
+        FilterContext filter,
+        CancellationToken cancellationToken)
+    {
+        var payments = orderItems
+            .Select(item => item.OrderId)
+            .Distinct()
+            .Count();
+
+        var waitlistQuery = _context.WaitlistEntries
+            .AsNoTracking()
+            .Where(entry => entry.CreatedAtUtc >= filter.FromUtc && entry.CreatedAtUtc <= filter.ToUtc);
+
+        if (filter.CourseIds.Count > 0)
+        {
+            waitlistQuery = waitlistQuery.Where(entry => filter.CourseIds.Contains(entry.CourseTerm!.CourseId));
+        }
+
+        var registrations = await waitlistQuery.CountAsync(cancellationToken);
+
+        var visitsQuery = _context.LogEntries
+            .AsNoTracking()
+            .Where(log => log.Timestamp >= filter.FromUtc && log.Timestamp <= filter.ToUtc);
+
+        var visits = await visitsQuery.CountAsync(cancellationToken);
+        if (filter.CourseIds.Count > 0)
+        {
+            visits = Math.Max(registrations, payments);
+        }
+        else
+        {
+            visits = Math.Max(visits, Math.Max(registrations, payments));
+        }
+
+        var visitToRegistration = visits > 0 ? (double)registrations / visits * 100d : 0d;
+        var registrationToPayment = registrations > 0 ? (double)payments / registrations * 100d : 0d;
+        var visitToPayment = visits > 0 ? (double)payments / visits * 100d : 0d;
+
+        return new ConversionDto(
+            visits,
+            registrations,
+            payments,
+            visitToRegistration,
+            registrationToPayment,
+            visitToPayment);
+    }
+
+    private static IReadOnlyList<SalesPointDto> BuildTrend(IEnumerable<OrderItemSnapshot> orderItems)
+    {
+        return orderItems
+            .GroupBy(item => DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(
+                DateTime.SpecifyKind(item.CreatedAtUtc, DateTimeKind.Utc),
+                PragueTimeZone)))
+            .OrderBy(group => group.Key)
+            .Select(group =>
+            {
+                var revenue = group.Sum(item => item.Total);
+                var orders = group.Select(item => item.OrderId).Distinct().Count();
+                var average = orders > 0 ? revenue / orders : 0m;
+                return new SalesPointDto(group.Key, Math.Round(revenue, 2), orders, Math.Round(average, 2));
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<TopCourseDto> BuildTopCourses(IEnumerable<OrderItemSnapshot> orderItems)
+    {
+        return orderItems
+            .GroupBy(item => new { item.CourseId, item.CourseTitle })
+            .Select(group => new TopCourseDto(
+                group.Key.CourseId,
+                group.Key.CourseTitle,
+                Math.Round(group.Sum(item => item.Total), 2),
+                group.Sum(item => item.Quantity)))
+            .OrderByDescending(course => course.Trzba)
+            .ThenBy(course => course.Nazev)
+            .Take(5)
+            .ToList();
+    }
+
+    private async Task<IReadOnlyList<TermSnapshot>> LoadTermSnapshotsAsync(FilterContext filter, CancellationToken cancellationToken)
+    {
+        var termQuery = _context.CourseTerms
+            .AsNoTracking()
+            .Where(term => term.StartUtc >= filter.FromUtc && term.StartUtc <= filter.ToUtc)
+            .Where(term => term.IsActive);
+
+        if (filter.CourseIds.Count > 0)
+        {
+            termQuery = termQuery.Where(term => filter.CourseIds.Contains(term.CourseId));
+        }
+
+        var terms = await termQuery
+            .Select(term => new TermSnapshot(term.StartUtc, term.Capacity, term.SeatsTaken))
+            .ToListAsync(cancellationToken);
+
+        return terms;
+    }
+
+    private static HeatmapDto BuildHeatmap(IEnumerable<TermSnapshot> terms)
+    {
+        var cells = terms
+            .Select(term =>
+            {
+                var startUtc = DateTime.SpecifyKind(term.StartUtc, DateTimeKind.Utc);
+                var local = TimeZoneInfo.ConvertTimeFromUtc(startUtc, PragueTimeZone);
+                var occupancy = term.Capacity > 0
+                    ? Math.Clamp((double)Math.Min(term.SeatsTaken, term.Capacity) / term.Capacity, 0d, 1d)
+                    : 0d;
+                return new
+                {
+                    Day = (int)local.DayOfWeek,
+                    Hour = local.Hour,
+                    occupancy,
+                    term.Capacity,
+                    Seats = Math.Min(term.SeatsTaken, term.Capacity)
+                };
+            })
+            .GroupBy(item => new { item.Day, item.Hour })
+            .Select(group => new HeatmapCellDto(
+                group.Key.Day,
+                group.Key.Hour,
+                Math.Round(group.Average(item => item.occupancy), 4),
+                group.Count(),
+                group.Sum(item => item.Capacity),
+                group.Sum(item => item.Seats)))
+            .OrderBy(cell => cell.Den)
+            .ThenBy(cell => cell.Hodina)
+            .ToList();
+
+        var maxOccupancy = cells.Count > 0 ? cells.Max(cell => cell.Obsazenost) : 0d;
+        return new HeatmapDto(cells, maxOccupancy);
+    }
+
+    private async Task<decimal> CalculateRevenueAsync(DateOnly from, DateOnly to, IReadOnlyCollection<int> courseIds, CancellationToken cancellationToken)
+    {
+        if (to < from)
+        {
+            return 0m;
+        }
+
+        var fromUtc = ToUtc(from, TimeOnly.MinValue);
+        var toUtc = ToUtc(to, TimeOnly.MaxValue);
+
+        var query = _context.OrderItems
+            .AsNoTracking()
+            .Where(oi => oi.Order != null && oi.Order.Status == OrderStatus.Paid)
+            .Where(oi => oi.Order!.CreatedAt >= fromUtc && oi.Order.CreatedAt <= toUtc);
+
+        if (courseIds.Count > 0)
+        {
+            query = query.Where(oi => courseIds.Contains(oi.CourseId));
+        }
+
+        var result = await query.SumAsync(oi => (decimal?)oi.Total, cancellationToken);
+        return Math.Round(result ?? 0m, 2);
+    }
+
+    private async Task<FilterContext> BuildFilterContextAsync(AnalyticsQuery query, CancellationToken cancellationToken)
+    {
+        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, PragueTimeZone);
+        var defaultTo = DateOnly.FromDateTime(nowLocal.Date);
+        var defaultFrom = defaultTo.AddDays(-29);
+
+        var from = ParseDate(query.From, defaultFrom);
+        var to = ParseDate(query.To, defaultTo);
+        if (to < from)
+        {
+            (from, to) = (to, from);
+        }
+
+        var periodLength = Math.Max(1, to.DayNumber - from.DayNumber + 1);
+        var previousTo = from.AddDays(-1);
+        var previousFrom = previousTo.AddDays(-(periodLength - 1));
+
+        var hasCourseFilter = (query.Normy?.Count ?? 0) > 0 || (query.Mesta?.Count ?? 0) > 0;
+        var courseIds = new List<int>();
+
+        if (hasCourseFilter)
+        {
+            var courseQuery = _context.Courses
+                .AsNoTracking()
+                .Where(course => course.IsActive);
+
+            if (query.Normy is { Count: > 0 })
+            {
+                var norms = query.Normy;
+                courseQuery = courseQuery.Where(course => course.CourseTags.Any(tag => norms.Contains(tag.TagId)));
+            }
+
+            if (query.Mesta is { Count: > 0 })
+            {
+                var cities = query.Mesta;
+                courseQuery = courseQuery.Where(course => course.CourseTags.Any(tag => cities.Contains(tag.TagId)));
+            }
+
+            courseIds = await courseQuery
+                .Select(course => course.Id)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+        }
+
+        return new FilterContext(from, to, previousFrom, previousTo, courseIds, hasCourseFilter);
+    }
+
+    private static DateOnly ParseDate(string? input, DateOnly fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(input) && DateOnly.TryParse(input, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            return parsed;
+        }
+
+        return fallback;
+    }
+
+    private static DateTime ToUtc(DateOnly date, TimeOnly time)
+    {
+        var local = date.ToDateTime(time);
+        var unspecified = DateTime.SpecifyKind(local, DateTimeKind.Unspecified);
+        return TimeZoneInfo.ConvertTimeToUtc(unspecified, PragueTimeZone);
+    }
+
+    private sealed record FilterContext(
+        DateOnly From,
+        DateOnly To,
+        DateOnly PreviousFrom,
+        DateOnly PreviousTo,
+        IReadOnlyList<int> CourseIds,
+        bool HasCourseFilter)
+    {
+        public DateTime FromUtc => ToUtc(From, TimeOnly.MinValue);
+        public DateTime ToUtc => ToUtc(To, TimeOnly.MaxValue);
+        public DateTime PreviousFromUtc => ToUtc(PreviousFrom, TimeOnly.MinValue);
+        public DateTime PreviousToUtc => ToUtc(PreviousTo, TimeOnly.MaxValue);
+    }
+
+    public sealed record AnalyticsQuery
+    {
+        [FromQuery(Name = "from")]
+        public string? From { get; init; }
+
+        [FromQuery(Name = "to")]
+        public string? To { get; init; }
+
+        [FromQuery(Name = "normy")]
+        public List<int> Normy { get; init; } = new();
+
+        [FromQuery(Name = "mesta")]
+        public List<int> Mesta { get; init; } = new();
+    }
+
+    public sealed record FilterResponse(
+        DateOnly VychoziOd,
+        DateOnly VychoziDo,
+        IReadOnlyList<FilterOption> Normy,
+        IReadOnlyList<FilterOption> Mesta);
+
+    public sealed record FilterOption(int Id, string Name);
+
+    public sealed record DashboardResponse(
+        DateOnly ObdobiOd,
+        DateOnly ObdobiDo,
+        SummaryDto Souhrn,
+        IReadOnlyList<SalesPointDto> Trend,
+        IReadOnlyList<TopCourseDto> TopKurzy,
+        ConversionDto Konverze,
+        HeatmapDto Heatmap)
+    {
+        public static DashboardResponse Empty(DateOnly from, DateOnly to) => new(
+            from,
+            to,
+            new SummaryDto(0m, 0m, 0d, 0, 0m, 0, 0d, 0, 0, Math.Max(1, to.DayNumber - from.DayNumber + 1)),
+            Array.Empty<SalesPointDto>(),
+            Array.Empty<TopCourseDto>(),
+            new ConversionDto(0, 0, 0, 0d, 0d, 0d),
+            new HeatmapDto(Array.Empty<HeatmapCellDto>(), 0d));
+    }
+
+    public sealed record SummaryDto(
+        decimal CelkoveTrzby,
+        decimal PredchoziTrzby,
+        double ZmenaTrzebProcenta,
+        int Objednavky,
+        decimal PrumernaObjednavka,
+        int ProdanaMista,
+        double PrumernaObsazenost,
+        int AktivniZakaznici,
+        int NoviZakaznici,
+        int DelkaObdobiDni);
+
+    public sealed record SalesPointDto(DateOnly Datum, decimal Trzba, int Objednavky, decimal PrumernaObjednavka);
+
+    public sealed record TopCourseDto(int KurzId, string Nazev, decimal Trzba, int Mnozstvi);
+
+    public sealed record ConversionDto(
+        int Navstevy,
+        int Registrace,
+        int Platby,
+        double NavstevyNaRegistraci,
+        double RegistraceNaPlatbu,
+        double NavstevyNaPlatbu);
+
+    public sealed record HeatmapDto(IReadOnlyList<HeatmapCellDto> Bunky, double MaxObsazenost);
+
+    public sealed record HeatmapCellDto(
+        int Den,
+        int Hodina,
+        double Obsazenost,
+        int PocetTerminu,
+        int KapacitaCelkem,
+        int ObsazenaMista);
+
+    private sealed record OrderItemSnapshot(
+        int OrderId,
+        DateTime CreatedAtUtc,
+        string? UserId,
+        decimal Total,
+        int Quantity,
+        int CourseId,
+        string CourseTitle);
+
+    private sealed record TermSnapshot(DateTime StartUtc, int Capacity, int SeatsTaken)
+    {
+        public double Occupancy => Capacity > 0
+            ? Math.Clamp((double)Math.Min(SeatsTaken, Capacity) / Capacity, 0d, 1d)
+            : 0d;
+    }
+}

--- a/Hubs/DashboardHub.cs
+++ b/Hubs/DashboardHub.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Data;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Hubs;
+
+[Authorize(Policy = AuthorizationPolicies.AdminDashboardAccess)]
+public class DashboardHub : Hub
+{
+    private readonly ApplicationDbContext _context;
+
+    public DashboardHub(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<RealTimeStatsMessage> RequestRealtimeStats(CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var onlineSince = now.AddMinutes(-15);
+
+        var onlineUsers = await _context.LogEntries
+            .AsNoTracking()
+            .Where(log => log.Timestamp >= onlineSince)
+            .Select(log => log.CorrelationId ?? log.Id.ToString())
+            .Distinct()
+            .CountAsync(cancellationToken);
+
+        var cartWindow = now.AddHours(-2);
+        var carts = await _context.Orders
+            .AsNoTracking()
+            .Where(order => order.Status == OrderStatus.Pending && order.CreatedAt >= cartWindow)
+            .Select(order => new
+            {
+                order.Total,
+                ItemCount = order.Items.Sum(item => item.Quantity)
+            })
+            .ToListAsync(cancellationToken);
+
+        var activeCarts = carts.Count;
+        var totalValue = carts.Sum(cart => cart.Total);
+        var totalItems = carts.Sum(cart => cart.ItemCount);
+
+        return new RealTimeStatsMessage(
+            onlineUsers,
+            activeCarts,
+            Math.Round(totalValue, 2),
+            totalItems,
+            DateTime.UtcNow);
+    }
+
+    public sealed record RealTimeStatsMessage(
+        int OnlineUzivatelu,
+        int AktivniKosiky,
+        decimal CelkovaHodnota,
+        int PolozkyCelkem,
+        DateTime VytvorenoUtc);
+}

--- a/Pages/Admin/Dashboard/Index.cshtml
+++ b/Pages/Admin/Dashboard/Index.cshtml
@@ -1,76 +1,228 @@
 @page
 @model SysJaky_N.Pages.Admin.Dashboard.IndexModel
 @{
-    ViewData["Title"] = "Přehled";
+    ViewData["Title"] = "Řídicí panel";
 }
 
-<h1>Přehled</h1>
+<h1 class="mb-4">Řídicí panel</h1>
 
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">Počet objednávek</h5>
-                <p class="card-text display-6">@Model.OrderCount</p>
-            </div>
-        </div>
+@if (TempData["ChatbotSettingsSaved"] is bool saved && saved)
+{
+    <div class="alert alert-success" role="alert">
+        Nastavení chatbota bylo úspěšně uloženo.
     </div>
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">Celkové tržby</h5>
-                <p class="card-text display-6">@Model.TotalRevenue.ToString("C")</p>
-            </div>
-        </div>
-    </div>
-</div>
+}
 
-<div class="row">
-    <div class="col-md-6">
-        <h3>Nejprodávanější kurzy</h3>
-        <canvas id="topCoursesChart"></canvas>
-    </div>
-    <div class="col-md-6">
-        <h3>Denní statistiky prodeje</h3>
-        <canvas id="revenueChart"></canvas>
-    </div>
-</div>
-
-<div class="row mt-4">
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-body">
-                <h3 class="card-title">Nástroje</h3>
-                <div class="d-flex flex-wrap gap-2">
-                    <a class="btn btn-outline-primary" asp-page="/Instructor/Attendance">
-                        <i class="bi bi-qr-code-scan"></i> Docházka (QR)
-                    </a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-6">
-        <div class="card h-100">
-            <div class="card-body">
-                <div class="d-flex justify-content-between align-items-start mb-3">
+<div class="row g-4">
+    <div class="col-12 col-xxl-9">
+        <div class="card shadow-sm mb-4">
+            <div class="card-header py-3">
+                <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
                     <div>
-                        <h3 class="card-title">Nastavení chatbota</h3>
-                        <p class="text-muted mb-0">Správa zobrazení a automatického spuštění virtuálního poradce.</p>
+                        <h2 class="h5 mb-1">Filtr přehledu</h2>
+                        <p class="text-muted mb-0">Zvolte období, normy a města, pro která chcete zobrazit statistiky.</p>
                     </div>
-                    @if (TempData["ChatbotSettingsSaved"] is bool saved && saved)
-                    {
-                        <span class="badge bg-success">Uloženo</span>
-                    }
+                    <div class="d-flex flex-wrap gap-2">
+                        <button id="preset7" type="button" class="btn btn-outline-secondary btn-sm" data-range="7">
+                            Posledních 7 dní
+                        </button>
+                        <button id="preset30" type="button" class="btn btn-outline-secondary btn-sm" data-range="30">
+                            Posledních 30 dní
+                        </button>
+                        <button id="preset365" type="button" class="btn btn-outline-secondary btn-sm" data-range="365">
+                            Posledních 12 měsíců
+                        </button>
+                    </div>
                 </div>
+            </div>
+            <div class="card-body">
+                <form id="dashboardFilters" class="row g-3 align-items-end" autocomplete="off">
+                    <div class="col-sm-6 col-lg-3">
+                        <label class="form-label" for="filterFrom">Od</label>
+                        <input id="filterFrom" type="date" class="form-control" required />
+                    </div>
+                    <div class="col-sm-6 col-lg-3">
+                        <label class="form-label" for="filterTo">Do</label>
+                        <input id="filterTo" type="date" class="form-control" required />
+                    </div>
+                    <div class="col-sm-6 col-lg-3">
+                        <label class="form-label" for="filterNorms">Norma</label>
+                        <select id="filterNorms" class="form-select" multiple size="4" aria-describedby="filterNormsHelp"></select>
+                        <div id="filterNormsHelp" class="form-text">Podržením Ctrl vyberete více norem.</div>
+                    </div>
+                    <div class="col-sm-6 col-lg-3">
+                        <label class="form-label" for="filterCities">Město</label>
+                        <select id="filterCities" class="form-select" multiple size="4" aria-describedby="filterCitiesHelp"></select>
+                        <div id="filterCitiesHelp" class="form-text">Podržením Ctrl vyberete více měst.</div>
+                    </div>
+                    <div class="col-12 d-flex flex-wrap gap-2">
+                        <button id="applyFilters" type="submit" class="btn btn-primary">
+                            <i class="bi bi-arrow-repeat"></i> Aktualizovat přehled
+                        </button>
+                        <button id="exportReport" type="button" class="btn btn-outline-success">
+                            <i class="bi bi-file-earmark-excel"></i> Exportovat do Excelu
+                        </button>
+                        <div id="filtersStatus" class="text-muted small align-self-center">
+                            <span class="spinner-border spinner-border-sm me-2 d-none" id="filtersSpinner" role="status" aria-hidden="true"></span>
+                            <span id="filtersStatusText">Připraveno</span>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="row g-3 mb-4" id="summaryCards">
+            <div class="col-sm-6 col-xl-3">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <p class="text-muted text-uppercase fw-semibold mb-1">Tržby celkem</p>
+                        <p class="display-6 mb-0" id="summaryRevenue">—</p>
+                        <p class="text-success small mb-0" id="summaryRevenueChange"></p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-xl-3">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <p class="text-muted text-uppercase fw-semibold mb-1">Objednávky</p>
+                        <p class="display-6 mb-0" id="summaryOrders">—</p>
+                        <p class="text-muted small mb-0" id="summaryAverageOrder">—</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-xl-3">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <p class="text-muted text-uppercase fw-semibold mb-1">Prodáno míst</p>
+                        <p class="display-6 mb-0" id="summarySeats">—</p>
+                        <p class="text-muted small mb-0" id="summaryOccupancy">—</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-sm-6 col-xl-3">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <p class="text-muted text-uppercase fw-semibold mb-1">Aktivní zákazníci</p>
+                        <p class="display-6 mb-0" id="summaryCustomers">—</p>
+                        <p class="text-muted small mb-0" id="summaryNewCustomers">—</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card shadow-sm mb-4">
+            <div class="card-header d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-2">
+                <div>
+                    <h2 class="h5 mb-0">Vývoj tržeb a objednávek</h2>
+                    <small class="text-muted" id="salesRangeLabel">—</small>
+                </div>
+                <div class="text-muted small" id="salesAggregateLabel"></div>
+            </div>
+            <div class="card-body">
+                <canvas id="salesTrendChart" height="280" role="img" aria-label="Graf vývoje tržeb"></canvas>
+                <p class="text-muted small mt-3 mb-0" id="salesEmpty" hidden>
+                    Pro zvolené období nejsou dostupná data.
+                </p>
+            </div>
+        </div>
+
+        <div class="card shadow-sm mb-4">
+            <div class="card-header d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-2">
+                <h2 class="h5 mb-0">Top kurzy podle tržeb</h2>
+                <small class="text-muted" id="topCoursesTotal">—</small>
+            </div>
+            <div class="card-body">
+                <canvas id="topCoursesChart" height="240" role="img" aria-label="Graf nejúspěšnějších kurzů"></canvas>
+                <div class="table-responsive mt-4">
+                    <table class="table table-sm mb-0 align-middle">
+                        <thead>
+                            <tr>
+                                <th scope="col">Kurz</th>
+                                <th scope="col" class="text-end">Tržby</th>
+                                <th scope="col" class="text-end">Počet míst</th>
+                            </tr>
+                        </thead>
+                        <tbody id="topCoursesTable">
+                            <tr><td colspan="3" class="text-center text-muted py-3">Načítám…</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="row g-4 mb-4">
+            <div class="col-lg-6">
+                <div class="card shadow-sm h-100">
+                    <div class="card-header d-flex flex-column flex-md-row align-items-md-center justify-content-md-between gap-2">
+                        <h2 class="h5 mb-0">Konverzní trychtýř</h2>
+                        <small class="text-muted" id="conversionRates">—</small>
+                    </div>
+                    <div class="card-body">
+                        <canvas id="conversionChart" height="240" role="img" aria-label="Graf konverzí"></canvas>
+                        <ul class="list-unstyled mt-3 mb-0" id="conversionDetails">
+                            <li class="text-muted">Načítám…</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6">
+                <div class="card shadow-sm h-100">
+                    <div class="card-header">
+                        <h2 class="h5 mb-0">Oblíbenost termínů</h2>
+                    </div>
+                    <div class="card-body">
+                        <canvas id="heatmapChart" height="260" role="img" aria-label="Heatmapa oblíbenosti termínů"></canvas>
+                        <p class="text-muted small mt-3 mb-0" id="heatmapEmpty" hidden>
+                            Pro vybraný filtr nejsou dostupné žádné termíny.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-12 col-xxl-3">
+        <div class="card shadow-sm mb-4">
+            <div class="card-header">
+                <h2 class="h5 mb-0">Real-time statistiky</h2>
+            </div>
+            <div class="card-body">
+                <p class="mb-2">
+                    <span class="text-muted d-block">Online uživatelé</span>
+                    <span class="fs-3 fw-semibold" id="realtimeUsers">—</span>
+                </p>
+                <p class="mb-2">
+                    <span class="text-muted d-block">Aktuální košíky</span>
+                    <span class="fs-3 fw-semibold" id="realtimeCarts">—</span>
+                </p>
+                <p class="mb-0">
+                    <span class="text-muted d-block">Hodnota v košících</span>
+                    <span class="fs-5" id="realtimeCartValue">—</span>
+                </p>
+                <p class="text-muted small mt-3 mb-0" id="realtimeUpdated">Čekám na připojení…</p>
+            </div>
+        </div>
+
+        <div class="card shadow-sm">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <div>
+                    <h2 class="h5 mb-0">Nastavení chatbota</h2>
+                    <small class="text-muted">Spravujte zobrazení virtuálního poradce.</small>
+                </div>
+                @if (TempData["ChatbotSettingsSaved"] is bool badgeSaved && badgeSaved)
+                {
+                    <span class="badge bg-success">Uloženo</span>
+                }
+            </div>
+            <div class="card-body">
                 <form method="post" asp-page-handler="Chatbot" class="vstack gap-3">
                     @Html.AntiForgeryToken()
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" asp-for="ChatbotSettings.IsEnabled" />
-                        <label class="form-check-label" asp-for="ChatbotSettings.IsEnabled">Zobrazit chatbota na webu</label>
+                        <input class="form-check-input" type="checkbox" asp-for="ChatbotSettings.IsEnabled" id="chatbotEnabled" />
+                        <label class="form-check-label" for="chatbotEnabled">Zobrazit chatbota na webu</label>
                     </div>
                     <div class="form-check form-switch">
-                        <input class="form-check-input" type="checkbox" asp-for="ChatbotSettings.AutoInitialize" />
-                        <label class="form-check-label" asp-for="ChatbotSettings.AutoInitialize">Automaticky inicializovat po načtení stránky</label>
+                        <input class="form-check-input" type="checkbox" asp-for="ChatbotSettings.AutoInitialize" id="chatbotAuto" />
+                        <label class="form-check-label" for="chatbotAuto">Automaticky inicializovat po načtení stránky</label>
                     </div>
                     <button type="submit" class="btn btn-primary align-self-start">
                         <i class="bi bi-save"></i> Uložit nastavení
@@ -83,112 +235,20 @@
 
 @section Scripts {
     <script src="~/lib/chart.js/chart.js" asp-append-version="true"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@microsoft/signalr@7.0.5/dist/browser/signalr.min.js" crossorigin="anonymous"></script>
+    <script src="~/js/admin/dashboard.js" asp-append-version="true"></script>
     <script>
-        const topCourseLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TopCourseLabels));
-        const topCourseData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.TopCourseValues));
-
-        const topCoursesCanvas = document.getElementById('topCoursesChart');
-        if (topCoursesCanvas) {
-            new Chart(topCoursesCanvas, {
-                type: 'bar',
-                data: {
-                    labels: topCourseLabels,
-                    datasets: [{
-                        label: 'Počet prodaných kusů',
-                        data: topCourseData,
-                        backgroundColor: 'rgba(54, 162, 235, 0.5)'
-                    }]
-                }
-            });
-        }
-
-        const revenueLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueLabels));
-        const revenueData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.RevenueValues));
-        const orderCounts = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.OrderCounts));
-        const averageOrderValues = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.AverageOrderValues));
-
-        const revenueCanvas = document.getElementById('revenueChart');
-        if (revenueCanvas) {
-            new Chart(revenueCanvas, {
-                type: 'bar',
-                data: {
-                    labels: revenueLabels,
-                    datasets: [
-                        {
-                            type: 'bar',
-                            label: 'Počet objednávek',
-                            data: orderCounts,
-                            backgroundColor: 'rgba(54, 162, 235, 0.5)',
-                            borderColor: 'rgba(54, 162, 235, 1)',
-                            borderWidth: 1,
-                            yAxisID: 'yOrders'
-                        },
-                        {
-                            type: 'line',
-                            label: 'Tržby',
-                            data: revenueData,
-                            borderColor: 'rgba(75, 192, 192, 1)',
-                            backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                            fill: true,
-                            tension: 0.3,
-                            yAxisID: 'yRevenue'
-                        },
-                        {
-                            type: 'line',
-                            label: 'Průměrná hodnota objednávky',
-                            data: averageOrderValues,
-                            borderColor: 'rgba(255, 159, 64, 1)',
-                            backgroundColor: 'rgba(255, 159, 64, 0.2)',
-                            tension: 0.3,
-                            borderDash: [5, 5],
-                            yAxisID: 'yAverage'
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    interaction: {
-                        mode: 'index',
-                        intersect: false
-                    },
-                    stacked: false,
-                    scales: {
-                        yOrders: {
-                            type: 'linear',
-                            position: 'left',
-                            beginAtZero: true,
-                            title: {
-                                display: true,
-                                text: 'Objednávky'
-                            }
-                        },
-                        yRevenue: {
-                            type: 'linear',
-                            position: 'right',
-                            beginAtZero: true,
-                            grid: {
-                                drawOnChartArea: false
-                            },
-                            title: {
-                                display: true,
-                                text: 'Tržby'
-                            }
-                        },
-                        yAverage: {
-                            type: 'linear',
-                            position: 'right',
-                            beginAtZero: true,
-                            grid: {
-                                drawOnChartArea: false
-                            },
-                            title: {
-                                display: true,
-                                text: 'Průměrná hodnota'
-                            }
-                        }
-                    }
-                }
-            });
-        }
+        window.dashboardKonfigurace = {
+            api: {
+                filtry: '@Url.Content("~/api/analytics/filters")',
+                prehled: '@Url.Content("~/api/analytics/dashboard")',
+                export: '@Url.Content("~/api/analytics/export")',
+                hub: '@Url.Content("~/hubs/dashboard")'
+            },
+            texty: {
+                zadnaData: 'Žádná data',
+                mena: '@System.Globalization.CultureInfo.CurrentCulture.NumberFormat.CurrencySymbol'
+            }
+        };
     </script>
 }

--- a/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -2,9 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using SysJaky_N.Authorization;
 using SysJaky_N.Data;
-using SysJaky_N.Models;
 
 namespace SysJaky_N.Pages.Admin.Dashboard;
 
@@ -18,51 +16,11 @@ public class IndexModel : PageModel
         _context = context;
     }
 
-    public int OrderCount { get; set; }
-    public decimal TotalRevenue { get; set; }
-    public List<string> TopCourseLabels { get; set; } = new();
-    public List<int> TopCourseValues { get; set; } = new();
-    public List<string> RevenueLabels { get; set; } = new();
-    public List<decimal> RevenueValues { get; set; } = new();
-    public List<int> OrderCounts { get; set; } = new();
-    public List<decimal> AverageOrderValues { get; set; } = new();
+    [BindProperty]
     public ChatbotSettingsInput ChatbotSettings { get; set; } = new();
 
     public async Task OnGetAsync()
     {
-        OrderCount = await _context.Orders.CountAsync();
-        TotalRevenue = await _context.Orders.SumAsync(o => o.Total);
-
-        var topCourses = await _context.OrderItems
-            .Include(oi => oi.Course)
-            .GroupBy(oi => oi.Course!.Title)
-            .Select(g => new
-            {
-                Course = g.Key,
-                Quantity = g.Sum(oi => oi.Quantity)
-            })
-            .OrderByDescending(g => g.Quantity)
-            .Take(5)
-            .ToListAsync();
-
-        foreach (var item in topCourses)
-        {
-            TopCourseLabels.Add(item.Course);
-            TopCourseValues.Add(item.Quantity);
-        }
-
-        var dailyStats = await _context.SalesStats
-            .OrderBy(s => s.Date)
-            .ToListAsync();
-
-        foreach (var stat in dailyStats)
-        {
-            RevenueLabels.Add(stat.Date.ToString("yyyy-MM-dd"));
-            RevenueValues.Add(stat.Revenue);
-            OrderCounts.Add(stat.OrderCount);
-            AverageOrderValues.Add(stat.AverageOrderValue);
-        }
-
         var settings = await _context.ChatbotSettings
             .AsNoTracking()
             .OrderBy(s => s.Id)
@@ -94,7 +52,7 @@ public class IndexModel : PageModel
 
         if (settings is null)
         {
-            settings = new ChatbotSettings();
+            settings = new Models.ChatbotSettings();
             _context.ChatbotSettings.Add(settings);
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Serilog;
 using Serilog.Events;
 using SysJaky_N.Logging;
+using SysJaky_N.Hubs;
 using SysJaky_N.Middleware;
 using RazorLight;
 using Microsoft.Extensions.Hosting;
@@ -166,6 +167,7 @@ try
                 factory.Create(typeof(SysJaky_N.Resources.SharedResources));
         });
     builder.Services.AddControllers();
+    builder.Services.AddSignalR();
     builder.Services.Configure<RequestLocalizationOptions>(options =>
     {
         var supportedCultures = new[] { "cs", "en" };
@@ -362,6 +364,7 @@ try
         name: "default",
         pattern: "{controller}/{action=Index}/{id?}");
     app.MapControllers();
+    app.MapHub<DashboardHub>("/hubs/dashboard");
     // Přesměrování na jednotné místo „Můj účet“
     app.MapGet("/Account/Dashboard", () => Results.Redirect("/Account/Manage", true));
     app.MapGet("/Orders", () => Results.Redirect("/Account/Manage#orders", true));

--- a/wwwroot/js/admin/dashboard.js
+++ b/wwwroot/js/admin/dashboard.js
@@ -1,0 +1,668 @@
+(function () {
+    const konfigurace = window.dashboardKonfigurace;
+    if (!konfigurace) {
+        console.warn('Chybí konfigurace dashboardu.');
+        return;
+    }
+
+    const prvky = {
+        filterForm: document.getElementById('dashboardFilters'),
+        filterFrom: document.getElementById('filterFrom'),
+        filterTo: document.getElementById('filterTo'),
+        filterNorms: document.getElementById('filterNorms'),
+        filterCities: document.getElementById('filterCities'),
+        summaryRevenue: document.getElementById('summaryRevenue'),
+        summaryRevenueChange: document.getElementById('summaryRevenueChange'),
+        summaryOrders: document.getElementById('summaryOrders'),
+        summaryAverageOrder: document.getElementById('summaryAverageOrder'),
+        summarySeats: document.getElementById('summarySeats'),
+        summaryOccupancy: document.getElementById('summaryOccupancy'),
+        summaryCustomers: document.getElementById('summaryCustomers'),
+        summaryNewCustomers: document.getElementById('summaryNewCustomers'),
+        salesRangeLabel: document.getElementById('salesRangeLabel'),
+        salesAggregateLabel: document.getElementById('salesAggregateLabel'),
+        salesEmpty: document.getElementById('salesEmpty'),
+        topCoursesTable: document.getElementById('topCoursesTable'),
+        topCoursesTotal: document.getElementById('topCoursesTotal'),
+        conversionRates: document.getElementById('conversionRates'),
+        conversionDetails: document.getElementById('conversionDetails'),
+        heatmapEmpty: document.getElementById('heatmapEmpty'),
+        filtersSpinner: document.getElementById('filtersSpinner'),
+        filtersStatusText: document.getElementById('filtersStatusText'),
+        exportButton: document.getElementById('exportReport'),
+        presetButtons: Array.from(document.querySelectorAll('[data-range]')),
+        realtimeUsers: document.getElementById('realtimeUsers'),
+        realtimeCarts: document.getElementById('realtimeCarts'),
+        realtimeCartValue: document.getElementById('realtimeCartValue'),
+        realtimeUpdated: document.getElementById('realtimeUpdated')
+    };
+
+    const stav = {
+        salesChart: null,
+        topCoursesChart: null,
+        conversionChart: null,
+        heatmapChart: null,
+        hub: null,
+        hubTimer: null,
+        posledniFiltry: null
+    };
+
+    const denniNazvy = ['Neděle', 'Pondělí', 'Úterý', 'Středa', 'Čtvrtek', 'Pátek', 'Sobota'];
+    const formatMena = new Intl.NumberFormat('cs-CZ', { style: 'currency', currency: 'CZK' });
+    const formatCislo = new Intl.NumberFormat('cs-CZ');
+    const formatDatum = new Intl.DateTimeFormat('cs-CZ', { dateStyle: 'medium' });
+
+    function nastavStavNačítání(nacitani, text) {
+        if (!prvky.filtersSpinner || !prvky.filtersStatusText) {
+            return;
+        }
+
+        if (nacitani) {
+            prvky.filtersSpinner.classList.remove('d-none');
+            prvky.filtersStatusText.textContent = text ?? 'Načítám data…';
+        } else {
+            prvky.filtersSpinner.classList.add('d-none');
+            prvky.filtersStatusText.textContent = text ?? 'Připraveno';
+        }
+    }
+
+    function smazatMožnosti(select) {
+        while (select.firstChild) {
+            select.removeChild(select.firstChild);
+        }
+    }
+
+    function naplnitSelect(select, možnosti) {
+        smazatMožnosti(select);
+        možnosti.forEach(možnost => {
+            const option = document.createElement('option');
+            option.value = možnost.id;
+            option.textContent = možnost.name;
+            select.appendChild(option);
+        });
+    }
+
+    async function načtiFiltry() {
+        nastavStavNačítání(true, 'Načítám filtry…');
+        try {
+            const odpověď = await fetch(konfigurace.api.filtry, { credentials: 'include' });
+            if (!odpověď.ok) {
+                throw new Error('Nepodařilo se načíst filtry');
+            }
+            const data = await odpověď.json();
+            naplnitSelect(prvky.filterNorms, data.normy ?? []);
+            naplnitSelect(prvky.filterCities, data.mesta ?? []);
+            if (data.vychoziOd) {
+                prvky.filterFrom.value = data.vychoziOd;
+            }
+            if (data.vychoziDo) {
+                prvky.filterTo.value = data.vychoziDo;
+            }
+            nastavStavNačítání(false, 'Filtry načteny');
+            await načtiPřehled();
+        } catch (chyba) {
+            console.error(chyba);
+            nastavStavNačítání(false, 'Chyba při načítání filtrů');
+        }
+    }
+
+    function získejHodnotyFiltru() {
+        const vybranéNormy = Array.from(prvky.filterNorms.selectedOptions).map(opt => opt.value);
+        const vybranáMěsta = Array.from(prvky.filterCities.selectedOptions).map(opt => opt.value);
+        return {
+            from: prvky.filterFrom.value,
+            to: prvky.filterTo.value,
+            normy: vybranéNormy,
+            mesta: vybranáMěsta
+        };
+    }
+
+    function sestavUrl(filters) {
+        const params = new URLSearchParams();
+        if (filters.from) {
+            params.set('from', filters.from);
+        }
+        if (filters.to) {
+            params.set('to', filters.to);
+        }
+        filters.normy.forEach(id => params.append('normy', id));
+        filters.mesta.forEach(id => params.append('mesta', id));
+        return `${konfigurace.api.prehled}?${params.toString()}`;
+    }
+
+    async function načtiPřehled(event) {
+        if (event) {
+            event.preventDefault();
+        }
+
+        const filtry = získejHodnotyFiltru();
+        if (!filtry.from || !filtry.to) {
+            nastavStavNačítání(false, 'Vyberte platné období');
+            return;
+        }
+
+        stav.posledniFiltry = filtry;
+        nastavStavNačítání(true);
+
+        try {
+            const odpověď = await fetch(sestavUrl(filtry), { credentials: 'include' });
+            if (!odpověď.ok) {
+                throw new Error('Načtení přehledu selhalo');
+            }
+            const data = await odpověď.json();
+            aktualizujPřehled(data);
+            nastavStavNačítání(false, 'Data aktualizována');
+        } catch (chyba) {
+            console.error(chyba);
+            nastavStavNačítání(false, 'Chyba při načítání dat');
+        }
+    }
+
+    function aktualizujPřehled(data) {
+        if (!data || !data.souhrn) {
+            return;
+        }
+
+        aktualizujSouhrn(data);
+        aktualizujGrafTržeb(data);
+        aktualizujTopKurzy(data);
+        aktualizujKonverze(data.konverze);
+        aktualizujHeatmapu(data.heatmap);
+    }
+
+    function aktualizujSouhrn(data) {
+        const souhrn = data.souhrn;
+        const intervalText = `${formatDatum(new Date(`${data.obdobiOd}T00:00:00`))} – ${formatDatum(new Date(`${data.obdobiDo}T00:00:00`))}`;
+        prvky.salesRangeLabel.textContent = intervalText;
+
+        prvky.summaryRevenue.textContent = formatMena.format(souhrn.celkoveTrzby);
+        const změna = souhrn.zmenaTrzebProcenta ?? 0;
+        let změnaText = "";
+        if (změna > 0) {
+            změnaText = `▲ ${změna.toFixed(2)} % vs. předchozí období`;
+            prvky.summaryRevenueChange.classList.remove("text-danger");
+            prvky.summaryRevenueChange.classList.add("text-success");
+        } else if (změna < 0) {
+            změnaText = `▼ ${Math.abs(změna).toFixed(2)} % vs. předchozí období`;
+            prvky.summaryRevenueChange.classList.remove("text-success");
+            prvky.summaryRevenueChange.classList.add("text-danger");
+        } else {
+            změnaText = "Žádná změna oproti předchozímu období";
+            prvky.summaryRevenueChange.classList.remove("text-success", "text-danger");
+        }
+        prvky.summaryRevenueChange.textContent = změnaText;
+
+        prvky.summaryOrders.textContent = formatCislo.format(souhrn.objednavky);
+        prvky.summaryAverageOrder.textContent = `Průměrná objednávka ${formatMena.format(souhrn.prumernaObjednavka)}`;
+        prvky.summarySeats.textContent = formatCislo.format(souhrn.prodanaMista);
+        prvky.summaryOccupancy.textContent = `Průměrná obsazenost ${(souhrn.prumernaObsazenost ?? 0).toFixed(1)} %`;
+        prvky.summaryCustomers.textContent = formatCislo.format(souhrn.aktivniZakaznici);
+        prvky.summaryNewCustomers.textContent = `${formatCislo.format(souhrn.noviZakaznici)} nových zákazníků`;
+
+        const prumerDen = souhrn.delkaObdobiDni > 0 ? souhrn.celkoveTrzby / souhrn.delkaObdobiDni : 0;
+        prvky.salesAggregateLabel.textContent = `Denní průměr ${formatMena.format(prumerDen)}`;
+    }
+
+    function vytvořNeboAktualizujGraf(nazev, canvas, config) {
+        if (!canvas) {
+            return;
+        }
+        if (stav[nazev]) {
+            stav[nazev].data = config.data;
+            stav[nazev].options = config.options;
+            stav[nazev].update();
+        } else {
+            stav[nazev] = new Chart(canvas, config);
+        }
+    }
+
+    function aktualizujGrafTržeb(data) {
+        const body = data.trend ?? [];
+        const canvas = document.getElementById('salesTrendChart');
+        if (!canvas) {
+            return;
+        }
+
+        const labels = body.map(b => b.datum);
+        const objednavky = body.map(b => b.objednavky);
+        const tržby = body.map(b => b.trzba);
+        const průměr = body.map(b => b.prumernaObjednavka);
+
+        prvky.salesEmpty.hidden = body.length > 0;
+
+        const config = {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [
+                    {
+                        type: 'bar',
+                        label: 'Objednávky',
+                        data: objednavky,
+                        backgroundColor: 'rgba(13,110,253,0.4)',
+                        borderColor: 'rgba(13,110,253,1)',
+                        yAxisID: 'objednavky'
+                    },
+                    {
+                        type: 'line',
+                        label: 'Tržby',
+                        data: tržby,
+                        borderColor: 'rgba(25,135,84,1)',
+                        backgroundColor: 'rgba(25,135,84,0.2)',
+                        fill: true,
+                        tension: 0.3,
+                        yAxisID: 'trzby'
+                    },
+                    {
+                        type: 'line',
+                        label: 'Průměrná objednávka',
+                        data: průměr,
+                        borderColor: 'rgba(255,193,7,1)',
+                        backgroundColor: 'rgba(255,193,7,0.2)',
+                        borderDash: [6, 4],
+                        yAxisID: 'trzby'
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                interaction: {
+                    mode: 'index',
+                    intersect: false
+                },
+                scales: {
+                    objednavky: {
+                        type: 'linear',
+                        position: 'left',
+                        beginAtZero: true,
+                        grid: {
+                            drawOnChartArea: false
+                        }
+                    },
+                    trzby: {
+                        type: 'linear',
+                        position: 'right',
+                        beginAtZero: true,
+                        ticks: {
+                            callback: hodnota => formatMena.format(hodnota)
+                        }
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: context => {
+                                if (context.datasetIndex === 0) {
+                                    return `Objednávky: ${formatCislo.format(context.parsed.y)}`;
+                                }
+                                return `${context.dataset.label}: ${formatMena.format(context.parsed.y)}`;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        vytvořNeboAktualizujGraf("salesChart", canvas, config);
+    }
+
+    function aktualizujTopKurzy(data) {
+        const kurzy = data.topKurzy ?? [];
+        const canvas = document.getElementById('topCoursesChart');
+        if (!canvas) {
+            return;
+        }
+
+        const labels = kurzy.map(k => k.nazev);
+        const hodnoty = kurzy.map(k => k.trzba);
+
+        const config = {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [
+                    {
+                        label: 'Tržby',
+                        data: hodnoty,
+                        backgroundColor: 'rgba(102,16,242,0.5)',
+                        borderColor: 'rgba(102,16,242,1)',
+                        borderWidth: 1
+                    }
+                ]
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        ticks: {
+                            callback: hodnot => formatMena.format(hodnot)
+                        }
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: context => `${context.label}: ${formatMena.format(context.parsed.x)}`
+                        }
+                    }
+                }
+            }
+        };
+
+        vytvořNeboAktualizujGraf("topCoursesChart", canvas, config);
+
+        if (prvky.topCoursesTotal) {
+            const součet = hodnoty.reduce((sum, val) => sum + val, 0);
+            prvky.topCoursesTotal.textContent = kurzy.length > 0
+                ? `Součet tržeb ${formatMena.format(součet)}`
+                : 'Žádné kurzy nesplňují filtr';
+        }
+
+        if (prvky.topCoursesTable) {
+            smazatMožnosti(prvky.topCoursesTable);
+            if (kurzy.length === 0) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 3;
+                cell.classList.add('text-muted', 'text-center', 'py-3');
+                cell.textContent = konfigurace.texty.zadnaData;
+                row.appendChild(cell);
+                prvky.topCoursesTable.appendChild(row);
+            } else {
+                kurzy.forEach(kurz => {
+                    const row = document.createElement('tr');
+                    const název = document.createElement('td');
+                    název.textContent = kurz.nazev;
+                    const trzby = document.createElement('td');
+                    trzby.classList.add('text-end');
+                    trzby.textContent = formatMena.format(kurz.trzba);
+                    const množství = document.createElement('td');
+                    množství.classList.add('text-end');
+                    množství.textContent = formatCislo.format(kurz.mnozstvi);
+                    row.append(název, trzby, množství);
+                    prvky.topCoursesTable.appendChild(row);
+                });
+            }
+        }
+    }
+
+    function aktualizujKonverze(konverze) {
+        if (!konverze) {
+            return;
+        }
+
+        const canvas = document.getElementById('conversionChart');
+        if (!canvas) {
+            return;
+        }
+
+        const hodnoty = [konverze.navstevy, konverze.registrace, konverze.platby];
+        const popisky = ['Návštěvy', 'Registrace', 'Platby'];
+
+        const config = {
+            type: 'bar',
+            data: {
+                labels: popisky,
+                datasets: [
+                    {
+                        label: 'Počet',
+                        data: hodnoty,
+                        backgroundColor: [
+                            'rgba(13,110,253,0.6)',
+                            'rgba(255,193,7,0.6)',
+                            'rgba(25,135,84,0.6)'
+                        ],
+                        borderColor: [
+                            'rgba(13,110,253,1)',
+                            'rgba(255,193,7,1)',
+                            'rgba(25,135,84,1)'
+                        ],
+                        borderWidth: 1
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: true
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: context => `${context.label}: ${formatCislo.format(context.parsed.y)}`
+                        }
+                    }
+                }
+            }
+        };
+
+        vytvořNeboAktualizujGraf("conversionChart", canvas, config);
+
+        if (prvky.conversionRates) {
+            prvky.conversionRates.textContent = `Registrace z návštěv ${konverze.navstevyNaRegistraci.toFixed(1)} %, platby z registrací ${konverze.registraceNaPlatbu.toFixed(1)} %`;
+        }
+
+        if (prvky.conversionDetails) {
+            prvky.conversionDetails.innerHTML = '';
+            const položky = [
+                `Návštěvy: ${formatCislo.format(konverze.navstevy)}`,
+                `Registrace: ${formatCislo.format(konverze.registrace)} (${konverze.navstevyNaRegistraci.toFixed(1)} % z návštěv)`,
+                `Platby: ${formatCislo.format(konverze.platby)} (${konverze.navstevyNaPlatbu.toFixed(1)} % z návštěv)`
+            ];
+            položky.forEach(text => {
+                const li = document.createElement('li');
+                li.textContent = text;
+                prvky.conversionDetails.appendChild(li);
+            });
+        }
+    }
+
+    function barvaProObsazenost(podíl) {
+        const clamped = Math.max(0, Math.min(1, podíl));
+        const start = [13, 110, 253];
+        const end = [25, 135, 84];
+        const r = Math.round(start[0] + (end[0] - start[0]) * clamped);
+        const g = Math.round(start[1] + (end[1] - start[1]) * clamped);
+        const b = Math.round(start[2] + (end[2] - start[2]) * clamped);
+        const alfa = 0.35 + clamped * 0.45;
+        return `rgba(${r}, ${g}, ${b}, ${alfa.toFixed(2)})`;
+    }
+
+    function aktualizujHeatmapu(heatmap) {
+        const canvas = document.getElementById('heatmapChart');
+        if (!canvas) {
+            return;
+        }
+
+        const bunky = (heatmap && heatmap.bunky) ? heatmap.bunky : [];
+        prvky.heatmapEmpty.hidden = bunky.length > 0;
+
+        const dataBody = bunky.map(bunka => {
+            const obsazenost = bunka.obsazenost ?? 0;
+            return {
+                x: bunka.den,
+                y: bunka.hodina,
+                r: Math.max(4, Math.round(obsazenost * 18) + 4),
+                backgroundColor: barvaProObsazenost(obsazenost),
+                borderColor: barvaProObsazenost(obsazenost),
+                occupancy: obsazenost,
+                terms: bunka.pocetTerminu,
+                seats: bunka.obsazenaMista,
+                capacity: bunka.kapacitaCelkem
+            };
+        });
+
+        const config = {
+            type: 'bubble',
+            data: {
+                datasets: [
+                    {
+                        label: 'Obsazenost',
+                        data: dataBody,
+                        parsing: false,
+                        backgroundColor: context => context.raw.backgroundColor,
+                        borderColor: context => context.raw.borderColor,
+                        borderWidth: 1
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    x: {
+                        type: 'linear',
+                        min: -0.5,
+                        max: 6.5,
+                        ticks: {
+                            callback: hodnota => denniNazvy[((hodnota % 7) + 7) % 7]
+                        }
+                    },
+                    y: {
+                        type: 'linear',
+                        min: -0.5,
+                        max: 23.5,
+                        ticks: {
+                            stepSize: 2,
+                            callback: hodnota => `${Math.round(hodnota)}:00`
+                        }
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            title: context => {
+                                const den = denniNazvy[((context[0].raw.x % 7) + 7) % 7];
+                                const hodina = context[0].raw.y;
+                                return `${den}, ${hodina}:00`;
+                            },
+                            label: context => {
+                                const raw = context.raw;
+                                const procenta = (raw.occupancy * 100).toFixed(1);
+                                return [
+                                    `Obsazenost ${procenta} %`,
+                                    `Termíny: ${raw.terms}`,
+                                    `Obsazená místa: ${formatCislo.format(raw.seats)} / ${formatCislo.format(raw.capacity)}`
+                                ];
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        vytvořNeboAktualizujGraf("heatmapChart", canvas, config);
+    }
+
+    function nastavPředvolbu(range) {
+        const dny = parseInt(range, 10);
+        if (!Number.isFinite(dny)) {
+            return;
+        }
+
+        const konec = prvky.filterTo.value ? new Date(`${prvky.filterTo.value}T00:00:00`) : new Date();
+        const začátek = new Date(konec);
+        začátek.setDate(konec.getDate() - dny + 1);
+        prvky.filterFrom.value = začátek.toISOString().slice(0, 10);
+        prvky.filterTo.value = konec.toISOString().slice(0, 10);
+        načtiPřehled();
+    }
+
+    function inicializujPředvolby() {
+        prvky.presetButtons.forEach(tlačítko => {
+            tlačítko.addEventListener('click', () => nastavPředvolbu(tlačítko.dataset.range));
+        });
+    }
+
+    function aktualizujRealTime(data) {
+        if (!data) {
+            return;
+        }
+        prvky.realtimeUsers.textContent = formatCislo.format(data.onlineUzivatelu ?? 0);
+        prvky.realtimeCarts.textContent = formatCislo.format(data.aktivniKosiky ?? 0);
+        prvky.realtimeCartValue.textContent = formatMena.format(data.celkovaHodnota ?? 0);
+        const čas = data.vytvorenoUtc ? new Date(data.vytvorenoUtc) : new Date();
+        prvky.realtimeUpdated.textContent = `Aktualizováno ${čas.toLocaleTimeString('cs-CZ')}`;
+    }
+
+    function inicializujSignalR() {
+        if (!window.signalR || !konfigurace.api.hub) {
+            prvky.realtimeUpdated.textContent = 'SignalR není dostupný.';
+            return;
+        }
+
+        const připojení = new signalR.HubConnectionBuilder()
+            .withUrl(konfigurace.api.hub)
+            .withAutomaticReconnect()
+            .build();
+
+        připojení.onreconnected(() => {
+            prvky.realtimeUpdated.textContent = 'Znovu připojeno – načítám aktuální data…';
+            požádejOStatistiky();
+        });
+
+        připojení.onclose(() => {
+            prvky.realtimeUpdated.textContent = 'Odpojeno, čekám na opětovné připojení…';
+        });
+
+        async function požádejOStatistiky() {
+            try {
+                const data = await připojení.invoke('RequestRealtimeStats');
+                aktualizujRealTime(data);
+            } catch (chyba) {
+                console.error('Nepodařilo se získat real-time data', chyba);
+            }
+        }
+
+        připojení.start()
+            .then(() => {
+                prvky.realtimeUpdated.textContent = 'Připojeno k real-time streamu';
+                požádejOStatistiky();
+                stav.hubTimer = setInterval(požádejOStatistiky, 15000);
+            })
+            .catch(chyba => {
+                console.error('SignalR připojení selhalo', chyba);
+                prvky.realtimeUpdated.textContent = 'Nepodařilo se připojit k real-time streamu';
+            });
+
+        stav.hub = připojení;
+    }
+
+    function inicializujExport() {
+        if (!prvky.exportButton) {
+            return;
+        }
+        prvky.exportButton.addEventListener('click', () => {
+            if (!stav.posledniFiltry) {
+                return;
+            }
+            const url = sestavUrl(stav.posledniFiltry).replace(konfigurace.api.prehled, konfigurace.api.export);
+            const link = document.createElement('a');
+            link.href = url;
+            link.setAttribute('download', 'report.xlsx');
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+        });
+    }
+
+    function inicializujFormulář() {
+        if (prvky.filterForm) {
+            prvky.filterForm.addEventListener('submit', načtiPřehled);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        inicializujFormulář();
+        inicializujPředvolby();
+        inicializujExport();
+        načtiFiltry();
+        inicializujSignalR();
+    });
+})();


### PR DESCRIPTION
## Summary
- přepracovat admin dashboard s filtry podle období, norem a měst včetně nových grafů a real-time panelu
- přidat API AnalyticsController pro grafy, export do Excelu a agregovaná data
- doplnit SignalR hub a klientský skript pro online uživatele, košíky a vizualizace pomocí Chart.js

## Testing
- dotnet build *(neprovedeno – dotnet není v prostředí dostupný)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0a08c69883219a857275776dc4c0