### PR TITLE
Enhance corporate inquiry wizard with service selection and details

### DIFF
--- a/Pages/CorporateInquiry.cshtml
+++ b/Pages/CorporateInquiry.cshtml
@@ -2,7 +2,7 @@
 @using Microsoft.AspNetCore.Mvc.Localization
 @inject IViewLocalizer Localizer
 @model SysJaky_N.Pages.CorporateInquiryModel
-@{
+@{ 
     ViewData["Title"] = Localizer["Title"];
     var shouldResetStorage = TempData.Peek("Success") is string;
     var modeLabels = new System.Collections.Generic.Dictionary<string, string>();
@@ -11,6 +11,18 @@
         modeLabels[option] = Localizer[$"ModeOption_{option}"].Value;
     }
     var modeLabelsJson = System.Text.Json.JsonSerializer.Serialize(modeLabels);
+    var serviceTypeLabels = new System.Collections.Generic.Dictionary<string, string>();
+    foreach (var option in Model.ServiceTypeOptions)
+    {
+        serviceTypeLabels[option] = Localizer[$"ServiceType_{option}"].Value;
+    }
+    var serviceTypeLabelsJson = System.Text.Json.JsonSerializer.Serialize(serviceTypeLabels);
+    var trainingLevelLabels = new System.Collections.Generic.Dictionary<string, string>();
+    foreach (var option in Model.TrainingLevelOptions)
+    {
+        trainingLevelLabels[option] = Localizer[$"TrainingLevel_{option}"].Value;
+    }
+    var trainingLevelLabelsJson = System.Text.Json.JsonSerializer.Serialize(trainingLevelLabels);
 }
 
 <h1 class="mb-4">@Localizer["Title"]</h1>
@@ -21,7 +33,7 @@
 </noscript>
 
 <div class="progress mb-4" aria-label="@Localizer["ProgressAriaLabel"]">
-    <div id="wizardProgressBar" class="progress-bar" role="progressbar" style="width:25%;" aria-valuenow="1" aria-valuemin="1" aria-valuemax="4">1 / 4</div>
+    <div id="wizardProgressBar" class="progress-bar" role="progressbar" style="width:20%;" aria-valuenow="1" aria-valuemin="1" aria-valuemax="5">1 / 5</div>
 </div>
 
 @if (TempData["Success"] is string success && !string.IsNullOrEmpty(success))
@@ -37,13 +49,20 @@
       data-participant-price="@Model.ParticipantPrice"
       data-mode-multipliers='@Html.Raw(Model.ModeMultipliersJson)'
       data-mode-labels='@Html.Raw(modeLabelsJson)'
+      data-service-multipliers='@Html.Raw(Model.ServiceTypeMultipliersJson)'
+      data-level-multipliers='@Html.Raw(Model.TrainingLevelMultipliersJson)'
+      data-service-labels='@Html.Raw(serviceTypeLabelsJson)'
+      data-level-labels='@Html.Raw(trainingLevelLabelsJson)'
       data-summary-placeholder="@Localizer["SummaryPlaceholder"]"
       data-price-unavailable="@Localizer["PriceUnavailable"]"
-      data-validation-step1="@Localizer["ValidationStep1"]"
+      data-validation-service-required="@Localizer["ValidationServiceTypeRequired"]"
+      data-validation-training-types="@Localizer["ValidationTrainingTypesRequired"]"
       data-validation-participant-required="@Localizer["ValidationParticipantRequired"]"
       data-validation-participant-range="@Localizer["ValidationParticipantRange"]"
       data-validation-date-required="@Localizer["ValidationDateRequired"]"
       data-validation-mode-required="@Localizer["ValidationModeRequired"]"
+      data-validation-training-level-required="@Localizer["ValidationTrainingLevelRequired"]"
+      data-validation-location-required="@Localizer["ValidationLocationRequired"]"
       data-validation-company-id-required="@Localizer["ValidationCompanyIdRequired"]"
       data-validation-company-name-required="@Localizer["ValidationCompanyNameRequired"]"
       data-validation-contact-person-required="@Localizer["ValidationContactPersonRequired"]"
@@ -55,18 +74,22 @@
     <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
 
     <div class="wizard-step" data-step="1">
-        <partial name="CorporateInquiry/Partials/_StepTraining" model="Model" />
+        <partial name="CorporateInquiry/Partials/_StepServiceType" model="Model" />
     </div>
 
     <div class="wizard-step d-none" data-step="2">
-        <partial name="CorporateInquiry/Partials/_StepDetails" model="Model" />
+        <partial name="CorporateInquiry/Partials/_StepTraining" model="Model" />
     </div>
 
     <div class="wizard-step d-none" data-step="3">
-        <partial name="CorporateInquiry/Partials/_StepCompany" model="Model" />
+        <partial name="CorporateInquiry/Partials/_StepDetails" model="Model" />
     </div>
 
     <div class="wizard-step d-none" data-step="4">
+        <partial name="CorporateInquiry/Partials/_StepCompany" model="Model" />
+    </div>
+
+    <div class="wizard-step d-none" data-step="5">
         <partial name="CorporateInquiry/Partials/_StepSummary" model="Model" />
     </div>
 
@@ -100,21 +123,32 @@
             const submitButton = document.getElementById('wizardSubmit');
             const priceValue = document.getElementById('priceEstimateValue');
             const storageKey = 'corporateInquiryDraft';
+            const serviceTypeRadios = Array.from(form.querySelectorAll('input[name="Input.ServiceType"]'));
             const isoCheckboxes = Array.from(form.querySelectorAll('input[name="Input.TrainingTypes"]'));
             const participantInput = form.querySelector('[name="Input.ParticipantCount"]');
             const dateInput = form.querySelector('[name="Input.PreferredDate"]');
-            const modeSelect = form.querySelector('[name="Input.Mode"]');
+            const trainingLevelRadios = Array.from(form.querySelectorAll('input[name="Input.TrainingLevel"]'));
+            const modeRadios = Array.from(form.querySelectorAll('input[name="Input.Mode"]'));
+            const locationInput = form.querySelector('[name="Input.Location"]');
+            const specialRequirementsInput = form.querySelector('[name="Input.SpecialRequirements"]');
+            const participantDisplay = document.getElementById('participant-count-display');
+            const locationContainer = form.querySelector('[data-location-container]');
             const companyIdInput = form.querySelector('[name="Input.CompanyId"]');
             const companyNameInput = form.querySelector('[name="Input.CompanyName"]');
             const contactPersonInput = form.querySelector('[name="Input.ContactPerson"]');
             const contactEmailInput = form.querySelector('[name="Input.ContactEmail"]');
             const contactPhoneInput = form.querySelector('[name="Input.ContactPhone"]');
