### PR TITLE
Add client-side theme switcher for dark mode

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -12,6 +12,10 @@
     var canAccessAdmin = ApplicationRoles.AdminDashboardRoles.Any(role => User.IsInRole(role));
     var returnUrl = string.Concat(Context.Request.Path, Context.Request.QueryString);
     var pushPublicKey = Configuration["PushNotifications:PublicKey"] ?? string.Empty;
+    var toggleThemeLabel = Localizer["ToggleTheme"];
+    var themeToggleText = toggleThemeLabel.ResourceNotFound
+        ? (currentCulture.TwoLetterISOLanguageName == "cs" ? "Přepnout vzhled" : "Toggle theme")
+        : toggleThemeLabel.Value;
 }
 <!DOCTYPE html>
 <html lang="@currentCulture.TwoLetterISOLanguageName">
@@ -77,6 +81,15 @@
                                 </a>
                             </li>
                         }
+                        <li class="nav-item">
+                            <button type="button" class="btn btn-outline-light d-flex align-items-center justify-content-center gap-2 theme-toggle"
+                                    data-theme-toggle aria-pressed="false" aria-label='@themeToggleText'
+                                    title='@themeToggleText'>
+                                <i class="bi bi-sun-fill" data-theme-icon="light" aria-hidden="true"></i>
+                                <i class="bi bi-moon-stars-fill d-none" data-theme-icon="dark" aria-hidden="true"></i>
+                                <span class="visually-hidden">@themeToggleText</span>
+                            </button>
+                        </li>
                         <li class="nav-item">
                             <a class="btn btn-outline-light ms-2" data-bs-toggle="offcanvas" href="#advisor" role="button" aria-controls="advisor" aria-haspopup="dialog">
                                 <i class="bi bi-magic"></i> @Localizer["AdvisorButton"]
@@ -180,6 +193,7 @@
     <script src="~/js/pwa.js" asp-append-version="true" defer></script>
     <script src="~/js/newsletter.js" asp-append-version="true" defer></script>
     <script src="~/js/chatbot.js" asp-append-version="true" defer></script>
+    <script type="module" src="~/js/theme-switcher.js" asp-append-version="true"></script>
 
     @await Html.PartialAsync("/Pages/Shared/_AdvisorOffcanvas.cshtml")
 

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -41,6 +41,26 @@ html {
   --bs-link-hover-color: var(--primary-dark);
 }
 
