### PR TITLE
Localize certification timeline partial

### DIFF
--- a/Pages/Shared/_CertificationTimeline.cshtml
+++ b/Pages/Shared/_CertificationTimeline.cshtml
@@ -1,41 +1,44 @@
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
+
 <section id="certification-path" class="certification-timeline-section py-5">
     <div class="container-xl">
         <div class="timeline-intro text-center text-md-start mb-5" data-scroll-reveal="fade-up">
-            <span class="timeline-eyebrow">Cesta k certifikaci</span>
-            <h2 class="timeline-heading">Zorientujte se v procesu získání certifikace</h2>
-            <p class="mb-0 text-muted">Od prvního kontaktu až po závěrečný certifikát vás provedeme pěti navazujícími kroky a zajistíme, aby váš tým měl jistotu v každé fázi.</p>
+            <span class="timeline-eyebrow">@Localizer["TimelineEyebrow"]</span>
+            <h2 class="timeline-heading">@Localizer["TimelineHeading"]</h2>
+            <p class="mb-0 text-muted">@Localizer["TimelineIntroDescription"]</p>
         </div>
         <div class="certification-timeline">
-            <aside class="timeline-progress" aria-label="Postup certifikace" data-scroll-reveal="fade-up">
+            <aside class="timeline-progress" aria-label="@Localizer["TimelineProgressAriaLabel"]" data-scroll-reveal="fade-up">
                 <ol class="timeline-progress-list">
                     <li class="timeline-progress-item is-active">
                         <button type="button" class="timeline-progress-button" data-step-index="0">
                             <span class="progress-step-number">1</span>
-                            <span class="progress-step-label">Úvodní konzultace</span>
+                            <span class="progress-step-label">@Localizer["ProgressStep1Label"]</span>
                         </button>
                     </li>
                     <li class="timeline-progress-item">
                         <button type="button" class="timeline-progress-button" data-step-index="1">
                             <span class="progress-step-number">2</span>
-                            <span class="progress-step-label">Školení</span>
+                            <span class="progress-step-label">@Localizer["ProgressStep2Label"]</span>
                         </button>
                     </li>
                     <li class="timeline-progress-item">
                         <button type="button" class="timeline-progress-button" data-step-index="2">
                             <span class="progress-step-number">3</span>
-                            <span class="progress-step-label">Implementace</span>
+                            <span class="progress-step-label">@Localizer["ProgressStep3Label"]</span>
                         </button>
                     </li>
                     <li class="timeline-progress-item">
                         <button type="button" class="timeline-progress-button" data-step-index="3">
                             <span class="progress-step-number">4</span>
-                            <span class="progress-step-label">Pre-audit</span>
+                            <span class="progress-step-label">@Localizer["ProgressStep4Label"]</span>
                         </button>
                     </li>
                     <li class="timeline-progress-item">
                         <button type="button" class="timeline-progress-button" data-step-index="4">
                             <span class="progress-step-number">5</span>
-                            <span class="progress-step-label">Certifikace</span>
+                            <span class="progress-step-label">@Localizer["ProgressStep5Label"]</span>
                         </button>
                     </li>
                 </ol>
@@ -52,19 +55,19 @@
                             </svg>
                         </span>
                         <span class="certification-step-copy">
-                            <span class="step-title">Úvodní konzultace a analýza</span>
-                            <span class="step-summary">Společně zmapujeme aktuální stav a nastavíme cíle projektu.</span>
+                            <span class="step-title">@Localizer["Step1Title"]</span>
+                            <span class="step-summary">@Localizer["Step1Summary"]</span>
                         </span>
                         <span class="step-indicator" aria-hidden="true"></span>
                     </button>
                     <div class="certification-step-detail" id="certification-step-panel-1">
-                        <p>V úvodní konzultaci si ujasníme rozsah projektu, legislativní a normativní požadavky i očekávání vedení. Výstupem je jasná strategie a plán další spolupráce.</p>
+                        <p>@Localizer["Step1Description"]</p>
                         <ul>
-                            <li>Analýza současného stavu organizace (gap analysis)</li>
-                            <li>Identifikace požadavků normy a legislativy</li>
-                            <li>Výběr vhodného certifikačního orgánu</li>
-                            <li>Stanovení realistického harmonogramu projektu</li>
-                            <li>Odhad nákladů a zdrojů</li>
+                            <li>@Localizer["Step1Point1"]</li>
+                            <li>@Localizer["Step1Point2"]</li>
+                            <li>@Localizer["Step1Point3"]</li>
+                            <li>@Localizer["Step1Point4"]</li>
+                            <li>@Localizer["Step1Point5"]</li>
                         </ul>
                     </div>
                 </article>
