### PR TITLE
Add searchable FAQ accordion component

### DIFF
--- a/Pages/Shared/_FAQ.cshtml
+++ b/Pages/Shared/_FAQ.cshtml
@@ -1,0 +1,215 @@
+@{
+    var faqId = $"faq-{Guid.NewGuid():N}";
+    var accordionId = $"{faqId}-accordion";
+    var searchInputId = $"{faqId}-search";
+    var searchIconId = $"{faqId}-search-icon";
+}
+
+<section class="faq" data-faq data-faq-id="@faqId">
+    <header class="faq-header">
+        <h2 class="faq-title">Nejčastější dotazy</h2>
+        <p class="faq-subtitle">Najděte odpovědi na nejčastější otázky k přípravě na certifikaci, školením i samotnému auditu.</p>
+        <div class="faq-search">
+            <label class="form-label" for="@searchInputId">Vyhledat dotaz</label>
+            <div class="input-group">
+                <span class="input-group-text" id="@searchIconId"><i class="bi bi-search"></i></span>
+                <input id="@searchInputId" class="form-control" type="search" placeholder="Začněte psát dotaz..." aria-describedby="@searchIconId" autocomplete="off" data-faq-search />
+            </div>
+        </div>
+    </header>
+
+    <div class="faq-categories" role="tablist" aria-label="Kategorie otázek">
+        <button type="button" class="faq-category active" data-faq-category="all">Vše</button>
+        <button type="button" class="faq-category" data-faq-category="general">Obecné otázky</button>
+        <button type="button" class="faq-category" data-faq-category="training">Školení</button>
+        <button type="button" class="faq-category" data-faq-category="certification">Certifikace</button>
+    </div>
+
+    <p class="faq-empty-message" aria-live="polite" hidden data-faq-empty>
+        Nenašli jsme žádný dotaz, který by odpovídal vašemu vyhledávání.
+    </p>
+
+    <div class="accordion faq-accordion" id="@accordionId">
+        <div class="accordion-item" data-faq-item data-faq-category="general">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-general-1")">
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-general-1")" aria-expanded="true" aria-controls="@($"{faqId}-collapse-general-1")">
+                    Jak dlouho trvá příprava k certifikaci?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-general-1")" class="accordion-collapse collapse show" aria-labelledby="@($"{faqId}-heading-general-1")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Záleží na velikosti organizace a současném stavu. Obvykle 3-12 měsíců. Kontaktujte nás pro odhad.
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="general">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-general-2")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-general-2")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-general-2")">
+                    Kolik stojí certifikace ISO?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-general-2")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-general-2")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Náklady zahrnují: školení (15-50 tis. Kč), poradenství (dle rozsahu), certifikační audit (30-100 tis. Kč dle velikosti firmy).
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="general">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-general-3")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-general-3")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-general-3")">
+                    Potřebujeme externí poradce?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-general-3")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-general-3")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Není povinné, ale výrazně to urychlí proces a zvýší šanci na úspěch v prvním auditu.
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="training">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-training-1")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-training-1")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-training-1")">
+                    Jaký je rozdíl mezi osvědčením a certifikátem?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-training-1")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-training-1")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Osvědčení potvrzuje účast na kurzu. Certifikát získáte po úspěšném složení závěrečné zkoušky.
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="training">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-training-2")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-training-2")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-training-2")">
+                    Jsou vaše kurzy akreditované?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-training-2")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-training-2")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Ano, naše kurzy splňují požadavky certifikačních orgánů a jsou uznávané v ČR i zahraničí.
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="training">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-training-3")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-training-3")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-training-3")">
+                    Můžeme absolvovat školení ve firmě?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-training-3")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-training-3")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Ano, připravíme program na míru od 4 účastníků.
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="certification">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-certification-1")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-certification-1")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-certification-1")">
+                    Kdo provádí certifikační audit?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-certification-1")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-certification-1")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Nezávislý certifikační orgán akreditovaný ČIA (např. TÜV, Bureau Veritas, LRQA).
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="certification">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-certification-2")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-certification-2")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-certification-2")">
+                    Jak často probíhají dozorové audity?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-certification-2")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-certification-2")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Obvykle 1x ročně po dobu 3 let platnosti certifikátu.
+                </div>
+            </div>
+        </div>
+
+        <div class="accordion-item" data-faq-item data-faq-category="certification">
+            <h3 class="accordion-header" id="@($"{faqId}-heading-certification-3")">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-certification-3")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-certification-3")">
+                    Co když v auditu najdou neshody?
+                </button>
+            </h3>
+            <div id="@($"{faqId}-collapse-certification-3")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-certification-3")" data-bs-parent="#@accordionId">
+                <div class="accordion-body">
+                    Menší neshody řešíte akčním plánem. Větší mohou vést k odložení certifikace - pomůžeme vám je odstranit.
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+@section Scripts {
+    <script>
+        (function () {
+            const faqInstances = document.querySelectorAll('[data-faq]');
+            if (!faqInstances.length) {
+                return;
+            }
+
+            faqInstances.forEach(faqRoot => {
+                const searchInput = faqRoot.querySelector('[data-faq-search]');
+                const categoryButtons = faqRoot.querySelectorAll('[data-faq-category]:not([data-faq-item])');
+                const faqItems = Array.from(faqRoot.querySelectorAll('[data-faq-item]'));
+                const emptyMessage = faqRoot.querySelector('[data-faq-empty]');
+
+                if (!searchInput || !categoryButtons.length || !faqItems.length) {
+                    return;
+                }
+
+                const normalize = (value) => (value || '')
+                    .normalize('NFD')
+                    .replace(/[\u0300-\u036f]/g, '')
+                    .toLowerCase();
+
+                let activeCategory = 'all';
+
+                const applyFilters = () => {
+                    const searchTerm = normalize(searchInput.value.trim());
+
+                    faqItems.forEach(item => {
+                        const matchesCategory = activeCategory === 'all' || item.dataset.faqCategory === activeCategory;
+                        const textContent = normalize(item.textContent);
+                        const matchesSearch = !searchTerm || textContent.includes(searchTerm);
+                        item.style.display = matchesCategory && matchesSearch ? '' : 'none';
+                    });
+
+                    const visibleItems = faqItems.filter(item => item.style.display !== 'none');
+                    const isEmpty = visibleItems.length === 0;
+
+                    faqRoot.classList.toggle('faq--empty', isEmpty);
+
+                    if (emptyMessage) {
+                        emptyMessage.hidden = !isEmpty;
+                    }
+                };
+
+                categoryButtons.forEach(button => {
+                    button.addEventListener('click', () => {
+                        activeCategory = button.dataset.faqCategory || 'all';
+
+                        categoryButtons.forEach(btn => btn.classList.toggle('active', btn === button));
+                        applyFilters();
+                    });
+                });
+
+                searchInput.addEventListener('input', () => {
+                    window.clearTimeout(searchInput._faqDebounce);
+                    searchInput._faqDebounce = window.setTimeout(applyFilters, 150);
+                });
+
+                applyFilters();
+            });
+        })();
+    </script>
+}

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -201,6 +201,140 @@ button:focus-visible {
   color: var(--neutral-900);
 }
 