-            const step1Error = document.getElementById('step1-error');
+            const trainingTypesError = document.getElementById('training-types-error');
+
             const summaryElements = {
+                serviceType: document.getElementById('summary-service-type'),
                 trainingTypes: document.getElementById('summary-training-types'),
                 participantCount: document.getElementById('summary-participant-count'),
                 preferredDate: document.getElementById('summary-preferred-date'),
                 mode: document.getElementById('summary-mode'),
+                trainingLevel: document.getElementById('summary-training-level'),
+                location: document.getElementById('summary-location'),
+                specialRequirements: document.getElementById('summary-special-requirements'),
                 companyId: document.getElementById('summary-company-id'),
                 companyName: document.getElementById('summary-company-name'),
                 contactPerson: document.getElementById('summary-contact-person'),
@@ -124,11 +158,14 @@
             };
 
             const validationMessages = {
-                step1: form.dataset.validationStep1,
+                serviceTypeRequired: form.dataset.validationServiceRequired,
+                trainingTypesRequired: form.dataset.validationTrainingTypes,
                 participantCountRequired: form.dataset.validationParticipantRequired,
                 participantCountRange: form.dataset.validationParticipantRange,
                 preferredDateRequired: form.dataset.validationDateRequired,
                 modeRequired: form.dataset.validationModeRequired,
+                trainingLevelRequired: form.dataset.validationTrainingLevelRequired,
+                locationRequired: form.dataset.validationLocationRequired,
                 companyIdRequired: form.dataset.validationCompanyIdRequired,
                 companyNameRequired: form.dataset.validationCompanyNameRequired,
                 contactPersonRequired: form.dataset.validationContactPersonRequired,
@@ -139,12 +176,18 @@
             };
 
             const modeLabels = JSON.parse(form.dataset.modeLabels || '{}');
+            const serviceLabels = JSON.parse(form.dataset.serviceLabels || '{}');
+            const trainingLevelLabels = JSON.parse(form.dataset.levelLabels || '{}');
             const basePrice = Number(form.dataset.basePrice || 0);
             const participantPrice = Number(form.dataset.participantPrice || 0);
             const modeMultipliers = JSON.parse(form.dataset.modeMultipliers || '{}');
+            const serviceMultipliers = JSON.parse(form.dataset.serviceMultipliers || '{}');
+            const levelMultipliers = JSON.parse(form.dataset.levelMultipliers || '{}');
             const totalSteps = steps.length;
             const dateFormatter = new Intl.DateTimeFormat(document.documentElement.lang || undefined, { dateStyle: 'medium' });
             const currencyFormatter = new Intl.NumberFormat(document.documentElement.lang || undefined, { style: 'currency', currency: 'CZK', maximumFractionDigits: 0 });
+            const locationRequiredModes = ['InPerson', 'Hybrid'];
+            const summaryPlaceholder = form.dataset.summaryPlaceholder || '';
 
             const initialStepFromServer = Number(form.dataset.initialStep || '1');
             let currentStep = Number.isNaN(initialStepFromServer) || initialStepFromServer < 1 || initialStepFromServer > totalSteps
@@ -169,6 +212,8 @@
                 }
             }
 
+            toggleLocationField();
+            updateParticipantDisplay();
             updateStep(currentStep);
             updateSummary();
             updatePrice();
@@ -199,19 +244,53 @@
                 persistState();
             });
 
