### PR TITLE
Add about page with responsive overview and nav link

### DIFF
--- a/Pages/About.cshtml
+++ b/Pages/About.cshtml
@@ -1,0 +1,155 @@
+@page
+@{
+    ViewData["Title"] = "O společnosti";
+}
+
+<section class="py-5">
+    <div class="text-center mb-5">
+        <span class="text-uppercase text-primary fw-semibold">O SPOLEČNOSTI SYSTÉMY JAKOSTI S.R.O.</span>
+        <h1 class="display-5 fw-bold mt-3">O SPOLEČNOSTI SYSTÉMY JAKOSTI S.R.O.</h1>
+        <p class="lead text-muted">Naše služby pomáhají organizacím růst, splňovat legislativní požadavky a rozvíjet kompetence zaměstnanců.</p>
+    </div>
+
+    <div class="row g-4 align-items-stretch">
+        <div class="col-12 col-lg-6">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body p-4 p-lg-5">
+                    <div class="d-flex align-items-center gap-3 mb-4">
+                        <div class="icon-circle bg-primary-subtle text-primary">
+                            <i class="bi bi-bullseye fs-3" aria-hidden="true"></i>
+                        </div>
+                        <h2 class="h4 mb-0">Naše mise</h2>
+                    </div>
+                    <p class="mb-0">
+                        Poskytování komplexních a odborných služeb v oblasti poradenství a vzdělávání, které pomáhají klientům
+                        při zvyšování konkurenceschopnosti, plnění právních předpisů a zvyšování odborných znalostí zaměstnanců.
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-12 col-lg-6">
+            <div class="card h-100 shadow-sm border-0">
+                <div class="card-body p-4 p-lg-5">
+                    <div class="d-flex align-items-center gap-3 mb-4">
+                        <div class="icon-circle bg-primary-subtle text-primary">
+                            <i class="bi bi-people-fill fs-3" aria-hidden="true"></i>
+                        </div>
+                        <h2 class="h4 mb-0">Služby</h2>
+                    </div>
+                    <ul class="list-unstyled mb-0 d-grid gap-2">
+                        <li class="d-flex align-items-start gap-2">
+                            <i class="bi bi-check-circle-fill text-success mt-1" aria-hidden="true"></i>
+                            <span>Příprava organizací k certifikaci podle ISO norem</span>
+                        </li>
+                        <li class="d-flex align-items-start gap-2">
+                            <i class="bi bi-check-circle-fill text-success mt-1" aria-hidden="true"></i>
+                            <span>Příprava laboratoří k akreditaci (ISO/IEC 17025, ISO 15189)</span>
+                        </li>
+                        <li class="d-flex align-items-start gap-2">
+                            <i class="bi bi-check-circle-fill text-success mt-1" aria-hidden="true"></i>
+                            <span>Odborná školení a kurzy pro management i operativu</span>
+                        </li>
+                        <li class="d-flex align-items-start gap-2">
+                            <i class="bi bi-check-circle-fill text-success mt-1" aria-hidden="true"></i>
+                            <span>Interní audity a pre-audity před certifikací</span>
+                        </li>
+                        <li class="d-flex align-items-start gap-2">
+                            <i class="bi bi-check-circle-fill text-success mt-1" aria-hidden="true"></i>
+                            <span>Firemní školení na míru</span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5 bg-light rounded-4">
+    <div class="container py-4">
+        <div class="text-center mb-4">
+            <div class="d-inline-flex align-items-center gap-2 px-3 py-1 bg-white shadow-sm rounded-pill">
+                <i class="bi bi-stars text-warning" aria-hidden="true"></i>
+                <span class="fw-semibold text-uppercase small">Oblasti expertise</span>
+            </div>
+            <h2 class="mt-3">Široké portfolio odborností</h2>
+            <p class="text-muted mb-0">Pomáháme s certifikacemi a akreditacemi napříč klíčovými normami a průmyslovými odvětvími.</p>
+        </div>
+
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4">
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-patch-check-fill text-primary fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO 9001</h3>
+                    <p class="text-muted mb-0">Systémy managementu kvality</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-globe-europe-africa text-success fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO 14001</h3>
+                    <p class="text-muted mb-0">Environmentální management</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-flask text-info fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO/IEC 17025</h3>
+                    <p class="text-muted mb-0">Akreditace zkušebních laboratoří</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-hospital text-danger fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO 15189</h3>
+                    <p class="text-muted mb-0">Akreditace zdravotnických laboratoří</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-shield-check text-warning fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">HACCP</h3>
+                    <p class="text-muted mb-0">Bezpečnost potravin</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-exclamation-triangle-fill text-secondary fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO 45001</h3>
+                    <p class="text-muted mb-0">Bezpečnost a ochrana zdraví při práci</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-shield-lock-fill text-primary fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO 27001</h3>
+                    <p class="text-muted mb-0">Informační bezpečnost</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-gear-wide-connected text-dark fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">IATF 16949</h3>
+                    <p class="text-muted mb-0">Automobilový průmysl</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-heart-pulse-fill text-danger fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">ISO 13485</h3>
+                    <p class="text-muted mb-0">Zdravotnické prostředky</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<style>
+    .icon-circle {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+</style>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -59,6 +59,9 @@
                             <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">@Localizer["NavHome"]</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@Localizer["NavAbout"]</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@Localizer["NavCourses"]</a>
                         </li>
                         <li class="nav-item">

--- a/Resources/Pages.Shared._Layout.cshtml.en.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.en.resx
@@ -24,6 +24,9 @@
   <data name="NavHome" xml:space="preserve">
     <value>Home</value>
   </data>
+  <data name="NavAbout" xml:space="preserve">
+    <value>About</value>
+  </data>
   <data name="NavCourses" xml:space="preserve">
     <value>Courses &amp; Training</value>
   </data>

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -24,6 +24,9 @@
   <data name="NavHome" xml:space="preserve">
     <value>Domů</value>
   </data>
+  <data name="NavAbout" xml:space="preserve">
+    <value>O společnosti</value>
+  </data>
   <data name="NavCourses" xml:space="preserve">
     <value>Kurzy a školení</value>
   </data>


### PR DESCRIPTION
## Summary
- add a new About page that presents the company mission, services, and expertise in a responsive card layout with icons
- expose the About page through the primary navigation and localize the new menu label in Czech and English

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd29ca44a48321b67cd7e452294753