### PR TITLE
Fix Razor compile errors

### DIFF
--- a/Pages/Api/Chatbot.cshtml
+++ b/Pages/Api/Chatbot.cshtml
@@ -1,4 +1,3 @@
-@page
 @page "{handler?}"
 @model SysJaky_N.Pages.Api.ChatbotModel
 @{

--- a/Pages/Api/Newsletter.cshtml
+++ b/Pages/Api/Newsletter.cshtml
@@ -1,4 +1,3 @@
-@page
 @page "{handler?}"
 @model SysJaky_N.Pages.Api.NewsletterModel
 @{

--- a/Pages/CorporateInquiry.cshtml
+++ b/Pages/CorporateInquiry.cshtml
@@ -490,7 +490,7 @@
             }
 
             function isValidEmail(value) {
-                return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+                return /^[^\s@@]+@@[^\s@@]+\.[^\s@@]+$/.test(value);
             }
 
             function isValidPhone(value) {

--- a/Pages/CorporateInquiry/Partials/_StepDetails.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepDetails.cshtml
@@ -22,7 +22,7 @@
         <option value="">@Localizer["ModePlaceholder"]</option>
         @foreach (var option in Model.ModeOptions)
         {
-            <option value="@option" @(Model.Input.Mode == option ? "selected" : null)>@Localizer[$"ModeOption_{option}"]</option>
+            <option value="@option" selected="@(Model.Input.Mode == option ? "selected" : null)">@Localizer[$"ModeOption_{option}"]</option>
         }
     </select>
     <span asp-validation-for="Input.Mode" class="invalid-feedback"></span>

--- a/Pages/StyleGuide/Index.cshtml
+++ b/Pages/StyleGuide/Index.cshtml
@@ -1,4 +1,5 @@
 @page "/StyleGuide"
+@using Microsoft.AspNetCore.Authorization
 @using SysJaky_N.Authorization
 @attribute [Authorize(Policy = AuthorizationPolicies.AdminOnly)]
 @{

--- a/Services/ICacheService.cs
+++ b/Services/ICacheService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using SysJaky_N.Extensions;
 using SysJaky_N.Models;
 
 namespace SysJaky_N.Services;


### PR DESCRIPTION
## Summary
- add the missing authorization namespace to the style guide page so the Authorize attribute resolves
- import the CourseTermSnapshot namespace in the cache service and correct Razor option markup
- clean up duplicated page directives and escape characters that broke the corporate inquiry script

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd0eadd04c8321be3285a9142abf59