@@ -80,19 +83,19 @@
                             </svg>
                         </span>
                         <span class="certification-step-copy">
-                            <span class="step-title">Odborná školení pro váš tým</span>
-                            <span class="step-summary">Vybereme cílené kurzy pro management, auditory i operativu.</span>
+                            <span class="step-title">@Localizer["Step2Title"]</span>
+                            <span class="step-summary">@Localizer["Step2Summary"]</span>
                         </span>
                         <span class="step-indicator" aria-hidden="true"></span>
                     </button>
                     <div class="certification-step-detail" id="certification-step-panel-2" hidden>
-                        <p>Na základě domluvené strategie vybereme kombinaci kurzů na míru. Propojíme teoretické požadavky s praktickými ukázkami, aby každý člen týmu přesně věděl, co má dělat.</p>
+                        <p>@Localizer["Step2Description"]</p>
                         <ul>
-                            <li>Úvodní školení k požadavkům normy pro všechny zaměstnance</li>
-                            <li>Specializované kurzy pro manažera kvality</li>
-                            <li>Školení interních auditorů</li>
-                            <li>Workshop implementačního týmu</li>
-                            <li>Pracovní materiály, check-listy a šablony dokumentů</li>
+                            <li>@Localizer["Step2Point1"]</li>
+                            <li>@Localizer["Step2Point2"]</li>
+                            <li>@Localizer["Step2Point3"]</li>
+                            <li>@Localizer["Step2Point4"]</li>
+                            <li>@Localizer["Step2Point5"]</li>
                         </ul>
                     </div>
                 </article>
@@ -110,19 +113,19 @@
                             </svg>
                         </span>
                         <span class="certification-step-copy">
-                            <span class="step-title">Implementace systému managementu</span>
-                            <span class="step-summary">Nastavíme procesy, dokumentaci i zapojení lidí do změn.</span>
+                            <span class="step-title">@Localizer["Step3Title"]</span>
+                            <span class="step-summary">@Localizer["Step3Summary"]</span>
                         </span>
                         <span class="step-indicator" aria-hidden="true"></span>
                     </button>
                     <div class="certification-step-detail" id="certification-step-panel-3" hidden>
-                        <p>Po školení společně nastavíme potřebné procesy, strukturu dokumentace a způsob komunikace změn. Zapojíme zaměstnance a nastavíme metriky pro dlouhodobé zlepšování.</p>
+                        <p>@Localizer["Step3Description"]</p>
                         <ul>
-                            <li>Tvorba/revize politiky a cílů</li>
-                            <li>Mapování a nastavení procesů</li>
-                            <li>Vytvoření/aktualizace řízené dokumentace</li>
-                            <li>Management rizik a příležitostí</li>
-                            <li>Školení pracovníků na nové postupy</li>
+                            <li>@Localizer["Step3Point1"]</li>
+                            <li>@Localizer["Step3Point2"]</li>
+                            <li>@Localizer["Step3Point3"]</li>
+                            <li>@Localizer["Step3Point4"]</li>
+                            <li>@Localizer["Step3Point5"]</li>
                         </ul>
                     </div>
                 </article>
@@ -140,19 +143,19 @@
                             </svg>
                         </span>
                         <span class="certification-step-copy">
-                            <span class="step-title">Interní audit a pre-audit</span>
-                            <span class="step-summary">Prověříme připravenost organizace a nasimulujeme auditní situace.</span>
+                            <span class="step-title">@Localizer["Step4Title"]</span>
+                            <span class="step-summary">@Localizer["Step4Summary"]</span>
                         </span>
                         <span class="step-indicator" aria-hidden="true"></span>
                     </button>
                     <div class="certification-step-detail" id="certification-step-panel-4" hidden>
-                        <p>Před ostrým auditem provedeme kompletní interní prověrku a modelové situace, které tým připraví na reálné otázky certifikačního orgánu.</p>
+                        <p>@Localizer["Step4Description"]</p>
                         <ul>