-            const trackedFields = [participantInput, dateInput, modeSelect, companyIdInput, companyNameInput, contactPersonInput, contactEmailInput, contactPhoneInput];
+            const trackedFields = [participantInput, dateInput, locationInput, specialRequirementsInput, companyIdInput, companyNameInput, contactPersonInput, contactEmailInput, contactPhoneInput];
             trackedFields.forEach(field => {
                 if (!field) {
                     return;
                 }
                 field.addEventListener('input', () => {
                     showFieldError(field.name, '');
+                    if (field === participantInput) {
+                        updateParticipantDisplay();
+                    }
                     updatePrice();
                     updateSummary();
                     persistState();
                 });
                 field.addEventListener('change', () => {
                     showFieldError(field.name, '');
+                    if (field === participantInput) {
+                        updateParticipantDisplay();
+                    }
+                    updatePrice();
+                    updateSummary();
+                    persistState();
+                });
+            });
+
+            serviceTypeRadios.forEach(radio => {
+                radio.addEventListener('change', () => {
+                    showFieldError('Input.ServiceType', '');
+                    updatePrice();
+                    updateSummary();
+                    persistState();
+                });
+            });
+
+            trainingLevelRadios.forEach(radio => {
+                radio.addEventListener('change', () => {
+                    showFieldError('Input.TrainingLevel', '');
+                    updatePrice();
+                    updateSummary();
+                    persistState();
+                });
+            });
+
+            modeRadios.forEach(radio => {
+                radio.addEventListener('change', () => {
+                    showFieldError('Input.Mode', '');
+                    toggleLocationField();
                     updatePrice();
                     updateSummary();
                     persistState();
@@ -220,9 +299,9 @@
 
             isoCheckboxes.forEach(checkbox => {
                 checkbox.addEventListener('change', () => {
-                    if (step1Error) {
-                        step1Error.textContent = '';
-                        step1Error.classList.add('d-none');
+                    if (trainingTypesError) {
+                        trainingTypesError.textContent = '';
+                        trainingTypesError.classList.add('d-none');
                     }
                     updatePrice();
                     updateSummary();
@@ -232,10 +311,14 @@
 
             function collectFormState() {
                 return {
+                    serviceType: getCheckedValue(serviceTypeRadios),
                     trainingTypes: isoCheckboxes.filter(c => c.checked).map(c => c.value),
                     participantCount: participantInput ? participantInput.value : '',
                     preferredDate: dateInput ? dateInput.value : '',
-                    mode: modeSelect ? modeSelect.value : '',
+                    trainingLevel: getCheckedValue(trainingLevelRadios),
+                    mode: getCheckedValue(modeRadios),
+                    location: locationInput ? locationInput.value : '',
+                    specialRequirements: specialRequirementsInput ? specialRequirementsInput.value : '',
                     companyId: companyIdInput ? companyIdInput.value : '',
                     companyName: companyNameInput ? companyNameInput.value : '',
                     contactPerson: contactPersonInput ? contactPersonInput.value : '',
@@ -246,6 +329,7 @@
             }
 
             function applyState(state) {
+                setCheckedValue(serviceTypeRadios, state.serviceType);
                 isoCheckboxes.forEach(checkbox => {
                     checkbox.checked = Array.isArray(state.trainingTypes) && state.trainingTypes.includes(checkbox.value);
                 });
@@ -255,8 +339,13 @@
                 if (dateInput && state.preferredDate !== undefined) {
                     dateInput.value = state.preferredDate;
                 }
-                if (modeSelect && state.mode !== undefined) {
-                    modeSelect.value = state.mode;
+                setCheckedValue(trainingLevelRadios, state.trainingLevel);
+                setCheckedValue(modeRadios, state.mode);
+                if (locationInput && state.location !== undefined) {
+                    locationInput.value = state.location;
+                }
+                if (specialRequirementsInput && state.specialRequirements !== undefined) {
+                    specialRequirementsInput.value = state.specialRequirements;
                 }
                 if (companyIdInput && state.companyId !== undefined) {
                     companyIdInput.value = state.companyId;
@@ -273,6 +362,8 @@
                 if (contactPhoneInput && state.contactPhone !== undefined) {
                     contactPhoneInput.value = state.contactPhone;
                 }
+                toggleLocationField();
+                updateParticipantDisplay();
             }
 
             function loadState() {
@@ -316,9 +407,20 @@
                 const messageElement = form.querySelector(`[data-valmsg-for="${fieldName}"]`);
                 if (messageElement) {
                     messageElement.textContent = message || '';
+                    if (message) {
+                        messageElement.classList.remove('d-none');
+                        if (messageElement.classList.contains('invalid-feedback') && !messageElement.classList.contains('d-block')) {
+                            messageElement.classList.add('d-block');
+                        }
+                    } else if (!messageElement.classList.contains('d-block')) {
+                        messageElement.classList.add('d-none');
+                    }
                 }
-                const field = form.querySelector(`[name="${fieldName}"]`);
-                if (field) {
+                const fields = Array.from(form.querySelectorAll(`[name="${fieldName}"]`));
+                if (!fields.length) {
+                    return;
+                }
+                fields.forEach(field => {
                     if (message) {
                         field.classList.add('is-invalid');
                         field.setAttribute('aria-invalid', 'true');
@@ -326,7 +428,7 @@
                         field.classList.remove('is-invalid');
                         field.removeAttribute('aria-invalid');
                     }
-                }
+                });
             }
 
             function validateStep(step) {
@@ -334,16 +436,21 @@
                 clearStepErrors(step);
 
                 if (step === 1) {
-                    const selected = isoCheckboxes.filter(c => c.checked);
-                    if (selected.length === 0) {
+                    const serviceTypeValue = getCheckedValue(serviceTypeRadios);
+                    if (!serviceTypeValue) {
                         isValid = false;
-                        const container = document.getElementById('step1-error');
-                        if (container) {
-                            container.textContent = validationMessages.step1 || '';
-                            container.classList.remove('d-none');
-                        }
+                        showFieldError('Input.ServiceType', validationMessages.serviceTypeRequired);
                     }
                 } else if (step === 2) {
+                    const selectedTrainings = isoCheckboxes.filter(c => c.checked);
+                    if (selectedTrainings.length === 0) {
+                        isValid = false;
+                        if (trainingTypesError) {
+                            trainingTypesError.textContent = validationMessages.trainingTypesRequired || '';
+                            trainingTypesError.classList.remove('d-none');
+                        }
+                    }
+                } else if (step === 3) {
                     const participantValue = participantInput ? Number(participantInput.value) : 0;
                     if (!participantInput || participantInput.value.trim() === '') {
                         isValid = false;
@@ -358,11 +465,27 @@
                         showFieldError('Input.PreferredDate', validationMessages.preferredDateRequired);
                     }
 
-                    if (!modeSelect || modeSelect.value.trim() === '') {
+                    const trainingLevelValue = getCheckedValue(trainingLevelRadios);
+                    if (!trainingLevelValue) {
+                        isValid = false;
+                        showFieldError('Input.TrainingLevel', validationMessages.trainingLevelRequired);
+                    }
+
+                    const modeValue = getCheckedValue(modeRadios);
+                    if (!modeValue) {
                         isValid = false;
                         showFieldError('Input.Mode', validationMessages.modeRequired);
                     }
-                } else if (step === 3) {
+
+                    if (locationInput) {
+                        if (locationRequiredModes.includes(modeValue) && locationInput.value.trim() === '') {
+                            isValid = false;
+                            showFieldError('Input.Location', validationMessages.locationRequired);
+                        } else if (!locationRequiredModes.includes(modeValue)) {
+                            showFieldError('Input.Location', '');
+                        }
+                    }
+                } else if (step === 4) {
                     if (!companyIdInput || companyIdInput.value.trim() === '') {
                         isValid = false;
                         showFieldError('Input.CompanyId', validationMessages.companyIdRequired);
@@ -391,12 +514,9 @@
                     }
                 }
 
-                if (isValid && step === 1) {
-                    const container = document.getElementById('step1-error');
-                    if (container) {
-                        container.textContent = '';
-                        container.classList.add('d-none');
-                    }
+                if (isValid && step === 2 && trainingTypesError) {
+                    trainingTypesError.textContent = '';
+                    trainingTypesError.classList.add('d-none');
                 }
 
                 return isValid;
@@ -418,75 +538,133 @@
             }
 
             function clearStepErrors(step) {
-                if (step === 1) {
-                    const container = document.getElementById('step1-error');
-                    if (container) {
-                        container.textContent = '';
-                        container.classList.add('d-none');
-                    }
+                if (step === 2 && trainingTypesError) {
+                    trainingTypesError.textContent = '';
+                    trainingTypesError.classList.add('d-none');
                 }
 
-                const fields = ['Input.ParticipantCount', 'Input.PreferredDate', 'Input.Mode', 'Input.CompanyId', 'Input.CompanyName', 'Input.ContactPerson', 'Input.ContactEmail', 'Input.ContactPhone'];
+                const fields = ['Input.ServiceType', 'Input.TrainingTypes', 'Input.ParticipantCount', 'Input.PreferredDate', 'Input.TrainingLevel', 'Input.Mode', 'Input.Location', 'Input.CompanyId', 'Input.CompanyName', 'Input.ContactPerson', 'Input.ContactEmail', 'Input.ContactPhone'];
                 fields.forEach(fieldName => {
                     showFieldError(fieldName, '');
                 });
             }
 
             function updateSummary() {
-                if (!summaryElements.trainingTypes) {
+                if (!summaryElements.serviceType) {
                     return;
                 }
-                const selected = isoCheckboxes.filter(c => c.checked).map(checkbox => {
+
+                const serviceTypeValue = getCheckedValue(serviceTypeRadios);
+                summaryElements.serviceType.textContent = serviceTypeValue ? (serviceLabels[serviceTypeValue] || serviceTypeValue) : summaryPlaceholder;
+
+                const selectedTrainings = isoCheckboxes.filter(c => c.checked).map(checkbox => {
                     const label = form.querySelector(`label[for="${checkbox.id}"]`);
                     return label ? label.textContent.trim() : checkbox.value;
                 });
-                summaryElements.trainingTypes.textContent = selected.length ? selected.join(', ') : form.dataset.summaryPlaceholder;
+                summaryElements.trainingTypes.textContent = selectedTrainings.length ? selectedTrainings.join(', ') : summaryPlaceholder;
 
-                summaryElements.participantCount.textContent = participantInput && participantInput.value ? participantInput.value : form.dataset.summaryPlaceholder;
+                if (participantInput && participantInput.value) {
+                    const participantValue = Number(participantInput.value);
+                    summaryElements.participantCount.textContent = Number.isNaN(participantValue) ? participantInput.value : (participantValue >= 50 ? '50+' : participantValue.toString());
+                } else {
+                    summaryElements.participantCount.textContent = summaryPlaceholder;
+                }
 
                 if (dateInput && dateInput.value) {
                     const date = new Date(dateInput.value);
-                    summaryElements.preferredDate.textContent = Number.isNaN(date.getTime()) ? form.dataset.summaryPlaceholder : dateFormatter.format(date);
+                    summaryElements.preferredDate.textContent = Number.isNaN(date.getTime()) ? summaryPlaceholder : dateFormatter.format(date);
                 } else {
-                    summaryElements.preferredDate.textContent = form.dataset.summaryPlaceholder;
+                    summaryElements.preferredDate.textContent = summaryPlaceholder;
                 }
 
-                const modeValue = modeSelect ? modeSelect.value : '';
-                summaryElements.mode.textContent = modeValue ? (modeLabels[modeValue] || modeValue) : form.dataset.summaryPlaceholder;
+                const modeValue = getCheckedValue(modeRadios);
+                summaryElements.mode.textContent = modeValue ? (modeLabels[modeValue] || modeValue) : summaryPlaceholder;
 
-                summaryElements.companyId.textContent = companyIdInput && companyIdInput.value ? companyIdInput.value : form.dataset.summaryPlaceholder;
-                summaryElements.companyName.textContent = companyNameInput && companyNameInput.value ? companyNameInput.value : form.dataset.summaryPlaceholder;
-                summaryElements.contactPerson.textContent = contactPersonInput && contactPersonInput.value ? contactPersonInput.value : form.dataset.summaryPlaceholder;
-                summaryElements.contactEmail.textContent = contactEmailInput && contactEmailInput.value ? contactEmailInput.value : form.dataset.summaryPlaceholder;
-                summaryElements.contactPhone.textContent = contactPhoneInput && contactPhoneInput.value ? contactPhoneInput.value : form.dataset.summaryPlaceholder;
+                const trainingLevelValue = getCheckedValue(trainingLevelRadios);
+                summaryElements.trainingLevel.textContent = trainingLevelValue ? (trainingLevelLabels[trainingLevelValue] || trainingLevelValue) : summaryPlaceholder;
+
+                summaryElements.location.textContent = locationInput && locationInput.value ? locationInput.value : summaryPlaceholder;
+
+                const specialText = specialRequirementsInput && specialRequirementsInput.value ? specialRequirementsInput.value.trim() : '';
+                summaryElements.specialRequirements.textContent = specialText ? specialText : summaryPlaceholder;
+
+                summaryElements.companyId.textContent = companyIdInput && companyIdInput.value ? companyIdInput.value : summaryPlaceholder;
+                summaryElements.companyName.textContent = companyNameInput && companyNameInput.value ? companyNameInput.value : summaryPlaceholder;
+                summaryElements.contactPerson.textContent = contactPersonInput && contactPersonInput.value ? contactPersonInput.value : summaryPlaceholder;
+                summaryElements.contactEmail.textContent = contactEmailInput && contactEmailInput.value ? contactEmailInput.value : summaryPlaceholder;
+                summaryElements.contactPhone.textContent = contactPhoneInput && contactPhoneInput.value ? contactPhoneInput.value : summaryPlaceholder;
 
                 const estimated = calculatePrice();
-                if (estimated > 0) {
-                    summaryElements.price.textContent = currencyFormatter.format(estimated);
-                } else {
-                    summaryElements.price.textContent = form.dataset.priceUnavailable;
-                }
+                summaryElements.price.textContent = estimated > 0 ? currencyFormatter.format(estimated) : form.dataset.priceUnavailable;
             }
 
             function updatePrice() {
                 const estimated = calculatePrice();
-                if (estimated > 0) {
-                    priceValue.textContent = currencyFormatter.format(estimated);
-                } else {
-                    priceValue.textContent = form.dataset.priceUnavailable;
-                }
+                priceValue.textContent = estimated > 0 ? currencyFormatter.format(estimated) : form.dataset.priceUnavailable;
             }
 
             function calculatePrice() {
                 const trainingCount = isoCheckboxes.filter(c => c.checked).length;
                 const participants = participantInput ? Number(participantInput.value) : 0;
-                if (trainingCount === 0 || !participants) {
+                const serviceTypeValue = getCheckedValue(serviceTypeRadios);
+                const trainingLevelValue = getCheckedValue(trainingLevelRadios);
+                const modeValue = getCheckedValue(modeRadios);
+
+                if (trainingCount === 0 || !serviceTypeValue || Number.isNaN(participants) || participants <= 0) {
                     return 0;
                 }
-                const baseTotal = basePrice * trainingCount;
+
+                const serviceMultiplier = Number(serviceMultipliers[serviceTypeValue] ?? 1);
+                const levelMultiplier = Number(levelMultipliers[trainingLevelValue] ?? 1);
+                const modeMultiplier = Number(modeMultipliers[modeValue] ?? 1);
+
+                const baseTotal = basePrice * trainingCount * serviceMultiplier;
                 const participantTotal = participantPrice * participants;
-                const multiplier = modeMultipliers[modeSelect ? modeSelect.value : ''] ?? 1;
-                return Math.round((baseTotal + participantTotal) * multiplier);
+
+                return Math.round((baseTotal + participantTotal) * levelMultiplier * modeMultiplier);
+            }
+
+            function toggleLocationField() {
+                if (!locationContainer) {
+                    return;
+                }
+                const modeValue = getCheckedValue(modeRadios);
+                const shouldShow = locationRequiredModes.includes(modeValue);
+                locationContainer.classList.toggle('d-none', !shouldShow);
+                if (!shouldShow && locationInput) {
+                    locationInput.value = '';
+                    showFieldError('Input.Location', '');
+                }
+            }
+
+            function updateParticipantDisplay() {
+                if (!participantDisplay) {
+                    return;
+                }
+                if (!participantInput || participantInput.value.trim() === '') {
+                    participantDisplay.textContent = summaryPlaceholder || '—';
+                    return;
+                }
+                const value = Number(participantInput.value);
+                if (Number.isNaN(value)) {
+                    participantDisplay.textContent = participantInput.value;
+                    return;
+                }
+                participantDisplay.textContent = value >= 50 ? '50+' : value.toString();
+            }
+
+            function getCheckedValue(inputs) {
+                const selected = inputs.find(input => input.checked);
+                return selected ? selected.value : '';
+            }
+
+            function setCheckedValue(inputs, value) {
+                if (!Array.isArray(inputs)) {
+                    return;
+                }
+                inputs.forEach(input => {
+                    input.checked = Boolean(value) && input.value === value;
+                });
             }
 
             function isValidEmail(value) {

--- a/Pages/CorporateInquiry/Partials/_StepDetails.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepDetails.cshtml
@@ -4,9 +4,13 @@
 <h2 class="h4 mb-3">@Localizer["Step2Title"]</h2>
 <p class="text-muted mb-4">@Localizer["Step2Description"]</p>
 
-<div class="mb-3">
-    <label asp-for="Input.ParticipantCount" class="form-label"></label>
-    <input asp-for="Input.ParticipantCount" class="form-control" min="1" max="1000" />
+<div class="mb-4">
+    <label asp-for="Input.ParticipantCount" class="form-label d-flex justify-content-between align-items-center">
+        <span>@Html.DisplayNameFor(m => m.Input.ParticipantCount)</span>
+        <span id="participant-count-display" class="badge bg-primary-subtle text-primary-emphasis">@(Model.Input.ParticipantCount ?? 1)</span>
+    </label>
+    <input asp-for="Input.ParticipantCount" class="form-range" type="range" min="1" max="50" value="@(Model.Input.ParticipantCount ?? 1)" aria-describedby="participant-count-display" />
+    <div class="form-text">@Localizer["ParticipantCountHint"]</div>
     <span asp-validation-for="Input.ParticipantCount" class="invalid-feedback"></span>
 </div>
 
@@ -16,14 +20,46 @@
     <span asp-validation-for="Input.PreferredDate" class="invalid-feedback"></span>
 </div>
 
-<div class="mb-3">
-    <label asp-for="Input.Mode" class="form-label"></label>
-    <select asp-for="Input.Mode" class="form-select">
-        <option value="">@Localizer["ModePlaceholder"]</option>
-        @foreach (var option in Model.ModeOptions)
-        {
-            <option value="@option" selected="@(Model.Input.Mode == option ? "selected" : null)">@Localizer[$"ModeOption_{option}"]</option>
-        }
-    </select>
+<div class="mb-3" role="group" aria-labelledby="trainingLevelLabel">
+    <span id="trainingLevelLabel" class="form-label d-block fw-semibold">@Html.DisplayNameFor(m => m.Input.TrainingLevel)</span>
+    @for (var index = 0; index < Model.TrainingLevelOptions.Count; index++)
+    {
+        var option = Model.TrainingLevelOptions[index];
+        var inputId = $"training-level-{index}";
+        <div class="form-check">
+            <input class="form-check-input" type="radio" id="@inputId" name="Input.TrainingLevel" value="@option" @(Model.Input.TrainingLevel == option ? "checked" : null) />
+            <label class="form-check-label" for="@inputId">@Localizer[$"TrainingLevel_{option}"]</label>
+        </div>
+    }
+    <span asp-validation-for="Input.TrainingLevel" class="invalid-feedback"></span>
+</div>
+
+<div class="mb-3" role="group" aria-labelledby="modeLabel">
+    <span id="modeLabel" class="form-label d-block fw-semibold">@Html.DisplayNameFor(m => m.Input.Mode)</span>
+    @for (var index = 0; index < Model.ModeOptions.Count; index++)
+    {
+        var option = Model.ModeOptions[index];
+        var inputId = $"mode-option-{index}";
+        <div class="form-check">
+            <input class="form-check-input" type="radio" id="@inputId" name="Input.Mode" value="@option" @(Model.Input.Mode == option ? "checked" : null) />
+            <label class="form-check-label" for="@inputId">@Localizer[$"ModeOption_{option}"]</label>
+        </div>
+    }
     <span asp-validation-for="Input.Mode" class="invalid-feedback"></span>
+</div>
+
+@{
+    var showLocation = Model.Input.Mode == "InPerson" || Model.Input.Mode == "Hybrid";
+    var locationClasses = showLocation ? "mb-3" : "mb-3 d-none";
+}
+<div class="@locationClasses" data-location-container>
+    <label asp-for="Input.Location" class="form-label"></label>
+    <input asp-for="Input.Location" class="form-control" />
+    <span asp-validation-for="Input.Location" class="invalid-feedback"></span>
+</div>
+
+<div class="mb-3">
+    <label asp-for="Input.SpecialRequirements" class="form-label"></label>
+    <textarea asp-for="Input.SpecialRequirements" class="form-control" rows="4"></textarea>
+    <span asp-validation-for="Input.SpecialRequirements" class="invalid-feedback"></span>
 </div>

--- a/Pages/CorporateInquiry/Partials/_StepServiceType.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepServiceType.cshtml
@@ -1,0 +1,19 @@
+@model SysJaky_N.Pages.CorporateInquiryModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+<h2 class="h4 mb-3">@Localizer["Step0Title"]</h2>
+<p class="text-muted mb-4">@Localizer["Step0Description"]</p>
+
+<div class="mb-3" role="group" aria-labelledby="serviceTypeLabel">
+    <span id="serviceTypeLabel" class="form-label d-block fw-semibold">@Html.DisplayNameFor(m => m.Input.ServiceType)</span>
+    @for (var index = 0; index < Model.ServiceTypeOptions.Count; index++)
+    {
+        var option = Model.ServiceTypeOptions[index];
+        var inputId = $"service-type-{index}";
+        <div class="form-check">
+            <input class="form-check-input" type="radio" id="@inputId" name="Input.ServiceType" value="@option" @(Model.Input.ServiceType == option ? "checked" : null) />
+            <label class="form-check-label" for="@inputId">@Localizer[$"ServiceType_{option}"]</label>
+        </div>
+    }
+    <span asp-validation-for="Input.ServiceType" class="invalid-feedback"></span>
+</div>

--- a/Pages/CorporateInquiry/Partials/_StepSummary.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepSummary.cshtml
@@ -8,6 +8,9 @@
     <div class="card-body">
         <h3 class="h5 mb-3">@Localizer["SummaryTitle"]</h3>
         <dl class="row mb-0">
+            <dt class="col-sm-4">@Localizer["SummaryServiceType"]</dt>
+            <dd class="col-sm-8" id="summary-service-type">@Localizer["SummaryPlaceholder"]</dd>
+
             <dt class="col-sm-4">@Localizer["SummaryTrainingTypes"]</dt>
             <dd class="col-sm-8" id="summary-training-types">@Localizer["SummaryPlaceholder"]</dd>
 
@@ -19,6 +22,15 @@
 
             <dt class="col-sm-4">@Localizer["SummaryMode"]</dt>
             <dd class="col-sm-8" id="summary-mode">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryTrainingLevel"]</dt>
+            <dd class="col-sm-8" id="summary-training-level">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummaryLocation"]</dt>
+            <dd class="col-sm-8" id="summary-location">@Localizer["SummaryPlaceholder"]</dd>
+
+            <dt class="col-sm-4">@Localizer["SummarySpecialRequirements"]</dt>
+            <dd class="col-sm-8" id="summary-special-requirements">@Localizer["SummaryPlaceholder"]</dd>
 
             <dt class="col-sm-4">@Localizer["SummaryCompanyId"]</dt>
             <dd class="col-sm-8" id="summary-company-id">@Localizer["SummaryPlaceholder"]</dd>

--- a/Pages/CorporateInquiry/Partials/_StepTraining.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepTraining.cshtml
@@ -21,5 +21,5 @@
             : null;
         var errorClass = string.IsNullOrEmpty(trainingError) ? "d-none" : string.Empty;
     }
-    <div id="step1-error" class="text-danger small mt-2 @errorClass">@trainingError</div>
+    <div id="training-types-error" class="invalid-feedback d-block @errorClass">@trainingError</div>
 </div>

--- a/Resources/CorporateInquiryResources.en.resx
+++ b/Resources/CorporateInquiryResources.en.resx
@@ -12,6 +12,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ServiceTypeLabel" xml:space="preserve">
+    <value>Select a service type</value>
+  </data>
   <data name="TrainingTypesLabel" xml:space="preserve">
     <value>Select desired ISO standards</value>
   </data>
@@ -23,6 +26,15 @@
   </data>
   <data name="ModeLabel" xml:space="preserve">
     <value>Preferred training mode</value>
+  </data>
+  <data name="TrainingLevelLabel" xml:space="preserve">
+    <value>Training level</value>
+  </data>
+  <data name="LocationLabel" xml:space="preserve">
+    <value>Training location</value>
+  </data>
+  <data name="SpecialRequirementsLabel" xml:space="preserve">
+    <value>Special requirements</value>
   </data>
   <data name="CompanyIdLabel" xml:space="preserve">
     <value>Company ID</value>

--- a/Resources/CorporateInquiryResources.resx
+++ b/Resources/CorporateInquiryResources.resx
@@ -12,6 +12,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ServiceTypeLabel" xml:space="preserve">
+    <value>Vyberte typ služby</value>
+  </data>
   <data name="TrainingTypesLabel" xml:space="preserve">
     <value>Vyberte požadované ISO normy</value>
   </data>
@@ -23,6 +26,15 @@
   </data>
   <data name="ModeLabel" xml:space="preserve">
     <value>Preferovaný režim školení</value>
+  </data>
+  <data name="TrainingLevelLabel" xml:space="preserve">
+    <value>Úroveň školení</value>
+  </data>
+  <data name="LocationLabel" xml:space="preserve">
+    <value>Lokalita školení</value>
+  </data>
+  <data name="SpecialRequirementsLabel" xml:space="preserve">
+    <value>Speciální požadavky</value>
   </data>
   <data name="CompanyIdLabel" xml:space="preserve">
     <value>IČO</value>

--- a/Resources/Pages.CorporateInquiry.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.en.resx
@@ -13,13 +13,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Title" xml:space="preserve">
-    <value>Corporate training inquiry</value>
+    <value>Tailored corporate training</value>
   </data>
   <data name="Intro" xml:space="preserve">
-    <value>Tell us which ISO standards you need to cover and we will prepare a tailored training offer for your company.</value>
+    <value>We help organisations prepare corporate training aligned with the ISO standards you need. Fill in the inquiry and we will get back to you with a tailored quote.</value>
   </data>
   <data name="EnableJavaScriptWarning" xml:space="preserve">
-    <value>JavaScript is required to submit this inquiry.</value>
+    <value>JavaScript must be enabled to submit the inquiry.</value>
   </data>
   <data name="ProgressAriaLabel" xml:space="preserve">
     <value>Inquiry progress</value>
@@ -39,32 +39,41 @@
   <data name="EstimatedPricePlaceholder" xml:space="preserve">
     <value>—</value>
   </data>
+  <data name="Step0Title" xml:space="preserve">
+    <value>Step 0 – Select service type</value>
+  </data>
+  <data name="Step0Description" xml:space="preserve">
+    <value>Choose the type of engagement you are interested in.</value>
+  </data>
   <data name="Step1Title" xml:space="preserve">
-    <value>Select ISO standards</value>
+    <value>Step 1 – Select standards</value>
   </data>
   <data name="Step1Description" xml:space="preserve">
-    <value>Choose which standards should be included in the training.</value>
+    <value>Select every standard you would like the training to cover.</value>
   </data>
   <data name="Step2Title" xml:space="preserve">
-    <value>Training details</value>
+    <value>Step 2 – Training details</value>
   </data>
   <data name="Step2Description" xml:space="preserve">
-    <value>Provide the core details of the training you require.</value>
+    <value>Provide the desired scope, delivery mode, and timing.</value>
   </data>
   <data name="Step3Title" xml:space="preserve">
-    <value>Company information</value>
+    <value>Step 3 – Company information</value>
   </data>
   <data name="Step3Description" xml:space="preserve">
-    <value>Let us know who we will be working with.</value>
+    <value>Tell us about your company and the primary contact.</value>
   </data>
   <data name="Step4Title" xml:space="preserve">
-    <value>Summary</value>
+    <value>Step 4 – Summary</value>
   </data>
   <data name="Step4Description" xml:space="preserve">
-    <value>Review your details before sending.</value>
+    <value>Review the provided information and submit your inquiry.</value>
   </data>
   <data name="SummaryTitle" xml:space="preserve">
     <value>Inquiry summary</value>
+  </data>
+  <data name="SummaryServiceType" xml:space="preserve">
+    <value>Service type</value>
   </data>
   <data name="SummaryTrainingTypes" xml:space="preserve">
     <value>ISO standards</value>
@@ -77,6 +86,15 @@
   </data>
   <data name="SummaryMode" xml:space="preserve">
     <value>Mode</value>
+  </data>
+  <data name="SummaryTrainingLevel" xml:space="preserve">
+    <value>Training level</value>
+  </data>
+  <data name="SummaryLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="SummarySpecialRequirements" xml:space="preserve">
+    <value>Special requirements</value>
   </data>
   <data name="SummaryCompanyId" xml:space="preserve">
     <value>Company ID</value>
@@ -102,8 +120,8 @@
   <data name="PriceUnavailable" xml:space="preserve">
     <value>Enter details</value>
   </data>
-  <data name="ModePlaceholder" xml:space="preserve">
-    <value>Select mode</value>
+  <data name="ParticipantCountHint" xml:space="preserve">
+    <value>Use the slider (value 50 stands for 50+ participants).</value>
   </data>
   <data name="ModeOption_InPerson" xml:space="preserve">
     <value>In person</value>
@@ -114,20 +132,62 @@
   <data name="ModeOption_Hybrid" xml:space="preserve">
     <value>Hybrid</value>
   </data>
+  <data name="ServiceType_CustomTraining" xml:space="preserve">
+    <value>Bespoke corporate training</value>
+  </data>
+  <data name="ServiceType_CertificationProject" xml:space="preserve">
+    <value>Certification readiness project</value>
+  </data>
+  <data name="ServiceType_PreAudit" xml:space="preserve">
+    <value>Pre-certification audit</value>
+  </data>
+  <data name="ServiceType_InternalAudit" xml:space="preserve">
+    <value>Internal audit</value>
+  </data>
+  <data name="ServiceType_Consulting" xml:space="preserve">
+    <value>Consulting &amp; advisory</value>
+  </data>
+  <data name="TrainingLevel_Basic" xml:space="preserve">
+    <value>Basic</value>
+  </data>
+  <data name="TrainingLevel_Advanced" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="TrainingLevel_Certification" xml:space="preserve">
+    <value>Certification</value>
+  </data>
   <data name="ISO9001" xml:space="preserve">
-    <value>ISO 9001 — Quality management</value>
+    <value>ISO 9001 - Quality management</value>
   </data>
   <data name="ISO14001" xml:space="preserve">
-    <value>ISO 14001 — Environmental management</value>
+    <value>ISO 14001 - Environmental management</value>
   </data>
-  <data name="ISO27001" xml:space="preserve">
-    <value>ISO/IEC 27001 — Information security</value>
+  <data name="ISO17025" xml:space="preserve">
+    <value>ISO/IEC 17025 - Laboratory accreditation</value>
+  </data>
+  <data name="ISO15189" xml:space="preserve">
+    <value>ISO 15189 - Medical laboratories</value>
+  </data>
+  <data name="HACCP" xml:space="preserve">
+    <value>HACCP - Food safety</value>
   </data>
   <data name="ISO45001" xml:space="preserve">
-    <value>ISO 45001 — Occupational health &amp; safety</value>
+    <value>ISO 45001 - Occupational health &amp; safety</value>
   </data>
-  <data name="ValidationStep1" xml:space="preserve">
-    <value>Select at least one ISO standard.</value>
+  <data name="ISO27001" xml:space="preserve">
+    <value>ISO 27001 - Information security</value>
+  </data>
+  <data name="IATF16949" xml:space="preserve">
+    <value>IATF 16949 - Automotive</value>
+  </data>
+  <data name="ISO13485" xml:space="preserve">
+    <value>ISO 13485 - Medical devices</value>
+  </data>
+  <data name="ValidationServiceTypeRequired" xml:space="preserve">
+    <value>Please select a service type.</value>
+  </data>
+  <data name="ValidationTrainingTypesRequired" xml:space="preserve">
+    <value>Select at least one standard.</value>
   </data>
   <data name="ValidationParticipantRequired" xml:space="preserve">
     <value>Please enter the number of participants.</value>
@@ -140,6 +200,12 @@
   </data>
   <data name="ValidationModeRequired" xml:space="preserve">
     <value>Please choose your preferred training mode.</value>
+  </data>
+  <data name="ValidationTrainingLevelRequired" xml:space="preserve">
+    <value>Please choose a training level.</value>
+  </data>
+  <data name="ValidationLocationRequired" xml:space="preserve">
+    <value>Please provide the location for the in-person part of the training.</value>
   </data>
   <data name="ValidationCompanyIdRequired" xml:space="preserve">
     <value>Please enter your company ID.</value>

--- a/Resources/Pages.CorporateInquiry.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.resx
@@ -39,32 +39,41 @@
   <data name="EstimatedPricePlaceholder" xml:space="preserve">
     <value>—</value>
   </data>
+  <data name="Step0Title" xml:space="preserve">
+    <value>Krok 0 – Výběr typu služby</value>
+  </data>
+  <data name="Step0Description" xml:space="preserve">
+    <value>Zvolte, s jakou službou vám můžeme pomoci.</value>
+  </data>
   <data name="Step1Title" xml:space="preserve">
-    <value>Vyberte ISO normy</value>
+    <value>Krok 1 – Výběr norem</value>
   </data>
   <data name="Step1Description" xml:space="preserve">
-    <value>Zvolte, které normy chcete zahrnout do školení.</value>
+    <value>Vyberte všechny normy, které chcete zahrnout do školení.</value>
   </data>
   <data name="Step2Title" xml:space="preserve">
-    <value>Detaily školení</value>
+    <value>Krok 2 – Detaily školení</value>
   </data>
   <data name="Step2Description" xml:space="preserve">
-    <value>Uveďte základní parametry plánovaného školení.</value>
+    <value>Upřesněte rozsah školení, režim a preferovaný termín.</value>
   </data>
   <data name="Step3Title" xml:space="preserve">
-    <value>Informace o společnosti</value>
+    <value>Krok 3 – Informace o společnosti</value>
   </data>
   <data name="Step3Description" xml:space="preserve">
     <value>Vyplňte údaje o firmě a kontaktní osobě.</value>
   </data>
   <data name="Step4Title" xml:space="preserve">
-    <value>Shrnutí</value>
+    <value>Krok 4 – Shrnutí</value>
   </data>
   <data name="Step4Description" xml:space="preserve">
     <value>Zkontrolujte zadané údaje a odešlete poptávku.</value>
   </data>
   <data name="SummaryTitle" xml:space="preserve">
     <value>Rekapitulace poptávky</value>
+  </data>
+  <data name="SummaryServiceType" xml:space="preserve">
+    <value>Typ služby</value>
   </data>
   <data name="SummaryTrainingTypes" xml:space="preserve">
     <value>ISO normy</value>
@@ -77,6 +86,15 @@
   </data>
   <data name="SummaryMode" xml:space="preserve">
     <value>Režim</value>
+  </data>
+  <data name="SummaryTrainingLevel" xml:space="preserve">
+    <value>Úroveň školení</value>
+  </data>
+  <data name="SummaryLocation" xml:space="preserve">
+    <value>Lokalita</value>
+  </data>
+  <data name="SummarySpecialRequirements" xml:space="preserve">
+    <value>Speciální požadavky</value>
   </data>
   <data name="SummaryCompanyId" xml:space="preserve">
     <value>IČO</value>
@@ -102,8 +120,8 @@
   <data name="PriceUnavailable" xml:space="preserve">
     <value>Doplnit údaje</value>
   </data>
-  <data name="ModePlaceholder" xml:space="preserve">
-    <value>Vyberte režim</value>
+  <data name="ParticipantCountHint" xml:space="preserve">
+    <value>Posuňte posuvník (hodnota 50 znamená 50 a více účastníků).</value>
   </data>
   <data name="ModeOption_InPerson" xml:space="preserve">
     <value>Prezenčně</value>
@@ -114,20 +132,62 @@
   <data name="ModeOption_Hybrid" xml:space="preserve">
     <value>Hybridně</value>
   </data>
+  <data name="ServiceType_CustomTraining" xml:space="preserve">
+    <value>Firemní školení na míru</value>
+  </data>
+  <data name="ServiceType_CertificationProject" xml:space="preserve">
+    <value>Příprava k certifikaci (kompletní projekt)</value>
+  </data>
+  <data name="ServiceType_PreAudit" xml:space="preserve">
+    <value>Pre-audit před certifikací</value>
+  </data>
+  <data name="ServiceType_InternalAudit" xml:space="preserve">
+    <value>Interní audit</value>
+  </data>
+  <data name="ServiceType_Consulting" xml:space="preserve">
+    <value>Poradenství a konzultace</value>
+  </data>
+  <data name="TrainingLevel_Basic" xml:space="preserve">
+    <value>Základní</value>
+  </data>
+  <data name="TrainingLevel_Advanced" xml:space="preserve">
+    <value>Pokročilé</value>
+  </data>
+  <data name="TrainingLevel_Certification" xml:space="preserve">
+    <value>Certifikační</value>
+  </data>
   <data name="ISO9001" xml:space="preserve">
-    <value>ISO 9001 — Systém managementu kvality</value>
+    <value>ISO 9001 - Systém managementu kvality</value>
   </data>
   <data name="ISO14001" xml:space="preserve">
-    <value>ISO 14001 — Environmentální management</value>
+    <value>ISO 14001 - Environmentální management</value>
   </data>
-  <data name="ISO27001" xml:space="preserve">
-    <value>ISO/IEC 27001 — Bezpečnost informací</value>
+  <data name="ISO17025" xml:space="preserve">
+    <value>ISO/IEC 17025 - Akreditace laboratoří</value>
+  </data>
+  <data name="ISO15189" xml:space="preserve">
+    <value>ISO 15189 - Zdravotnické laboratoře</value>
+  </data>
+  <data name="HACCP" xml:space="preserve">
+    <value>HACCP - Bezpečnost potravin</value>
   </data>
   <data name="ISO45001" xml:space="preserve">
-    <value>ISO 45001 — BOZP</value>
+    <value>ISO 45001 - BOZP</value>
   </data>
-  <data name="ValidationStep1" xml:space="preserve">
-    <value>Vyberte alespoň jednu ISO normu.</value>
+  <data name="ISO27001" xml:space="preserve">
+    <value>ISO 27001 - Informační bezpečnost</value>
+  </data>
+  <data name="IATF16949" xml:space="preserve">
+    <value>IATF 16949 - Automotive</value>
+  </data>
+  <data name="ISO13485" xml:space="preserve">
+    <value>ISO 13485 - Zdravotnické prostředky</value>
+  </data>
+  <data name="ValidationServiceTypeRequired" xml:space="preserve">
+    <value>Vyberte typ služby.</value>
+  </data>
+  <data name="ValidationTrainingTypesRequired" xml:space="preserve">
+    <value>Vyberte alespoň jednu normu.</value>
   </data>
   <data name="ValidationParticipantRequired" xml:space="preserve">
     <value>Zadejte počet účastníků.</value>
@@ -140,6 +200,12 @@
   </data>
   <data name="ValidationModeRequired" xml:space="preserve">
     <value>Vyberte preferovaný režim školení.</value>
+  </data>
+  <data name="ValidationTrainingLevelRequired" xml:space="preserve">
+    <value>Vyberte úroveň školení.</value>
+  </data>
+  <data name="ValidationLocationRequired" xml:space="preserve">
+    <value>Uveďte lokalitu pro prezenční část školení.</value>
   </data>
   <data name="ValidationCompanyIdRequired" xml:space="preserve">
     <value>Vyplňte IČO společnosti.</value>

--- a/Resources/Pages.CorporateInquiryModel.cs.en.resx
+++ b/Resources/Pages.CorporateInquiryModel.cs.en.resx
@@ -12,8 +12,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ValidationStep1" xml:space="preserve">
-    <value>Please select at least one ISO standard.</value>
+  <data name="ValidationTrainingTypesRequired" xml:space="preserve">
+    <value>Select at least one standard.</value>
+  </data>
+  <data name="ValidationLocationRequired" xml:space="preserve">
+    <value>Please provide the location for the in-person part of the training.</value>
   </data>
   <data name="SuccessMessage" xml:space="preserve">
     <value>Thank you, we will contact you shortly with an offer.</value>

--- a/Resources/Pages.CorporateInquiryModel.cs.resx
+++ b/Resources/Pages.CorporateInquiryModel.cs.resx
@@ -12,8 +12,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ValidationStep1" xml:space="preserve">
-    <value>Vyberte alespoň jednu ISO normu.</value>
+  <data name="ValidationTrainingTypesRequired" xml:space="preserve">
+    <value>Vyberte alespoň jednu normu.</value>
+  </data>
+  <data name="ValidationLocationRequired" xml:space="preserve">
+    <value>Uveďte lokalitu pro prezenční část školení.</value>
   </data>
   <data name="SuccessMessage" xml:space="preserve">
     <value>Děkujeme, ozveme se vám co nejdříve s nabídkou.</value>


### PR DESCRIPTION
## Summary
- add a new initial wizard step for selecting the desired service type and expand ISO standard options
- extend the training details step with slider-based participant selection, training level and mode radios, and conditional location and notes
- update the summary, pricing logic, and persistence/validation scripts to cover the new fields with refreshed localized resources

## Testing
- ⚠️ `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2a19eb348321bdb3b08df1547760