### PR TITLE
Update navigation labels for quality consulting

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -83,6 +83,9 @@
                             <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@Localizer["NavAbout"]</a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@Localizer["NavServices"]</a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@Localizer["NavCourses"]</a>
                         </li>
                         <li class="nav-item">

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -16,25 +16,28 @@
     <value>Přeskočit na obsah</value>
   </data>
   <data name="BrandName" xml:space="preserve">
-    <value>Systémy jakosti</value>
+    <value>Systémy jakosti – poradenství ISO</value>
   </data>
   <data name="ToggleNavigation" xml:space="preserve">
     <value>Přepnout navigaci</value>
   </data>
   <data name="NavHome" xml:space="preserve">
-    <value>Domů</value>
+    <value>Úvod – poradenství systémů jakosti</value>
   </data>
   <data name="NavAbout" xml:space="preserve">
-    <value>O společnosti</value>
+    <value>O společnosti Systémy jakosti</value>
   </data>
   <data name="NavCourses" xml:space="preserve">
-    <value>Kurzy a školení</value>
+    <value>Kurzy a školení ISO</value>
   </data>
   <data name="NavArticles" xml:space="preserve">
-    <value>Články</value>
+    <value>Články a případové studie</value>
   </data>
   <data name="NavCorporateInquiry" xml:space="preserve">
-    <value>Firemní poptávka</value>
+    <value>Firemní poptávka / audit na míru</value>
+  </data>
+  <data name="NavServices" xml:space="preserve">
+    <value>Poradenství a audity</value>
   </data>
   <data name="NavPrivacy" xml:space="preserve">
     <value>Ochrana soukromí</value>


### PR DESCRIPTION
## Summary
- refresh key navigation labels to reflect ISO quality consulting terminology and expand brand description
- introduce a new localized "Poradenství a audity" menu entry pointing to the About page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de100d8e708321ba4ddd462164c648