### PR TITLE
Fix JSON-LD script escaping in layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -49,13 +49,13 @@
     <link rel="apple-touch-icon" sizes="512x512" href="~/img/icons/icon-512.png" />
     <script type="application/ld+json">
     {
-      "@context": "https://schema.org",
-      "@type": "EducationalOrganization",
+      "@@context": "https://schema.org",
+      "@@type": "EducationalOrganization",
       "name": "Systémy jakosti s.r.o.",
       "description": "Poskytovatel školení a poradenství v oblasti ISO norem",
       "url": "https://www.systemy-jakosti.cz",
       "address": {
-        "@type": "PostalAddress",
+        "@@type": "PostalAddress",
         "addressCountry": "CZ"
       }
     }


### PR DESCRIPTION
## Summary
- escape JSON-LD metadata keys in the shared layout so Razor does not treat them as C# expressions

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd46033d188321a144a8aef728b9f3