### PR TITLE
Fix Razor layout JSON script formatting

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -48,7 +48,6 @@
     <link rel="apple-touch-icon" sizes="192x192" href="~/img/icons/icon-192.png" />
     <link rel="apple-touch-icon" sizes="512x512" href="~/img/icons/icon-512.png" />
     <script type="application/ld+json">
-    @Html.Raw("""
     {
       "@context": "https://schema.org",
       "@type": "EducationalOrganization",
@@ -60,7 +59,6 @@
         "addressCountry": "CZ"
       }
     }
-    """)
     </script>
     @await RenderSectionAsync("Head", required: false)
 </head>


### PR DESCRIPTION
## Summary
- remove Html.Raw wrapper around structured data JSON to resolve Razor parse errors

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd44a1a7a48321bf9882e3c706f0ed