### PR TITLE
Add localized services page and fix navigation

### DIFF
--- a/Pages/Services.cshtml
+++ b/Pages/Services.cshtml
@@ -1,0 +1,170 @@
+@page
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
+@{
+    ViewData["Title"] = Localizer["Title"];
+}
+
+<section class="py-5">
+    <div class="container">
+        <div class="text-center mb-5">
+            <span class="text-uppercase text-primary fw-semibold">@Localizer["HeroBadge"]</span>
+            <h1 class="display-5 fw-bold mt-3">@Localizer["HeroHeading"]</h1>
+            <p class="lead text-muted">@Localizer["HeroDescription"]</p>
+        </div>
+
+        <div class="row g-4">
+            <div class="col-12 col-lg-6">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body p-4 p-lg-5">
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <div class="icon-circle bg-primary-subtle text-primary">
+                                <i class="bi bi-clipboard-check fs-3" aria-hidden="true"></i>
+                            </div>
+                            <h2 class="h4 mb-0">@Localizer["ServiceCard1Title"]</h2>
+                        </div>
+                        <p class="mb-0">@Localizer["ServiceCard1Description"]</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body p-4 p-lg-5">
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <div class="icon-circle bg-success-subtle text-success">
+                                <i class="bi bi-diagram-3 fs-3" aria-hidden="true"></i>
+                            </div>
+                            <h2 class="h4 mb-0">@Localizer["ServiceCard2Title"]</h2>
+                        </div>
+                        <p class="mb-0">@Localizer["ServiceCard2Description"]</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body p-4 p-lg-5">
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <div class="icon-circle bg-warning-subtle text-warning">
+                                <i class="bi bi-mortarboard fs-3" aria-hidden="true"></i>
+                            </div>
+                            <h2 class="h4 mb-0">@Localizer["ServiceCard3Title"]</h2>
+                        </div>
+                        <p class="mb-0">@Localizer["ServiceCard3Description"]</p>
+                    </div>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6">
+                <div class="card h-100 shadow-sm border-0">
+                    <div class="card-body p-4 p-lg-5">
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <div class="icon-circle bg-info-subtle text-info">
+                                <i class="bi bi-shield-lock fs-3" aria-hidden="true"></i>
+                            </div>
+                            <h2 class="h4 mb-0">@Localizer["ServiceCard4Title"]</h2>
+                        </div>
+                        <p class="mb-0">@Localizer["ServiceCard4Description"]</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5 bg-light rounded-4">
+    <div class="container py-4">
+        <div class="text-center mb-5">
+            <div class="d-inline-flex align-items-center gap-2 px-3 py-1 bg-white shadow-sm rounded-pill">
+                <i class="bi bi-stars text-warning" aria-hidden="true"></i>
+                <span class="fw-semibold text-uppercase small">@Localizer["HighlightsBadge"]</span>
+            </div>
+            <h2 class="mt-3">@Localizer["HighlightsHeading"]</h2>
+            <p class="text-muted mb-0">@Localizer["HighlightsDescription"]</p>
+        </div>
+
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-4">
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-graph-up-arrow text-primary fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">@Localizer["Highlight1Title"]</h3>
+                    <p class="text-muted mb-0">@Localizer["Highlight1Description"]</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-people text-success fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">@Localizer["Highlight2Title"]</h3>
+                    <p class="text-muted mb-0">@Localizer["Highlight2Description"]</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-tools text-warning fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">@Localizer["Highlight3Title"]</h3>
+                    <p class="text-muted mb-0">@Localizer["Highlight3Description"]</p>
+                </div>
+            </div>
+            <div class="col">
+                <div class="h-100 p-4 bg-white rounded-3 shadow-sm text-center">
+                    <i class="bi bi-calendar-check text-info fs-1" aria-hidden="true"></i>
+                    <h3 class="h5 mt-3">@Localizer["Highlight4Title"]</h3>
+                    <p class="text-muted mb-0">@Localizer["Highlight4Description"]</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5">
+    <div class="container">
+        <div class="row g-4 align-items-center">
+            <div class="col-12 col-lg-7">
+                <h2 class="h3 mb-3">@Localizer["ProcessHeading"]</h2>
+                <p class="text-muted">@Localizer["ProcessDescription"]</p>
+                <ol class="list-unstyled d-grid gap-3 mb-0">
+                    <li class="d-flex align-items-start gap-3">
+                        <span class="badge rounded-pill bg-primary">1</span>
+                        <div>
+                            <h3 class="h5 mb-1">@Localizer["ProcessStep1Title"]</h3>
+                            <p class="mb-0 text-muted">@Localizer["ProcessStep1Description"]</p>
+                        </div>
+                    </li>
+                    <li class="d-flex align-items-start gap-3">
+                        <span class="badge rounded-pill bg-primary">2</span>
+                        <div>
+                            <h3 class="h5 mb-1">@Localizer["ProcessStep2Title"]</h3>
+                            <p class="mb-0 text-muted">@Localizer["ProcessStep2Description"]</p>
+                        </div>
+                    </li>
+                    <li class="d-flex align-items-start gap-3">
+                        <span class="badge rounded-pill bg-primary">3</span>
+                        <div>
+                            <h3 class="h5 mb-1">@Localizer["ProcessStep3Title"]</h3>
+                            <p class="mb-0 text-muted">@Localizer["ProcessStep3Description"]</p>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+            <div class="col-12 col-lg-5">
+                <div class="p-4 p-lg-5 bg-primary text-white rounded-4 shadow-sm">
+                    <h3 class="h4 mb-3">@Localizer["CtaHeading"]</h3>
+                    <p class="mb-4">@Localizer["CtaDescription"]</p>
+                    <div class="d-grid gap-2">
+                        <a class="btn btn-light" asp-page="/CorporateInquiry">@Localizer["CtaPrimaryButton"]</a>
+                        <a class="btn btn-outline-light" asp-page="/Contact">@Localizer["CtaSecondaryButton"]</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<style>
+    .icon-circle {
+        width: 56px;
+        height: 56px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+</style>

--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -85,7 +85,7 @@
                             <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@Localizer["NavAbout"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@Localizer["NavServices"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Services" aria-current="@(currentPage == "/Services" ? "page" : null)">@Localizer["NavServices"]</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@Localizer["NavCourses"]</a>

--- a/Resources/Pages.Services.cshtml.en.resx
+++ b/Resources/Pages.Services.cshtml.en.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Services</value>
+  </data>
+  <data name="HeroBadge" xml:space="preserve">
+    <value>Comprehensive ISO services</value>
+  </data>
+  <data name="HeroHeading" xml:space="preserve">
+    <value>End-to-end support for management systems and accreditation</value>
+  </data>
+  <data name="HeroDescription" xml:space="preserve">
+    <value>We guide organisations through certification readiness, process design and capability building so that management systems deliver measurable impact.</value>
+  </data>
+  <data name="ServiceCard1Title" xml:space="preserve">
+    <value>Management system implementation</value>
+  </data>
+  <data name="ServiceCard1Description" xml:space="preserve">
+    <value>We assess the current state, define the target design and co-create documentation and tools required for ISO certification.</value>
+  </data>
+  <data name="ServiceCard2Title" xml:space="preserve">
+    <value>Internal &amp; supplier audits</value>
+  </data>
+  <data name="ServiceCard2Description" xml:space="preserve">
+    <value>Our team delivers internal audits, gap analyses and supplier audit support including action plans and follow-up guidance.</value>
+  </data>
+  <data name="ServiceCard3Title" xml:space="preserve">
+    <value>Training and capability development</value>
+  </data>
+  <data name="ServiceCard3Description" xml:space="preserve">
+    <value>We provide interactive training, workshops and mentoring tailored for leadership, specialists and operational staff.</value>
+  </data>
+  <data name="ServiceCard4Title" xml:space="preserve">
+    <value>Compliance &amp; risk management</value>
+  </data>
+  <data name="ServiceCard4Description" xml:space="preserve">
+    <value>We design risk management, internal control and compliance frameworks that are sustainable and audit-ready.</value>
+  </data>
+  <data name="HighlightsBadge" xml:space="preserve">
+    <value>Why work with us</value>
+  </data>
+  <data name="HighlightsHeading" xml:space="preserve">
+    <value>What you gain from our cooperation</value>
+  </data>
+  <data name="HighlightsDescription" xml:space="preserve">
+    <value>We act as a partner and focus on tangible value for your business.</value>
+  </data>
+  <data name="Highlight1Title" xml:space="preserve">
+    <value>Measurable outcomes</value>
+  </data>
+  <data name="Highlight1Description" xml:space="preserve">
+    <value>Every engagement is driven by clear objectives, KPIs and evaluation of benefits.</value>
+  </data>
+  <data name="Highlight2Title" xml:space="preserve">
+    <value>Expert team</value>
+  </data>
+  <data name="Highlight2Description" xml:space="preserve">
+    <value>You work with specialists in certification, laboratories and regulated industries.</value>
+  </data>
+  <data name="Highlight3Title" xml:space="preserve">
+    <value>Practical toolset</value>
+  </data>
+  <data name="Highlight3Description" xml:space="preserve">
+    <value>Templates, checklists and digital tools support long-term system sustainability.</value>
+  </data>
+  <data name="Highlight4Title" xml:space="preserve">
+    <value>Flexible delivery</value>
+  </data>
+  <data name="Highlight4Description" xml:space="preserve">
+    <value>We provide short-term interventions as well as comprehensive programmes with ongoing support.</value>
+  </data>
+  <data name="ProcessHeading" xml:space="preserve">
+    <value>How our cooperation works</value>
+  </data>
+  <data name="ProcessDescription" xml:space="preserve">
+    <value>We involve your team in every phase so that knowledge stays inside your organisation and changes last.</value>
+  </data>
+  <data name="ProcessStep1Title" xml:space="preserve">
+    <value>Initial consultation &amp; analysis</value>
+  </data>
+  <data name="ProcessStep1Description" xml:space="preserve">
+    <value>We map your current state, clarify objectives and define the scope of cooperation.</value>
+  </data>
+  <data name="ProcessStep2Title" xml:space="preserve">
+    <value>Implementation and training</value>
+  </data>
+  <data name="ProcessStep2Description" xml:space="preserve">
+    <value>We deliver the required changes, prepare documentation, set up processes and train your people.</value>
+  </data>
+  <data name="ProcessStep3Title" xml:space="preserve">
+    <value>Certification support</value>
+  </data>
+  <data name="ProcessStep3Description" xml:space="preserve">
+    <value>We assist during certification audits and help evaluate results and subsequent actions.</value>
+  </data>
+  <data name="CtaHeading" xml:space="preserve">
+    <value>Ready to elevate your management system?</value>
+  </data>
+  <data name="CtaDescription" xml:space="preserve">
+    <value>Tell us what you need. Together we will design the right form of cooperation.</value>
+  </data>
+  <data name="CtaPrimaryButton" xml:space="preserve">
+    <value>Request a tailored proposal</value>
+  </data>
+  <data name="CtaSecondaryButton" xml:space="preserve">
+    <value>Contact our team</value>
+  </data>
+</root>

--- a/Resources/Pages.Services.cshtml.resx
+++ b/Resources/Pages.Services.cshtml.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Služby</value>
+  </data>
+  <data name="HeroBadge" xml:space="preserve">
+    <value>Komplexní služby ISO</value>
+  </data>
+  <data name="HeroHeading" xml:space="preserve">
+    <value>Komplexní podpora pro systémy řízení a akreditace</value>
+  </data>
+  <data name="HeroDescription" xml:space="preserve">
+    <value>Pomáháme organizacím s přípravou na certifikace, zaváděním procesů a rozvojem kompetencí tak, aby systémy řízení přinášely měřitelné výsledky.</value>
+  </data>
+  <data name="ServiceCard1Title" xml:space="preserve">
+    <value>Implementace systémů řízení</value>
+  </data>
+  <data name="ServiceCard1Description" xml:space="preserve">
+    <value>Analyzujeme současný stav, navrhujeme cílové nastavení a společně s vaším týmem připravujeme dokumentaci i praktické nástroje pro certifikaci dle ISO norem.</value>
+  </data>
+  <data name="ServiceCard2Title" xml:space="preserve">
+    <value>Interní a dodavatelské audity</value>
+  </data>
+  <data name="ServiceCard2Description" xml:space="preserve">
+    <value>Zajišťujeme interní audity, gap analýzy i auditní podporu u dodavatelů včetně akčních plánů a asistence při nápravách.</value>
+  </data>
+  <data name="ServiceCard3Title" xml:space="preserve">
+    <value>Školení a rozvoj týmů</value>
+  </data>
+  <data name="ServiceCard3Description" xml:space="preserve">
+    <value>Připravujeme interaktivní školení pro management i odborné pracovníky, workshopy a mentoring zaměřený na praxi.</value>
+  </data>
+  <data name="ServiceCard4Title" xml:space="preserve">
+    <value>Compliance a řízení rizik</value>
+  </data>
+  <data name="ServiceCard4Description" xml:space="preserve">
+    <value>Nastavujeme procesy řízení rizik, interní kontroly a legislativní compliance tak, aby byly udržitelné a auditovatelné.</value>
+  </data>
+  <data name="HighlightsBadge" xml:space="preserve">
+    <value>Proč spolupracovat s námi</value>
+  </data>
+  <data name="HighlightsHeading" xml:space="preserve">
+    <value>Co od naší spolupráce získáte</value>
+  </data>
+  <data name="HighlightsDescription" xml:space="preserve">
+    <value>Pracujeme partnersky a zaměřujeme se na skutečné přínosy pro vaše podnikání.</value>
+  </data>
+  <data name="Highlight1Title" xml:space="preserve">
+    <value>Měřitelné výsledky</value>
+  </data>
+  <data name="Highlight1Description" xml:space="preserve">
+    <value>Naše projekty stojí na jasných cílech, sledování KPI a vyhodnocení dopadů.</value>
+  </data>
+  <data name="Highlight2Title" xml:space="preserve">
+    <value>Expertní tým</value>
+  </data>
+  <data name="Highlight2Description" xml:space="preserve">
+    <value>Spolupracujete se specialisty na certifikace, laboratoře i specifické odvětví.</value>
+  </data>
+  <data name="Highlight3Title" xml:space="preserve">
+    <value>Praktické nástroje</value>
+  </data>
+  <data name="Highlight3Description" xml:space="preserve">
+    <value>Přinášíme šablony, checklisty a software podporující dlouhodobou udržitelnost systému.</value>
+  </data>
+  <data name="Highlight4Title" xml:space="preserve">
+    <value>Flexibilní spolupráce</value>
+  </data>
+  <data name="Highlight4Description" xml:space="preserve">
+    <value>Umíme krátkodobé zásahy i komplexní projekty s dlouhodobou podporou.</value>
+  </data>
+  <data name="ProcessHeading" xml:space="preserve">
+    <value>Jak spolupráce probíhá</value>
+  </data>
+  <data name="ProcessDescription" xml:space="preserve">
+    <value>V každém kroku zapojujeme váš tým, aby know-how zůstalo uvnitř organizace a změny byly udržitelné.</value>
+  </data>
+  <data name="ProcessStep1Title" xml:space="preserve">
+    <value>Úvodní konzultace a analýza</value>
+  </data>
+  <data name="ProcessStep1Description" xml:space="preserve">
+    <value>Zmapujeme současný stav, pochopíme vaše cíle a navrhneme rozsah spolupráce.</value>
+  </data>
+  <data name="ProcessStep2Title" xml:space="preserve">
+    <value>Implementace a školení</value>
+  </data>
+  <data name="ProcessStep2Description" xml:space="preserve">
+    <value>Realizujeme změny, připravujeme dokumentaci, nastavujeme procesy a školíme váš tým.</value>
+  </data>
+  <data name="ProcessStep3Title" xml:space="preserve">
+    <value>Podpora při certifikaci</value>
+  </data>
+  <data name="ProcessStep3Description" xml:space="preserve">
+    <value>Doprovodíme vás při certifikačním auditu a pomůžeme s vyhodnocením i následnými opatřeními.</value>
+  </data>
+  <data name="CtaHeading" xml:space="preserve">
+    <value>Připraveni posunout váš systém řízení?</value>
+  </data>
+  <data name="CtaDescription" xml:space="preserve">
+    <value>Dejte nám vědět, s čím potřebujete pomoci. Společně najdeme ideální formu spolupráce.</value>
+  </data>
+  <data name="CtaPrimaryButton" xml:space="preserve">
+    <value>Nezávazně poptat služby</value>
+  </data>
+  <data name="CtaSecondaryButton" xml:space="preserve">
+    <value>Kontaktovat tým</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._Layout.cshtml.en.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.en.resx
@@ -37,7 +37,7 @@
     <value>Articles</value>
   </data>
   <data name="NavServices" xml:space="preserve">
-    <value>Consulting &amp; audits</value>
+    <value>Services &amp; consulting</value>
   </data>
   <data name="NavCorporateInquiry" xml:space="preserve">
     <value>Corporate inquiry</value>

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -40,7 +40,7 @@
     <value>Firemní poptávka / audit na míru</value>
   </data>
   <data name="NavServices" xml:space="preserve">
-    <value>Poradenství a audity</value>
+    <value>Služby a poradenství</value>
   </data>
   <data name="NavPrivacy" xml:space="preserve">
     <value>Ochrana soukromí</value>


### PR DESCRIPTION
## Summary
- add a dedicated Services Razor page with localized content for CZ and EN
- point the navigation Services link to the new page and refresh its label in both locales

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de154345348321b35068e49dbd0c7a