### PR TITLE
Update homepage quality filters and ISO chips

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -58,6 +58,8 @@
             <a class="chip chip-light" href="/Courses/Index?Level=Beginner">@Localizer["ChipBeginner"]</a>
             <a class="chip chip-light" href="/Courses/Index?City=Praha">@Localizer["ChipPrague"]</a>
             <a class="chip chip-light" href="/Courses/Index?HasCertificate=true">@Localizer["ChipCertificate"]</a>
+            <a class="chip chip-light" href="/Courses/Index?q=akreditace">@Localizer["ChipAccreditation"]</a>
+            <a class="chip chip-light" href="/Courses/Index?q=intern%C3%AD%20audit">@Localizer["ChipInternalAudits"]</a>
         </div>
     </div>
 </section>

--- a/Resources/Pages.Index.cshtml.en.resx
+++ b/Resources/Pages.Index.cshtml.en.resx
@@ -58,10 +58,10 @@
     <value>I am</value>
   </data>
   <data name="PersonaLabel" xml:space="preserve">
-    <value>Choose your role</value>
+    <value>Select your role in the quality system</value>
   </data>
   <data name="PersonaHelp" xml:space="preserve">
-    <value>Helps us tailor course suggestions.</value>
+    <value>Helps us tailor course suggestions. For example, quality manager or internal auditor.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Select a course</value>
@@ -90,6 +90,12 @@
   <data name="ChipCertificate" xml:space="preserve">
     <value>With certificate</value>
   </data>
+  <data name="ChipAccreditation" xml:space="preserve">
+    <value>Accreditation preparation</value>
+  </data>
+  <data name="ChipInternalAudits" xml:space="preserve">
+    <value>Internal audits</value>
+  </data>
   <data name="ChipOnline" xml:space="preserve">
     <value>Online</value>
   </data>
@@ -103,10 +109,10 @@
     <value>I want to</value>
   </data>
   <data name="GoalLabel" xml:space="preserve">
-    <value>Choose your goal</value>
+    <value>Which goal do you want to achieve by meeting the standards?</value>
   </data>
   <data name="GoalHelp" xml:space="preserve">
-    <value>Tell us what you want to achieve with the training.</value>
+    <value>Tell us what you want to achieve with the training. For example, process improvement or accreditation preparation.</value>
   </data>
   <data name="NewsHeading" xml:space="preserve">
     <value>News</value>

--- a/Resources/Pages.Index.cshtml.resx
+++ b/Resources/Pages.Index.cshtml.resx
@@ -58,10 +58,10 @@
     <value>Jsem</value>
   </data>
   <data name="PersonaLabel" xml:space="preserve">
-    <value>Vyberte svoji roli</value>
+    <value>Vyberte svou roli v systému jakosti</value>
   </data>
   <data name="PersonaHelp" xml:space="preserve">
-    <value>Pomůže nám lépe doporučit kurzy.</value>
+    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Vyberte kurz</value>
@@ -90,6 +90,12 @@
   <data name="ChipCertificate" xml:space="preserve">
     <value>S certifikátem</value>
   </data>
+  <data name="ChipAccreditation" xml:space="preserve">
+    <value>Příprava na akreditaci</value>
+  </data>
+  <data name="ChipInternalAudits" xml:space="preserve">
+    <value>Interní audity</value>
+  </data>
   <data name="ChipOnline" xml:space="preserve">
     <value>Online</value>
   </data>
@@ -103,10 +109,10 @@
     <value>Chci</value>
   </data>
   <data name="GoalLabel" xml:space="preserve">
-    <value>Vyberte cíl</value>
+    <value>Jaký cíl chcete plněním norem dosáhnout?</value>
   </data>
   <data name="GoalHelp" xml:space="preserve">
-    <value>Popište, čeho chcete školením dosáhnout.</value>
+    <value>Popište, čeho chcete školením dosáhnout. Například zlepšení procesů, příprava na akreditaci.</value>
   </data>
   <data name="NewsHeading" xml:space="preserve">
     <value>Novinky</value>


### PR DESCRIPTION
## Summary
- refresh the hero form labels and help texts to highlight quality system roles and goals
- add ISO-focused quick filters for accreditation and internal audits on the homepage
- localize the new filter chips and updated helper copy in both Czech and English resources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de11e89c3483218bc7a8e3443bf33f