+[data-theme="dark"] {
+  color-scheme: dark;
+  --primary: #3db9e5;
+  --primary-dark: #5dc4ed;
+  --primary-light: #6dd0f1;
+  --primary-600: #2c90ba;
+  --primary-50: #0f172a;
+  --neutral-900: #e2e8f0;
+  --neutral-700: #cbd5e1;
+  --neutral-500: #94a3b8;
+  --neutral-300: #334155;
+  --neutral-200: #1e293b;
+  --neutral-100: #0f172a;
+  --neutral-50: #020617;
+  --neutral-400: #64748b;
+  --accent: #fbbf24;
+  --accent-dark: #f59e0b;
+  /* Další barvy... */
+}
+
 html {
   position: relative;
   min-height: 100%;
@@ -156,6 +176,29 @@ button:focus-visible {
 .app-navbar {
   background: linear-gradient(120deg, var(--primary) 0%, var(--primary-dark) 55%, var(--primary-light) 100%);
   padding-block: 1rem;
+}
+
+.theme-toggle {
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  border-radius: 999px;
+  padding: 0.5rem;
+}
+
+.theme-toggle i {
+  font-size: 1.1rem;
+}
+
+[data-theme="dark"] .theme-toggle {
+  border-color: rgba(148, 163, 184, 0.7);
+  color: var(--neutral-900);
+  background-color: rgba(30, 41, 59, 0.6);
+}
+
+[data-theme="dark"] .theme-toggle:hover,
+[data-theme="dark"] .theme-toggle:focus-visible {
+  background-color: rgba(51, 65, 85, 0.8);
+  color: var(--neutral-900);
 }
 
 .chatbot {

--- a/wwwroot/js/theme-switcher.js
+++ b/wwwroot/js/theme-switcher.js
@@ -1,0 +1,108 @@
+const STORAGE_KEY = 'theme-preference';
+const THEMES = {
+    LIGHT: 'light',
+    DARK: 'dark'
+};
+
+const DARK_META_COLOR = '#0f172a';
+const LIGHT_META_COLOR = '#0b7bb3';
+
+function getStoredPreference() {
+    try {
+        return localStorage.getItem(STORAGE_KEY);
+    } catch (error) {
+        return null;
+    }
+}
+
+function storePreference(theme) {
+    try {
+        localStorage.setItem(STORAGE_KEY, theme);
+    } catch (error) {
+        // Ignore storage errors (e.g., private browsing modes).
+    }
+}
+
+function getSystemPreference() {
+    if (typeof window.matchMedia !== 'function') {
+        return THEMES.LIGHT;
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? THEMES.DARK : THEMES.LIGHT;
+}
+
+function updateMetaThemeColor(theme) {
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
+
+    if (!metaThemeColor) {
+        return;
+    }
+
+    metaThemeColor.setAttribute('content', theme === THEMES.DARK ? DARK_META_COLOR : LIGHT_META_COLOR);
+}
+
+function toggleIcons(button, theme) {
+    if (!button) {
+        return;
+    }
+
+    button.setAttribute('aria-pressed', theme === THEMES.DARK ? 'true' : 'false');
+
+    const icons = button.querySelectorAll('[data-theme-icon]');
+    icons.forEach((icon) => {
+        const isDarkIcon = icon.getAttribute('data-theme-icon') === THEMES.DARK;
+        icon.classList.toggle('d-none', theme === THEMES.DARK ? !isDarkIcon : isDarkIcon);
+    });
+}
+
+function reflectTheme(theme) {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', theme);
+    updateMetaThemeColor(theme);
+    toggleIcons(document.querySelector('[data-theme-toggle]'), theme);
+}
+
+export function initThemeSwitcher() {
+    let storedPreference = getStoredPreference();
+    const mediaQueryList = typeof window.matchMedia === 'function'
+        ? window.matchMedia('(prefers-color-scheme: dark)')
+        : null;
+    const initialTheme = storedPreference ?? getSystemPreference();
+
+    reflectTheme(initialTheme);
+
+    const toggleButton = document.querySelector('[data-theme-toggle]');
+
+    if (toggleButton) {
+        toggleButton.addEventListener('click', () => {
+            const currentTheme = document.documentElement.getAttribute('data-theme') === THEMES.DARK ? THEMES.DARK : THEMES.LIGHT;
+            const nextTheme = currentTheme === THEMES.DARK ? THEMES.LIGHT : THEMES.DARK;
+
+            reflectTheme(nextTheme);
+            storePreference(nextTheme);
+            storedPreference = nextTheme;
+        });
+    }
+
+    if (mediaQueryList) {
+        const systemPreferenceListener = (event) => {
+            if (storedPreference) {
+                return;
+            }
+
+            reflectTheme(event.matches ? THEMES.DARK : THEMES.LIGHT);
+        };
+
+        if (typeof mediaQueryList.addEventListener === 'function') {
+            mediaQueryList.addEventListener('change', systemPreferenceListener);
+        } else if (typeof mediaQueryList.addListener === 'function') {
+            mediaQueryList.addListener(systemPreferenceListener);
+        }
+    }
+}
+
+reflectTheme(getStoredPreference() ?? getSystemPreference());
+
+initThemeSwitcher();
+
+export default initThemeSwitcher;


### PR DESCRIPTION
## Summary
- add a dedicated theme toggle button to the public layout with localized labelling
- implement a theme-switcher module that respects stored preferences and system dark mode while updating meta colors
- extend the site palette and component styles to support a dark theme without affecting the admin dashboard

## Testing
- not run (environment missing `dotnet` CLI)


------
https://chatgpt.com/codex/tasks/task_e_68dd1f79c8148321aa8243e4b0007661