### PR TITLE
Add responsive WebP image handling and extend HTTP/2 push

### DIFF
--- a/Extensions/ImageUrlExtensions.cs
+++ b/Extensions/ImageUrlExtensions.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Text;
+
+namespace SysJaky_N.Extensions;
+
+public static class ImageUrlExtensions
+{
+    public static string WithImageParameters(this string? url, int? width = null, string? format = null)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        if (IsExternalUrl(url) || (width is null && string.IsNullOrWhiteSpace(format)))
+        {
+            return url;
+        }
+
+        var builder = new StringBuilder(url);
+        var hasQuery = url.Contains('?', StringComparison.Ordinal);
+        var appended = false;
+
+        if (width.HasValue && !ContainsQueryKey(url, "w"))
+        {
+            builder.Append(hasQuery ? '&' : '?');
+            builder.Append("w=");
+            builder.Append(width.Value);
+            hasQuery = true;
+            appended = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(format) && !ContainsQueryKey(url, "format"))
+        {
+            builder.Append(hasQuery ? '&' : '?');
+            builder.Append("format=");
+            builder.Append(format);
+            appended = true;
+        }
+
+        return appended ? builder.ToString() : url;
+    }
+
+    private static bool ContainsQueryKey(string url, string key)
+    {
+        return url.Contains($"?{key}=", StringComparison.OrdinalIgnoreCase)
+               || url.Contains($"&{key}=", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsExternalUrl(string url)
+    {
+        if (url.StartsWith("//", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return Uri.TryCreate(url, UriKind.Absolute, out var absolute)
+               && absolute.Scheme is "http" or "https";
+    }
+}

--- a/Pages/Shared/_TestimonialsCarousel.cshtml
+++ b/Pages/Shared/_TestimonialsCarousel.cshtml
@@ -33,7 +33,34 @@
                                 <div class="col-md-4 text-center text-md-start">
                                     @if (!string.IsNullOrWhiteSpace(testimonial.PhotoUrl))
                                     {
-                                        <img src="@testimonial.PhotoUrl" alt="@(!string.IsNullOrWhiteSpace(testimonial.PhotoAltText) ? testimonial.PhotoAltText : testimonial.FullName)" class="rounded-circle shadow-sm" style="width: 120px; height: 120px; object-fit: cover;" />
+                                        var avatarAlt = !string.IsNullOrWhiteSpace(testimonial.PhotoAltText)
+                                            ? testimonial.PhotoAltText
+                                            : testimonial.FullName;
+                                        var avatarWebp1x = testimonial.PhotoUrl.WithImageParameters(120, "webp");
+                                        var avatarWebp2x = testimonial.PhotoUrl.WithImageParameters(240, "webp");
+                                        var avatarJpeg1x = testimonial.PhotoUrl.WithImageParameters(120, "jpg");
+                                        var avatarJpeg2x = testimonial.PhotoUrl.WithImageParameters(240, "jpg");
+                                        var jpegSources = new List<string>();
+                                        if (!string.IsNullOrWhiteSpace(avatarJpeg1x))
+                                        {
+                                            jpegSources.Add($"{avatarJpeg1x} 120w");
+                                        }
+                                        if (!string.IsNullOrWhiteSpace(avatarJpeg2x))
+                                        {
+                                            jpegSources.Add($"{avatarJpeg2x} 240w");
+                                        }
+                                        var jpegSrcSet = string.Join(", ", jpegSources);
+                                        <picture>
+                                            @if (!string.IsNullOrWhiteSpace(avatarWebp1x))
+                                            {
+                                                <source type="image/webp" srcset="@avatarWebp1x 120w@(string.IsNullOrWhiteSpace(avatarWebp2x) ? string.Empty : ", " + avatarWebp2x + " 240w")" sizes="120px" />
+                                            }
+                                            @if (!string.IsNullOrWhiteSpace(jpegSrcSet))
+                                            {
+                                                <source type="image/jpeg" srcset="@jpegSrcSet" sizes="120px" />
+                                            }
+                                            <img src="@(!string.IsNullOrWhiteSpace(avatarJpeg1x) ? avatarJpeg1x : testimonial.PhotoUrl)" alt="@avatarAlt" class="rounded-circle shadow-sm" width="120" height="120" loading="lazy" decoding="async" style="width: 120px; height: 120px; object-fit: cover;" />
+                                        </picture>
                                     }
                                     else
                                     {

--- a/Pages/Testimonials/Index.cshtml
+++ b/Pages/Testimonials/Index.cshtml
@@ -24,7 +24,34 @@
                         <div class="d-flex align-items-center gap-3 mb-3">
                             @if (!string.IsNullOrWhiteSpace(testimonial.PhotoUrl))
                             {
-                                <img src="@testimonial.PhotoUrl" alt="@(!string.IsNullOrWhiteSpace(testimonial.PhotoAltText) ? testimonial.PhotoAltText : testimonial.FullName)" class="rounded-circle" style="width: 64px; height: 64px; object-fit: cover;" />
+                                var thumbAlt = !string.IsNullOrWhiteSpace(testimonial.PhotoAltText)
+                                    ? testimonial.PhotoAltText
+                                    : testimonial.FullName;
+                                var thumbWebp1x = testimonial.PhotoUrl.WithImageParameters(64, "webp");
+                                var thumbWebp2x = testimonial.PhotoUrl.WithImageParameters(128, "webp");
+                                var thumbJpeg1x = testimonial.PhotoUrl.WithImageParameters(64, "jpg");
+                                var thumbJpeg2x = testimonial.PhotoUrl.WithImageParameters(128, "jpg");
+                                var thumbJpegSources = new List<string>();
+                                if (!string.IsNullOrWhiteSpace(thumbJpeg1x))
+                                {
+                                    thumbJpegSources.Add($"{thumbJpeg1x} 64w");
+                                }
+                                if (!string.IsNullOrWhiteSpace(thumbJpeg2x))
+                                {
+                                    thumbJpegSources.Add($"{thumbJpeg2x} 128w");
+                                }
+                                var thumbJpegSrcSet = string.Join(", ", thumbJpegSources);
+                                <picture>
+                                    @if (!string.IsNullOrWhiteSpace(thumbWebp1x))
+                                    {
+                                        <source type="image/webp" srcset="@thumbWebp1x 64w@(string.IsNullOrWhiteSpace(thumbWebp2x) ? string.Empty : ", " + thumbWebp2x + " 128w")" sizes="64px" />
+                                    }
+                                    @if (!string.IsNullOrWhiteSpace(thumbJpegSrcSet))
+                                    {
+                                        <source type="image/jpeg" srcset="@thumbJpegSrcSet" sizes="64px" />
+                                    }
+                                    <img src="@(!string.IsNullOrWhiteSpace(thumbJpeg1x) ? thumbJpeg1x : testimonial.PhotoUrl)" alt="@thumbAlt" class="rounded-circle" width="64" height="64" loading="lazy" decoding="async" style="width: 64px; height: 64px; object-fit: cover;" />
+                                </picture>
                             }
                             else
                             {

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -2,6 +2,8 @@
 @using SysJaky_N.Models
 @using SysJaky_N.Models.ViewModels
 @using SysJaky_N.Pages.Account
+@using SysJaky_N.Extensions
+@using System.Collections.Generic
 @namespace SysJaky_N.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, SysJaky_N

--- a/Program.cs
+++ b/Program.cs
@@ -328,16 +328,25 @@ try
             && context.Request.Headers.TryGetValue(HeaderNames.Accept, out var accepted)
             && accepted.Any(value => value.Contains("text/html", StringComparison.OrdinalIgnoreCase)))
         {
-            try
+            var assetsToPush = new (string Path, string Accept)[]
             {
-                pushFeature.PushPromise("/dist/styles.min.css", new HeaderDictionary
+                ("/dist/styles.min.css", "text/css,*/*;q=0.1"),
+                ("/dist/scripts.min.js", "application/javascript,*/*;q=0.1")
+            };
+
+            foreach (var asset in assetsToPush)
+            {
+                try
                 {
-                    [HeaderNames.Accept] = "text/css,*/*;q=0.1"
-                });
-            }
-            catch (Exception ex)
-            {
-                Log.Logger.Debug(ex, "HTTP/2 push failed");
+                    pushFeature.PushPromise(asset.Path, new HeaderDictionary
+                    {
+                        [HeaderNames.Accept] = asset.Accept
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Debug(ex, "HTTP/2 push failed for {Asset}", asset.Path);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add reusable helper for appending width/format parameters to local image URLs
- serve testimonial avatars and dynamic course thumbnails through picture tags with WebP/srcset fallbacks
- push bundled CSS and JS during HTTP/2 navigation for faster first paints

## Testing
- ❌ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1f8651208321993dd7d89532f6a5