### PR TITLE
Add course category filters and breadcrumbs

### DIFF
--- a/Pages/Courses/Index.cshtml
+++ b/Pages/Courses/Index.cshtml
@@ -6,6 +6,13 @@
     ViewData["Title"] = Localizer["Title"];
 }
 
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-page="/Index">@Localizer["BreadcrumbHome"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["BreadcrumbCourses"]</li>
+    </ol>
+</nav>
+
 <h1 class="mb-3">@Localizer["Title"]</h1>
 
 <ul class="nav nav-pills mb-3">
@@ -99,6 +106,7 @@
             cities = Model.SelectedCityTagIds,
             levels = Model.SelectedLevels.Select(l => l.ToString()),
             types = Model.SelectedTypes.Select(t => t.ToString()),
+            categories = Model.SelectedCategoryIds,
             minPrice = Model.MinPrice ?? Model.PriceMinimum,
             maxPrice = Model.MaxPrice ?? Model.PriceMaximum,
             hasFilters = Model.HasActiveFilters,
@@ -134,6 +142,7 @@
         {
             norms = Model.NormOptions.Select(o => new { id = o.Id, name = o.Name }),
             cities = Model.CityOptions.Select(o => new { id = o.Id, name = o.Name }),
+            categories = Model.CategoryOptions.Select(o => new { id = o.Id, name = o.Name, count = o.Count }),
             levels = Model.LevelOptions.Select(o => new { value = o.Value, label = o.Label }),
             types = Model.TypeOptions.Select(o => new { value = o.Value, label = o.Label })
         },
@@ -141,6 +150,8 @@
         {
             searchPlaceholder = Localizer["SearchPlaceholder"].Value ?? string.Empty,
             searchLabel = Localizer["SearchLabel"].Value ?? "Hledat",
+            categoriesLabel = Localizer["CategoriesLabel"].Value ?? "Kategorie kurzů",
+            categoryCountTemplate = Localizer["CategoryCountFormat", "{0}", "{1}"].Value ?? "{0} ({1})",
             normsLabel = Localizer["NormsLabel"].Value ?? "Normy",
             citiesLabel = Localizer["CitiesLabel"].Value ?? "Města",
             levelsLabel = Localizer["LevelsLabel"].Value ?? "Úrovně",

--- a/Pages/Courses/_FiltersForm.cshtml
+++ b/Pages/Courses/_FiltersForm.cshtml
@@ -8,6 +8,10 @@
         <input type="search" class="form-control" data-filter="search" placeholder="@Localizer["SearchPlaceholder"]" aria-label="@Localizer["SearchAria"]" />
     </div>
     <div class="mb-3">
+        <label class="form-label">@Localizer["CategoriesLabel"]</label>
+        <select class="form-select" multiple data-filter="categories" size="8" aria-label="@Localizer["CategoriesLabel"]"></select>
+    </div>
+    <div class="mb-3">
         <label class="form-label">@Localizer["NormsLabel"]</label>
         <select class="form-select" multiple data-filter="norms" size="6" aria-label="@Localizer["NormsLabel"]"></select>
     </div>

--- a/Resources/Pages.Courses.Index.cshtml.en.resx
+++ b/Resources/Pages.Courses.Index.cshtml.en.resx
@@ -15,6 +15,12 @@
   <data name="Title" xml:space="preserve">
     <value>Courses &amp; Training</value>
   </data>
+  <data name="BreadcrumbHome" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="BreadcrumbCourses" xml:space="preserve">
+    <value>Courses</value>
+  </data>
   <data name="TabList" xml:space="preserve">
     <value>List</value>
   </data>
@@ -29,6 +35,12 @@
   </data>
   <data name="FiltersButton" xml:space="preserve">
     <value>Filters</value>
+  </data>
+  <data name="CategoriesLabel" xml:space="preserve">
+    <value>Course categories</value>
+  </data>
+  <data name="CategoryCountFormat" xml:space="preserve">
+    <value>{0} ({1})</value>
   </data>
   <data name="PaginationLabel" xml:space="preserve">
     <value>Course pagination</value>

--- a/Resources/Pages.Courses.Index.cshtml.resx
+++ b/Resources/Pages.Courses.Index.cshtml.resx
@@ -15,6 +15,12 @@
   <data name="Title" xml:space="preserve">
     <value>Kurzy a školení</value>
   </data>
+  <data name="BreadcrumbHome" xml:space="preserve">
+    <value>Domů</value>
+  </data>
+  <data name="BreadcrumbCourses" xml:space="preserve">
+    <value>Kurzy</value>
+  </data>
   <data name="TabList" xml:space="preserve">
     <value>Seznam</value>
   </data>
@@ -29,6 +35,12 @@
   </data>
   <data name="FiltersButton" xml:space="preserve">
     <value>Filtry</value>
+  </data>
+  <data name="CategoriesLabel" xml:space="preserve">
+    <value>Kategorie kurzů</value>
+  </data>
+  <data name="CategoryCountFormat" xml:space="preserve">
+    <value>{0} ({1})</value>
   </data>
   <data name="PaginationLabel" xml:space="preserve">
     <value>Stránkování kurzů</value>


### PR DESCRIPTION
## Summary
- add breadcrumb navigation to the courses index page for clearer hierarchy
- introduce static course category definitions with counts and expose them through the Razor page model and JSON config
- update the filters UI and client logic to support multi-select category filtering with localization strings

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd29f5fea883218bd62f4c5e94ad12