+.faq {
+  background-color: var(--neutral-100);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.5rem, 2.5vw, 2.75rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.faq-header {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.faq-title {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  color: var(--neutral-900);
+}
+
+.faq-subtitle {
+  margin-bottom: 0;
+  color: var(--neutral-500);
+  font-size: 1rem;
+}
+
+.faq-search .input-group-text {
+  background: transparent;
+  border-right: 0;
+  color: var(--neutral-500);
+}
+
+.faq-search .form-control {
+  border-left: 0;
+  padding-block: 0.65rem;
+}
+
+.faq-search .form-control:focus {
+  box-shadow: none;
+}
+
+.faq-categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.faq-category {
+  border: 1px solid var(--neutral-300);
+  background-color: transparent;
+  color: var(--neutral-500);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.faq-category:hover,
+.faq-category:focus-visible {
+  background-color: var(--primary-50);
+  color: var(--primary);
+  border-color: var(--primary);
+}
+
+.faq-category.active {
+  background: linear-gradient(120deg, var(--primary) 0%, var(--primary-dark) 100%);
+  color: var(--neutral-100);
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(11, 123, 179, 0.25);
+}
+
+.faq-accordion .accordion-item {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  overflow: hidden;
+  background-color: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 12px 40px rgba(15, 118, 194, 0.08);
+}
+
+.faq-accordion .accordion-item + .accordion-item {
+  margin-top: 1rem;
+}
+
+.faq-accordion .accordion-button {
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 1rem 1.25rem;
+  color: var(--neutral-700);
+  background-color: transparent;
+}
+
+.faq-accordion .accordion-button::after {
+  filter: invert(27%) sepia(51%) saturate(700%) hue-rotate(158deg) brightness(95%) contrast(94%);
+}
+
+.faq-accordion .accordion-button:not(.collapsed) {
+  color: var(--primary);
+  background-color: rgba(11, 123, 179, 0.08);
+  box-shadow: inset 0 -1px 0 rgba(148, 163, 184, 0.35);
+}
+
+.faq-accordion .accordion-body {
+  padding: 0 1.25rem 1.25rem;
+  color: var(--neutral-500);
+  line-height: 1.6;
+}
+
+.faq-empty-message {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  background-color: rgba(11, 123, 179, 0.12);
+  color: var(--primary-dark);
+  font-weight: 600;
+}
+
+.faq--empty .faq-accordion {
+  display: none;
+}
+
+@media (max-width: 575.98px) {
+  .faq {
+    padding: 1.25rem;
+  }
+
+  .faq-accordion .accordion-button {
+    padding: 0.9rem 1rem;
+  }
+
+  .faq-accordion .accordion-body {
+    padding: 0 1rem 1rem;
+  }
+}
+
 .chatbot {
   position: fixed;
   bottom: 2rem;


### PR DESCRIPTION
## Summary
- add a shared FAQ partial with categorized accordion layout and client-side filtering
- style the FAQ component, including category chips and empty-state messaging

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2a72c6fc83219f6a2489acf45749