-                            <li>Provedení kompletního interního auditu</li>
-                            <li>Identifikace neshod a oblastí ke zlepšení</li>
-                            <li>Modelové rozhovory s pracovníky</li>
-                            <li>Kontrola dokumentace a záznamů</li>
-                            <li>Akční plán pro odstranění zjištěných neshod</li>
+                            <li>@Localizer["Step4Point1"]</li>
+                            <li>@Localizer["Step4Point2"]</li>
+                            <li>@Localizer["Step4Point3"]</li>
+                            <li>@Localizer["Step4Point4"]</li>
+                            <li>@Localizer["Step4Point5"]</li>
                         </ul>
                     </div>
                 </article>
@@ -169,19 +172,19 @@
                             </svg>
                         </span>
                         <span class="certification-step-copy">
-                            <span class="step-title">Certifikační audit a získání certifikátu</span>
-                            <span class="step-summary">Doprovodíme vás u certifikačního auditu a nastavíme následnou péči.</span>
+                            <span class="step-title">@Localizer["Step5Title"]</span>
+                            <span class="step-summary">@Localizer["Step5Summary"]</span>
                         </span>
                         <span class="step-indicator" aria-hidden="true"></span>
                     </button>
                     <div class="certification-step-detail" id="certification-step-panel-5" hidden>
-                        <p>Společně zvládneme certifikační audit, pomůžeme odstranit případné neshody a nastavíme plán dozorových auditů, aby certifikace dlouhodobě vydržela.</p>
+                        <p>@Localizer["Step5Description"]</p>
                         <ul>
-                            <li>Koordinace s certifikačním orgánem</li>
-                            <li>Asistence při průběhu auditu</li>
-                            <li>Podpora při odstranění případných neshod</li>
-                            <li>Získání certifikátu</li>
-                            <li>Plán dozorových auditů a refresher školení</li>
+                            <li>@Localizer["Step5Point1"]</li>
+                            <li>@Localizer["Step5Point2"]</li>
+                            <li>@Localizer["Step5Point3"]</li>
+                            <li>@Localizer["Step5Point4"]</li>
+                            <li>@Localizer["Step5Point5"]</li>
                         </ul>
                     </div>
                 </article>
@@ -189,8 +192,8 @@
         </div>
         <div class="timeline-cta text-center text-md-start mt-5" data-scroll-reveal="fade-up">
             <div class="d-flex flex-column flex-md-row gap-3">
-                <a class="btn btn-primary btn-lg" href="/Contact">Domluvit konzultaci</a>
-                <a class="btn btn-accent btn-lg" href="/Courses/Index?HasCertificate=true">Zobrazit relevantní kurzy</a>
+                <a class="btn btn-primary btn-lg" href="/Contact">@Localizer["PrimaryCta"]</a>
+                <a class="btn btn-accent btn-lg" href="/Courses/Index?HasCertificate=true">@Localizer["SecondaryCta"]</a>
             </div>
         </div>
     </div>

