### PR TITLE
Align homepage process steps across locales

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -267,7 +267,7 @@
             <div class="col-md-4">
                 <div class="feature-card h-100 p-4">
                     <div class="icon-circle mx-auto mb-3">
-                        <i class="bi bi-journal"></i>
+                        <i class="bi bi-clipboard-data" aria-hidden="true"></i>
                     </div>
                     <h3 class="h5">@Localizer["StepSelectTitle"]</h3>
                     <p class="mb-0">@Localizer["StepSelectDescription"]</p>
@@ -276,7 +276,7 @@
             <div class="col-md-4">
                 <div class="feature-card h-100 p-4">
                     <div class="icon-circle mx-auto mb-3">
-                        <i class="bi bi-person-check"></i>
+                        <i class="bi bi-calendar-check" aria-hidden="true"></i>
                     </div>
                     <h3 class="h5">@Localizer["StepRegisterTitle"]</h3>
                     <p class="mb-0">@Localizer["StepRegisterDescription"]</p>
@@ -285,7 +285,7 @@
             <div class="col-md-4">
                 <div class="feature-card h-100 p-4">
                     <div class="icon-circle mx-auto mb-3">
-                        <i class="bi bi-credit-card"></i>
+                        <i class="bi bi-patch-check" aria-hidden="true"></i>
                     </div>
                     <h3 class="h5">@Localizer["StepPayTitle"]</h3>
                     <p class="mb-0">@Localizer["StepPayDescription"]</p>

--- a/Resources/Pages.Index.cshtml.en.resx
+++ b/Resources/Pages.Index.cshtml.en.resx
@@ -64,22 +64,22 @@
     <value>Helps us tailor course suggestions. For example, quality manager or internal auditor.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
-    <value>Select a course</value>
+    <value>Analyze the current state</value>
   </data>
   <data name="StepSelectDescription" xml:space="preserve">
-    <value>Browse our offer and choose the right course.</value>
+    <value>Perform a gap analysis, map your processes and identify areas that need improvement.</value>
   </data>
   <data name="StepRegisterTitle" xml:space="preserve">
-    <value>Register</value>
+    <value>Plan training and audits</value>
   </data>
   <data name="StepRegisterDescription" xml:space="preserve">
-    <value>Register easily and create your account.</value>
+    <value>Build a training plan for your team, schedule the internal audit and assign responsibilities.</value>
   </data>
   <data name="StepPayTitle" xml:space="preserve">
-    <value>Pay</value>
+    <value>Achieve certification with confidence</value>
   </data>
   <data name="StepPayDescription" xml:space="preserve">
-    <value>Secure online payment reserves your spot.</value>
+    <value>Prepare the documentation, coordinate the certification audit and guide everyone through the process stress-free.</value>
   </data>
   <data name="CalendarButton" xml:space="preserve">
     <value>Course calendar</value>


### PR DESCRIPTION
## Summary
- synchronize the homepage process steps between Czech and English resources to describe the ISO implementation workflow
- adjust the homepage "How it works" icons to match the updated process and add aria-hidden attributes for consistency

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68de1543f3e08321940b3c5a31bbfea4