### PR TITLE
Localize newsletter strings in layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -197,13 +197,13 @@
                 </div>
                 <form id="newsletter-form" class="newsletter-form d-flex flex-column flex-sm-row align-items-stretch gap-2" asp-page="/Api/Newsletter" method="post" novalidate>
                     <div class="d-flex flex-column flex-sm-row gap-2 w-100">
-                        <label class="visually-hidden" for="newsletter-email">E-mail</label>
-                        <input id="newsletter-email" name="Email" type="email" class="form-control form-control-sm" placeholder="Váš e-mail" autocomplete="email" required />
-                        <button type="submit" class="btn btn-primary btn-sm flex-shrink-0">Odebírat</button>
+                        <label class="visually-hidden" for="newsletter-email">@Localizer["NewsletterEmailLabel"]</label>
+                        <input id="newsletter-email" name="Email" type="email" class="form-control form-control-sm" placeholder='@Localizer["NewsletterPlaceholder"]' autocomplete="email" required />
+                        <button type="submit" class="btn btn-primary btn-sm flex-shrink-0">@Localizer["NewsletterButtonText"]</button>
                     </div>
                     <div class="form-check small mb-0">
                         <input class="form-check-input" type="checkbox" value="true" id="newsletter-consent" name="Consent" />
-                        <label class="form-check-label" for="newsletter-consent">Souhlasím se zpracováním</label>
+                        <label class="form-check-label" for="newsletter-consent">@Localizer["NewsletterConsentText"]</label>
                     </div>
                     <div class="newsletter-message small" role="status" aria-live="polite"></div>
                 </form>

--- a/Resources/Pages.Shared._Layout.cshtml.en.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.en.resx
@@ -93,6 +93,18 @@
   <data name="FooterPrivacy" xml:space="preserve">
     <value>Privacy</value>
   </data>
+  <data name="NewsletterEmailLabel" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="NewsletterPlaceholder" xml:space="preserve">
+    <value>Your email</value>
+  </data>
+  <data name="NewsletterButtonText" xml:space="preserve">
+    <value>Subscribe</value>
+  </data>
+  <data name="NewsletterConsentText" xml:space="preserve">
+    <value>I agree with data processing</value>
+  </data>
   <data name="LoginTitle" xml:space="preserve">
     <value>Login</value>
   </data>

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -93,6 +93,18 @@
   <data name="FooterPrivacy" xml:space="preserve">
     <value>Ochrana soukromí</value>
   </data>
+  <data name="NewsletterEmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="NewsletterPlaceholder" xml:space="preserve">
+    <value>Váš e-mail</value>
+  </data>
+  <data name="NewsletterButtonText" xml:space="preserve">
+    <value>Odebírat</value>
+  </data>
+  <data name="NewsletterConsentText" xml:space="preserve">
+    <value>Souhlasím se zpracováním</value>
+  </data>
   <data name="LoginTitle" xml:space="preserve">
     <value>Přihlášení</value>
   </data>


### PR DESCRIPTION
## Summary
- localize the newsletter form strings in the shared layout using the view localizer
- add Czech and English resource keys for the newsletter email placeholder, submit button, and consent text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de15453378832194b7cad42b1ecd4f