--- a/Resources/Pages.Shared._CertificationTimeline.cshtml.en.resx
+++ b/Resources/Pages.Shared._CertificationTimeline.cshtml.en.resx
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TimelineEyebrow" xml:space="preserve">
+    <value>Certification journey</value>
+  </data>
+  <data name="TimelineHeading" xml:space="preserve">
+    <value>Navigate the certification process</value>
+  </data>
+  <data name="TimelineIntroDescription" xml:space="preserve">
+    <value>From the first contact to the final certificate, we guide you through five consecutive steps and ensure your team feels confident at every stage.</value>
+  </data>
+  <data name="TimelineProgressAriaLabel" xml:space="preserve">
+    <value>Certification progress</value>
+  </data>
+  <data name="ProgressStep1Label" xml:space="preserve">
+    <value>Initial consultation</value>
+  </data>
+  <data name="ProgressStep2Label" xml:space="preserve">
+    <value>Training</value>
+  </data>
+  <data name="ProgressStep3Label" xml:space="preserve">
+    <value>Implementation</value>
+  </data>
+  <data name="ProgressStep4Label" xml:space="preserve">
+    <value>Pre-audit</value>
+  </data>
+  <data name="ProgressStep5Label" xml:space="preserve">
+    <value>Certification</value>
+  </data>
+  <data name="Step1Title" xml:space="preserve">
+    <value>Initial consultation and analysis</value>
+  </data>
+  <data name="Step1Summary" xml:space="preserve">
+    <value>Together we assess the current situation and set project objectives.</value>
+  </data>
+  <data name="Step1Description" xml:space="preserve">
+    <value>During the initial consultation we clarify the project scope, legislative and standard requirements, and leadership expectations. The outcome is a clear strategy and cooperation plan.</value>
+  </data>
+  <data name="Step1Point1" xml:space="preserve">
+    <value>Analysis of the organisation's current state (gap analysis)</value>
+  </data>
+  <data name="Step1Point2" xml:space="preserve">
+    <value>Identification of standard and legislative requirements</value>
+  </data>
+  <data name="Step1Point3" xml:space="preserve">
+    <value>Selection of a suitable certification body</value>
+  </data>
+  <data name="Step1Point4" xml:space="preserve">
+    <value>Setting a realistic project timeline</value>
+  </data>
+  <data name="Step1Point5" xml:space="preserve">
+    <value>Estimating costs and resources</value>
+  </data>
+  <data name="Step2Title" xml:space="preserve">
+    <value>Specialised training for your team</value>
+  </data>
+  <data name="Step2Summary" xml:space="preserve">
+    <value>We select targeted courses for management, auditors, and operations.</value>
+  </data>
+  <data name="Step2Description" xml:space="preserve">
+    <value>Based on the agreed strategy we choose a tailored mix of courses. We connect theoretical requirements with practical examples so every team member knows exactly what to do.</value>
+  </data>
+  <data name="Step2Point1" xml:space="preserve">
+    <value>Introductory training on standard requirements for all employees</value>
+  </data>
+  <data name="Step2Point2" xml:space="preserve">
+    <value>Specialised courses for the quality manager</value>
+  </data>
+  <data name="Step2Point3" xml:space="preserve">
+    <value>Internal auditor training</value>
+  </data>
+  <data name="Step2Point4" xml:space="preserve">
+    <value>Implementation team workshop</value>
+  </data>
+  <data name="Step2Point5" xml:space="preserve">
+    <value>Working materials, checklists, and document templates</value>
+  </data>
+  <data name="Step3Title" xml:space="preserve">
+    <value>Management system implementation</value>
+  </data>
+  <data name="Step3Summary" xml:space="preserve">
+    <value>We set up processes, documentation, and people engagement for the changes.</value>
+  </data>
+  <data name="Step3Description" xml:space="preserve">
+    <value>After the training we jointly establish the necessary processes, documentation structure, and change communication. We involve employees and define metrics for long-term improvement.</value>
+  </data>
+  <data name="Step3Point1" xml:space="preserve">
+    <value>Creation/revision of policies and objectives</value>
+  </data>
+  <data name="Step3Point2" xml:space="preserve">
+    <value>Process mapping and setup</value>
+  </data>
+  <data name="Step3Point3" xml:space="preserve">
+    <value>Creation/update of controlled documentation</value>
+  </data>
+  <data name="Step3Point4" xml:space="preserve">
+    <value>Risk and opportunity management</value>
+  </data>
+  <data name="Step3Point5" xml:space="preserve">
+    <value>Training staff on new procedures</value>
+  </data>
+  <data name="Step4Title" xml:space="preserve">
+    <value>Internal audit and pre-audit</value>
+  </data>
+  <data name="Step4Summary" xml:space="preserve">
+    <value>We verify the organisation's readiness and simulate audit situations.</value>
+  </data>
+  <data name="Step4Description" xml:space="preserve">
+    <value>Before the official audit we carry out a complete internal review and model situations to prepare the team for real questions from the certification body.</value>
+  </data>
+  <data name="Step4Point1" xml:space="preserve">
+    <value>Carrying out a full internal audit</value>
+  </data>
+  <data name="Step4Point2" xml:space="preserve">
+    <value>Identifying nonconformities and improvement areas</value>
+  </data>
+  <data name="Step4Point3" xml:space="preserve">
+    <value>Mock interviews with employees</value>
+  </data>
+  <data name="Step4Point4" xml:space="preserve">
+    <value>Review of documentation and records</value>
+  </data>
+  <data name="Step4Point5" xml:space="preserve">
+    <value>Action plan to resolve identified nonconformities</value>
+  </data>
+  <data name="Step5Title" xml:space="preserve">
+    <value>Certification audit and obtaining the certificate</value>
+  </data>
+  <data name="Step5Summary" xml:space="preserve">
+    <value>We accompany you during the certification audit and set up ongoing support.</value>
+  </data>
+  <data name="Step5Description" xml:space="preserve">
+    <value>Together we handle the certification audit, help resolve any nonconformities, and set a surveillance audit plan to keep the certification long term.</value>
+  </data>
+  <data name="Step5Point1" xml:space="preserve">
+    <value>Coordination with the certification body</value>
+  </data>
+  <data name="Step5Point2" xml:space="preserve">
+    <value>Assistance throughout the audit</value>
+  </data>
+  <data name="Step5Point3" xml:space="preserve">
+    <value>Support in resolving any nonconformities</value>
+  </data>
+  <data name="Step5Point4" xml:space="preserve">
+    <value>Receiving the certificate</value>
+  </data>
+  <data name="Step5Point5" xml:space="preserve">
+    <value>Plan for surveillance audits and refresher training</value>
+  </data>
+  <data name="PrimaryCta" xml:space="preserve">
+    <value>Book a consultation</value>
+  </data>
+  <data name="SecondaryCta" xml:space="preserve">
+    <value>View relevant courses</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._CertificationTimeline.cshtml.resx
+++ b/Resources/Pages.Shared._CertificationTimeline.cshtml.resx
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TimelineEyebrow" xml:space="preserve">
+    <value>Cesta k certifikaci</value>
+  </data>
+  <data name="TimelineHeading" xml:space="preserve">
+    <value>Zorientujte se v procesu získání certifikace</value>
+  </data>
+  <data name="TimelineIntroDescription" xml:space="preserve">
+    <value>Od prvního kontaktu až po závěrečný certifikát vás provedeme pěti navazujícími kroky a zajistíme, aby váš tým měl jistotu v každé fázi.</value>
+  </data>
+  <data name="TimelineProgressAriaLabel" xml:space="preserve">
+    <value>Postup certifikace</value>
+  </data>
+  <data name="ProgressStep1Label" xml:space="preserve">
+    <value>Úvodní konzultace</value>
+  </data>
+  <data name="ProgressStep2Label" xml:space="preserve">
+    <value>Školení</value>
+  </data>
+  <data name="ProgressStep3Label" xml:space="preserve">
+    <value>Implementace</value>
+  </data>
+  <data name="ProgressStep4Label" xml:space="preserve">
+    <value>Pre-audit</value>
+  </data>
+  <data name="ProgressStep5Label" xml:space="preserve">
+    <value>Certifikace</value>
+  </data>
+  <data name="Step1Title" xml:space="preserve">
+    <value>Úvodní konzultace a analýza</value>
+  </data>
+  <data name="Step1Summary" xml:space="preserve">
+    <value>Společně zmapujeme aktuální stav a nastavíme cíle projektu.</value>
+  </data>
+  <data name="Step1Description" xml:space="preserve">
+    <value>V úvodní konzultaci si ujasníme rozsah projektu, legislativní a normativní požadavky i očekávání vedení. Výstupem je jasná strategie a plán další spolupráce.</value>
+  </data>
+  <data name="Step1Point1" xml:space="preserve">
+    <value>Analýza současného stavu organizace (gap analysis)</value>
+  </data>
+  <data name="Step1Point2" xml:space="preserve">
+    <value>Identifikace požadavků normy a legislativy</value>
+  </data>
+  <data name="Step1Point3" xml:space="preserve">
+    <value>Výběr vhodného certifikačního orgánu</value>
+  </data>
+  <data name="Step1Point4" xml:space="preserve">
+    <value>Stanovení realistického harmonogramu projektu</value>
+  </data>
+  <data name="Step1Point5" xml:space="preserve">
+    <value>Odhad nákladů a zdrojů</value>
+  </data>
+  <data name="Step2Title" xml:space="preserve">
+    <value>Odborná školení pro váš tým</value>
+  </data>
+  <data name="Step2Summary" xml:space="preserve">
+    <value>Vybereme cílené kurzy pro management, auditory i operativu.</value>
+  </data>
+  <data name="Step2Description" xml:space="preserve">
+    <value>Na základě domluvené strategie vybereme kombinaci kurzů na míru. Propojíme teoretické požadavky s praktickými ukázkami, aby každý člen týmu přesně věděl, co má dělat.</value>
+  </data>
+  <data name="Step2Point1" xml:space="preserve">
+    <value>Úvodní školení k požadavkům normy pro všechny zaměstnance</value>
+  </data>
+  <data name="Step2Point2" xml:space="preserve">
+    <value>Specializované kurzy pro manažera kvality</value>
+  </data>
+  <data name="Step2Point3" xml:space="preserve">
+    <value>Školení interních auditorů</value>
+  </data>
+  <data name="Step2Point4" xml:space="preserve">
+    <value>Workshop implementačního týmu</value>
+  </data>
+  <data name="Step2Point5" xml:space="preserve">
+    <value>Pracovní materiály, check-listy a šablony dokumentů</value>
+  </data>
+  <data name="Step3Title" xml:space="preserve">
+    <value>Implementace systému managementu</value>
+  </data>
+  <data name="Step3Summary" xml:space="preserve">
+    <value>Nastavíme procesy, dokumentaci i zapojení lidí do změn.</value>
+  </data>
+  <data name="Step3Description" xml:space="preserve">
+    <value>Po školení společně nastavíme potřebné procesy, strukturu dokumentace a způsob komunikace změn. Zapojíme zaměstnance a nastavíme metriky pro dlouhodobé zlepšování.</value>
+  </data>
+  <data name="Step3Point1" xml:space="preserve">
+    <value>Tvorba/revize politiky a cílů</value>
+  </data>
+  <data name="Step3Point2" xml:space="preserve">
+    <value>Mapování a nastavení procesů</value>
+  </data>
+  <data name="Step3Point3" xml:space="preserve">
+    <value>Vytvoření/aktualizace řízené dokumentace</value>
+  </data>
+  <data name="Step3Point4" xml:space="preserve">
+    <value>Management rizik a příležitostí</value>
+  </data>
+  <data name="Step3Point5" xml:space="preserve">
+    <value>Školení pracovníků na nové postupy</value>
+  </data>
+  <data name="Step4Title" xml:space="preserve">
+    <value>Interní audit a pre-audit</value>
+  </data>
+  <data name="Step4Summary" xml:space="preserve">
+    <value>Prověříme připravenost organizace a nasimulujeme auditní situace.</value>
+  </data>
+  <data name="Step4Description" xml:space="preserve">
+    <value>Před ostrým auditem provedeme kompletní interní prověrku a modelové situace, které tým připraví na reálné otázky certifikačního orgánu.</value>
+  </data>
+  <data name="Step4Point1" xml:space="preserve">
+    <value>Provedení kompletního interního auditu</value>
+  </data>
+  <data name="Step4Point2" xml:space="preserve">
+    <value>Identifikace neshod a oblastí ke zlepšení</value>
+  </data>
+  <data name="Step4Point3" xml:space="preserve">
+    <value>Modelové rozhovory s pracovníky</value>
+  </data>
+  <data name="Step4Point4" xml:space="preserve">
+    <value>Kontrola dokumentace a záznamů</value>
+  </data>
+  <data name="Step4Point5" xml:space="preserve">
+    <value>Akční plán pro odstranění zjištěných neshod</value>
+  </data>
+  <data name="Step5Title" xml:space="preserve">
+    <value>Certifikační audit a získání certifikátu</value>
+  </data>
+  <data name="Step5Summary" xml:space="preserve">
+    <value>Doprovodíme vás u certifikačního auditu a nastavíme následnou péči.</value>
+  </data>
+  <data name="Step5Description" xml:space="preserve">
+    <value>Společně zvládneme certifikační audit, pomůžeme odstranit případné neshody a nastavíme plán dozorových auditů, aby certifikace dlouhodobě vydržela.</value>
+  </data>
+  <data name="Step5Point1" xml:space="preserve">
+    <value>Koordinace s certifikačním orgánem</value>
+  </data>
+  <data name="Step5Point2" xml:space="preserve">
+    <value>Asistence při průběhu auditu</value>
+  </data>
+  <data name="Step5Point3" xml:space="preserve">
+    <value>Podpora při odstranění případných neshod</value>
+  </data>
+  <data name="Step5Point4" xml:space="preserve">
+    <value>Získání certifikátu</value>
+  </data>
+  <data name="Step5Point5" xml:space="preserve">
+    <value>Plán dozorových auditů a refresher školení</value>
+  </data>
+  <data name="PrimaryCta" xml:space="preserve">
+    <value>Domluvit konzultaci</value>
+  </data>
+  <data name="SecondaryCta" xml:space="preserve">
+    <value>Zobrazit relevantní kurzy</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- inject the view localizer into the certification timeline partial and replace hardcoded strings with resource lookups
- add Czech and English resource files that cover all timeline copy, including CTA buttons and aria labels

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68de154459d483218029ee288c559acc