### PR TITLE
Refresh homepage hero content for ISO training

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -7,8 +7,28 @@
 
 <section class="py-5 gradient-hero text-white text-center rounded-4 mb-4 hero-section">
     <div class="container-xl position-relative">
-        <h1 class="display-5 fw-bold mb-2">@Localizer["HeroHeadingPrefix"] <span class="underline-accent"><span class="typewriter" data-typewriter-text="@Localizer["HeroHeadingAccent"]">@Localizer["HeroHeadingAccent"]</span></span></h1>
-        <p class="lead mb-4 opacity-75">@Localizer["HeroSubheading"]</p>
+        <h1 class="display-5 fw-bold mb-3">@Localizer["HeroMainHeading"]</h1>
+        <p class="lead mb-4 opacity-75 mx-auto" style="max-width: 56rem;">@Localizer["HeroSubheading"]</p>
+
+        <ul class="list-unstyled d-flex flex-column flex-lg-row justify-content-center align-items-lg-center gap-3 mb-4">
+            <li class="d-flex align-items-center gap-2">
+                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-patch-check-fill"></i></span>
+                <span class="fw-semibold">@Localizer["HeroUSP1"]</span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-award-fill"></i></span>
+                <span class="fw-semibold">@Localizer["HeroUSP2"]</span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-people-fill"></i></span>
+                <span class="fw-semibold">@Localizer["HeroUSP3"]</span>
+            </li>
+        </ul>
+
+        <div class="d-flex flex-column flex-sm-row justify-content-center gap-2 mb-4">
+            <a href="/Courses/Index" class="btn btn-light fw-semibold px-4">@Localizer["HeroPrimaryCTA"]</a>
+            <a href="/CorporateInquiry" class="btn btn-outline-light fw-semibold px-4">@Localizer["HeroSecondaryCTA"]</a>
+        </div>
 
         <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm" role="search" aria-label="@Localizer["HeroSearchAriaLabel"]">
             <div class="col-12 col-md-3">

--- a/Resources/Pages.Index.cshtml.en.resx
+++ b/Resources/Pages.Index.cshtml.en.resx
@@ -18,11 +18,8 @@
   <data name="HeroDescription" xml:space="preserve">
     <value>Professional courses and training for your company.</value>
   </data>
-  <data name="HeroHeadingAccent" xml:space="preserve">
-    <value>match your goals</value>
-  </data>
-  <data name="HeroHeadingPrefix" xml:space="preserve">
-    <value>Find training that will</value>
+  <data name="HeroMainHeading" xml:space="preserve">
+    <value>ISO training, courses and certifications for your organization</value>
   </data>
   <data name="HeroSearchPlaceholder" xml:space="preserve">
     <value>Search for a course, tool, or skill…</value>
@@ -34,10 +31,25 @@
     <value>Search</value>
   </data>
   <data name="HeroSubheading" xml:space="preserve">
-    <value>Pick your role and goal — we will narrow the list for you. Or just start searching.</value>
+    <value>Comprehensive preparation for certification and accreditation according to ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 and ISO 13485</value>
   </data>
   <data name="HeroSubmit" xml:space="preserve">
     <value>Suggest courses</value>
+  </data>
+  <data name="HeroPrimaryCTA" xml:space="preserve">
+    <value>View all courses</value>
+  </data>
+  <data name="HeroSecondaryCTA" xml:space="preserve">
+    <value>Request in-company training</value>
+  </data>
+  <data name="HeroUSP1" xml:space="preserve">
+    <value>20+ years of experience in management systems</value>
+  </data>
+  <data name="HeroUSP2" xml:space="preserve">
+    <value>Certified courses with recognized credentials</value>
+  </data>
+  <data name="HeroUSP3" xml:space="preserve">
+    <value>Training on-site, online or directly at your company</value>
   </data>
   <data name="HowItWorksTitle" xml:space="preserve">
     <value>How it works</value>

--- a/Resources/Pages.Index.cshtml.resx
+++ b/Resources/Pages.Index.cshtml.resx
@@ -18,11 +18,8 @@
   <data name="HeroDescription" xml:space="preserve">
     <value>Profesionální kurzy a školení pro vaši firmu.</value>
   </data>
-  <data name="HeroHeadingAccent" xml:space="preserve">
-    <value>sedne vašemu cíli</value>
-  </data>
-  <data name="HeroHeadingPrefix" xml:space="preserve">
-    <value>Najděte školení, které</value>
+  <data name="HeroMainHeading" xml:space="preserve">
+    <value>Školení, kurzy a certifikace ISO pro vaši organizaci</value>
   </data>
   <data name="HeroSearchPlaceholder" xml:space="preserve">
     <value>Hledat kurz, nástroj nebo dovednost…</value>
@@ -34,10 +31,25 @@
     <value>Vyhledávání</value>
   </data>
   <data name="HeroSubheading" xml:space="preserve">
-    <value>Vyberte roli a cíl – my zúžíme výběr. Nebo rovnou hledejte.</value>
+    <value>Komplexní příprava k certifikaci a akreditaci podle ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485</value>
   </data>
   <data name="HeroSubmit" xml:space="preserve">
     <value>Navrhnout kurzy</value>
+  </data>
+  <data name="HeroPrimaryCTA" xml:space="preserve">
+    <value>Zobrazit všechny kurzy</value>
+  </data>
+  <data name="HeroSecondaryCTA" xml:space="preserve">
+    <value>Poptávka na firemní školení</value>
+  </data>
+  <data name="HeroUSP1" xml:space="preserve">
+    <value>20+ let zkušeností v oblasti systémů managementu</value>
+  </data>
+  <data name="HeroUSP2" xml:space="preserve">
+    <value>Certifikované kurzy s uznávanými osvědčeními</value>
+  </data>
+  <data name="HeroUSP3" xml:space="preserve">
+    <value>Školení prezenčně, online i ve vaší firmě</value>
   </data>
   <data name="HowItWorksTitle" xml:space="preserve">
     <value>Jak to funguje</value>


### PR DESCRIPTION
## Summary
- update the homepage hero to highlight ISO-focused headline, subheading, USP points, and CTA buttons
- provide Czech and English localizations for the new hero content

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd29b912a0832195ba97c3491796d0