### PR TITLE
Fix localization references and JSON-LD encoding

### DIFF
--- a/Pages/Admin/Dashboard/Index.cshtml.cs
+++ b/Pages/Admin/Dashboard/Index.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using SysJaky_N.Authorization;
 using SysJaky_N.Data;
 
 namespace SysJaky_N.Pages.Admin.Dashboard;

--- a/Pages/Api/Newsletter.cshtml.cs
+++ b/Pages/Api/Newsletter.cshtml.cs
@@ -7,7 +7,6 @@ using SysJaky_N.Data;
 using SysJaky_N.EmailTemplates.Models;
 using SysJaky_N.Models;
 using SysJaky_N.Services;
-using EmailTemplate = SysJaky_N.Services.EmailTemplate;
 
 namespace SysJaky_N.Pages.Api;
 
@@ -112,7 +111,7 @@ public class NewsletterModel : PageModel
 
         await _emailSender.SendEmailAsync(
             normalizedEmail,
-            EmailTemplate.NewsletterConfirmation,
+            SysJaky_N.Services.EmailTemplate.NewsletterConfirmation,
             new NewsletterConfirmationEmailModel(normalizedEmail, confirmationUrl ?? string.Empty),
             cancellationToken);
 

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -48,17 +48,19 @@
     <link rel="apple-touch-icon" sizes="192x192" href="~/img/icons/icon-192.png" />
     <link rel="apple-touch-icon" sizes="512x512" href="~/img/icons/icon-512.png" />
     <script type="application/ld+json">
+    @Html.Raw("""
     {
-      "@@context": "https://schema.org",
-      "@@type": "EducationalOrganization",
+      "@context": "https://schema.org",
+      "@type": "EducationalOrganization",
       "name": "Systémy jakosti s.r.o.",
       "description": "Poskytovatel školení a poradenství v oblasti ISO norem",
       "url": "https://www.systemy-jakosti.cz",
       "address": {
-        "@@type": "PostalAddress",
+        "@type": "PostalAddress",
         "addressCountry": "CZ"
       }
     }
+    """)
     </script>
     @await RenderSectionAsync("Head", required: false)
 </head>


### PR DESCRIPTION
## Summary
- ensure the admin dashboard page model imports authorization policies so chatbot settings compile
- reference the newsletter confirmation email template with the fully qualified enum value
- render the layout's JSON-LD metadata with Html.Raw to avoid Razor parsing issues

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd416573d0832180dce1f62fc6f74e