### PR TITLE
Expand layout containers for wider screens

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -70,7 +70,7 @@
     <div id="accessibility-assertive-region" class="visually-hidden" aria-live="assertive" aria-atomic="true"></div>
     <header class="app-header" role="banner">
         <nav class="navbar navbar-expand-lg navbar-toggleable-lg navbar-dark app-navbar" role="navigation" aria-label='@Localizer["PrimaryNavigation"]' style="background-color: #1ca8d7;">
-            <div class="container-xl">
+            <div class="container-xxl">
                 <a class="navbar-brand" asp-area="" asp-page="/Index">@Localizer["BrandName"]</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNavigation" aria-controls="primaryNavigation"
                         aria-expanded="false" aria-label='@Localizer["ToggleNavigation"]'>
@@ -183,14 +183,14 @@
             </div>
         </nav>
     </header>
-    <div class="app-content container-xl px-3 px-md-4">
+    <div class="app-content container-xxl px-3 px-md-4">
         <main id="main-content" role="main" class="app-main" tabindex="-1">
             @RenderBody()
         </main>
     </div>
 
     <footer class="footer app-footer mt-5" role="contentinfo">
-        <div class="container-xl py-4">
+        <div class="container-xxl py-4">
             <div class="d-flex flex-column flex-md-row gap-3 align-items-start align-items-md-center justify-content-between">
                 <div class="text-muted small">
                     &copy; 2025 - SysJaky_N - <a asp-area="" asp-page="/Privacy" class="text-decoration-none">@Localizer["FooterPrivacy"]</a>


### PR DESCRIPTION
## Summary
- expand the shared layout's container classes to use Bootstrap's `container-xxl`
- allow header, main content, and footer to take advantage of the wider breakpoint for large displays

## Testing
- N/A (environment missing `dotnet` SDK)

------
https://chatgpt.com/codex/tasks/task_e_68de1542bf1c8321a20cde2a56090081