### PR TITLE
Localize article index UI strings

### DIFF
--- a/Pages/Articles/Index.cshtml
+++ b/Pages/Articles/Index.cshtml
@@ -3,6 +3,8 @@
 @using System.Collections.Generic
 @using System.Globalization
 @using System.Linq
+@using Microsoft.AspNetCore.Mvc.Localization
+@inject IViewLocalizer Localizer
 @functions {
     public record ArticleCard(
         int Id,
@@ -23,7 +25,7 @@
     public record CategoryOption(string Name, string Key);
 }
 @{
-    ViewData["Title"] = "Články a inspirace";
+    ViewData["Title"] = Localizer["PageTitle"];
     var culture = CultureInfo.CurrentUICulture;
 
     var sampleArticles = new List<ArticleCard>
@@ -114,22 +116,22 @@
 
 <section class="articles-hero">
     <div class="articles-hero__content">
-        <p class="text-uppercase fw-semibold text-primary mb-2">Inspirační knihovna</p>
-        <h1 class="display-5 fw-bold mb-3">Články, které zefektivní vaše systémy řízení</h1>
-        <p class="lead text-muted mb-0">Vyberte si z kurátorovaného výběru článků o ISO normách, auditech i procesním řízení. Filtrujte podle kategorií, vyhledávejte klíčová témata a přepínejte mezi dlaždicovým a seznamovým zobrazením.</p>
+        <p class="text-uppercase fw-semibold text-primary mb-2">@Localizer["HeroBadge"]</p>
+        <h1 class="display-5 fw-bold mb-3">@Localizer["HeroHeadline"]</h1>
+        <p class="lead text-muted mb-0">@Localizer["HeroSubheadline"]</p>
     </div>
 </section>
 
-<section class="articles-toolbar" aria-label="Ovládací panel článků">
+<section class="articles-toolbar" aria-label="@Localizer["ToolbarAriaLabel"]">
     <div class="toolbar-group toolbar-group--search" role="search">
-        <label for="articleSearch" class="form-label fw-semibold">Hledat články</label>
-        <input type="search" id="articleSearch" class="form-control" placeholder="Zadejte název, téma nebo tag" data-articles-search aria-describedby="articleSearchHelp" />
-        <div id="articleSearchHelp" class="form-text">Vyhledáváme v názvu, perexu i značkách článků.</div>
+        <label for="articleSearch" class="form-label fw-semibold">@Localizer["SearchLabel"]</label>
+        <input type="search" id="articleSearch" class="form-control" placeholder="@Localizer["SearchPlaceholder"]" data-articles-search aria-describedby="articleSearchHelp" />
+        <div id="articleSearchHelp" class="form-text">@Localizer["SearchHelpText"]</div>
     </div>
     <div class="toolbar-group toolbar-group--filters" role="group" aria-labelledby="articleFiltersLabel">
         <div class="d-flex align-items-center gap-2 mb-2">
             <i class="bi bi-filter fs-5 text-primary" aria-hidden="true"></i>
-            <span id="articleFiltersLabel" class="fw-semibold">Filtrovat podle kategorií</span>
+            <span id="articleFiltersLabel" class="fw-semibold">@Localizer["FilterLabel"]</span>
         </div>
         <div class="toolbar-filters" data-filter-checkboxes>
             @foreach (var category in categories)
@@ -141,14 +143,14 @@
             }
         </div>
     </div>
-    <div class="toolbar-group toolbar-group--view" role="group" aria-label="Přepnout zobrazení">
+    <div class="toolbar-group toolbar-group--view" role="group" aria-label="@Localizer["ViewToggleAriaLabel"]">
         <button type="button" class="btn btn-outline-primary active" data-view-toggle="grid" aria-pressed="true">
             <i class="bi bi-grid" aria-hidden="true"></i>
-            <span class="ms-2">Dlaždice</span>
+            <span class="ms-2">@Localizer["GridView"]</span>
         </button>
         <button type="button" class="btn btn-outline-primary" data-view-toggle="list" aria-pressed="false">
             <i class="bi bi-list" aria-hidden="true"></i>
-            <span class="ms-2">Seznam</span>
+            <span class="ms-2">@Localizer["ListView"]</span>
         </button>
     </div>
 </section>
@@ -185,7 +187,7 @@
                             <time datetime="@article.PublishedAt:yyyy-MM-dd">@article.PublishedAt.ToString("d. MMMM yyyy", culture)</time>
                         </div>
                     </div>
-                    <div class="article-card__tags" aria-label="Tagy článku">
+                    <div class="article-card__tags" aria-label="@Localizer["TagsAriaLabel"]">
                         @foreach (var tag in article.Tags)
                         {
                             <span class="badge rounded-pill bg-primary-subtle text-primary">@tag</span>
@@ -195,8 +197,8 @@
                 <footer class="article-card__footer">
                     <div class="d-flex flex-wrap align-items-center gap-3">
                         <a class="btn btn-primary" href="@article.CtaUrl">@article.CtaText</a>
-                        <a class="link-primary d-flex align-items-center gap-1" href="#" role="button" aria-label="Zobrazit více o článku @article.Title">
-                            Číst náhled
+                        <a class="link-primary d-flex align-items-center gap-1" href="#" role="button" aria-label="@Localizer["PreviewAriaLabel", article.Title]">
+                            @Localizer["PreviewLink"]
                             <i class="bi bi-arrow-right" aria-hidden="true"></i>
                         </a>
                     </div>
@@ -206,7 +208,7 @@
     </div>
     <div class="articles-empty alert alert-info d-none" data-empty-state role="status">
         <i class="bi bi-info-circle" aria-hidden="true"></i>
-        <span>Nenašli jsme žádné články pro zadanou kombinaci vyhledávání a filtrů. Upravte prosím podmínky a zkuste to znovu.</span>
+        <span>@Localizer["EmptyState"]</span>
     </div>
 </section>
 
@@ -214,16 +216,16 @@
     <div class="card border-0 shadow-sm overflow-hidden">
         <div class="row g-0 align-items-center">
             <div class="col-lg-7 p-4 p-lg-5">
-                <h2 id="relatedCourses" class="h3 fw-bold mb-3">Posuňte znalosti díky navazujícím kurzům</h2>
-                <p class="mb-4 text-muted">Každý článek navazuje na praktické kurzy, které vás provedou implementací standardů krok za krokem. Získejte přístup k bonusovým materiálům, Q&A se specialisty i komunitním workshopům.</p>
+                <h2 id="relatedCourses" class="h3 fw-bold mb-3">@Localizer["CtaHeading"]</h2>
+                <p class="mb-4 text-muted">@Localizer["CtaDescription"]</p>
                 <div class="d-flex flex-wrap gap-3">
-                    <a class="btn btn-outline-primary" href="/Courses/Index?search=ISO">Prozkoumat všechny kurzy</a>
-                    <a class="btn btn-outline-secondary" href="/Contact">Spojit se s konzultantem</a>
+                    <a class="btn btn-outline-primary" href="/Courses/Index?search=ISO">@Localizer["CtaPrimaryButton"]</a>
+                    <a class="btn btn-outline-secondary" href="/Contact">@Localizer["CtaSecondaryButton"]</a>
                 </div>
             </div>
             <div class="col-lg-5 bg-primary-subtle p-4 text-center">
                 <i class="bi bi-mortarboard fs-1 text-primary" aria-hidden="true"></i>
-                <p class="mt-3 mb-0 fw-semibold text-primary">Certifikovaní lektoři a aktuální sylaby</p>
+                <p class="mt-3 mb-0 fw-semibold text-primary">@Localizer["CtaHighlight"]</p>
             </div>
         </div>
     </div>

--- a/Resources/Pages.Articles.Index.cshtml.en.resx
+++ b/Resources/Pages.Articles.Index.cshtml.en.resx
@@ -15,16 +15,31 @@
   <data name="Heading" xml:space="preserve">
     <value>Articles</value>
   </data>
+  <data name="HeroBadge" xml:space="preserve">
+    <value>Inspiration library</value>
+  </data>
+  <data name="HeroHeadline" xml:space="preserve">
+    <value>Articles that streamline your management systems</value>
+  </data>
+  <data name="HeroSubheadline" xml:space="preserve">
+    <value>Browse a curated selection of articles on ISO standards, audits and process management. Filter by category, search key topics and switch between grid and list views.</value>
+  </data>
   <data name="Next" xml:space="preserve">
     <value>Next</value>
   </data>
   <data name="PaginationAriaLabel" xml:space="preserve">
     <value>Articles pagination</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>Articles &amp; inspiration</value>
+  </data>
   <data name="Previous" xml:space="preserve">
     <value>Previous</value>
   </data>
   <data name="SearchAriaLabel" xml:space="preserve">
+    <value>Search articles</value>
+  </data>
+  <data name="SearchLabel" xml:space="preserve">
     <value>Search articles</value>
   </data>
   <data name="SearchButton" xml:space="preserve">
@@ -34,15 +49,57 @@
     <value>Search articles</value>
   </data>
   <data name="SearchHelpText" xml:space="preserve">
-    <value>Enter a keyword or article topic.</value>
+    <value>We search in the title, teaser and article tags.</value>
   </data>
   <data name="SearchPlaceholder" xml:space="preserve">
-    <value>Search…</value>
+    <value>Enter a title, topic or tag</value>
   </data>
   <data name="PageStatus" xml:space="preserve">
     <value>Page {0} of {1}</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>Articles</value>
+  </data>
+  <data name="ToolbarAriaLabel" xml:space="preserve">
+    <value>Articles control panel</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filter by categories</value>
+  </data>
+  <data name="ViewToggleAriaLabel" xml:space="preserve">
+    <value>Switch view</value>
+  </data>
+  <data name="GridView" xml:space="preserve">
+    <value>Grid</value>
+  </data>
+  <data name="ListView" xml:space="preserve">
+    <value>List</value>
+  </data>
+  <data name="TagsAriaLabel" xml:space="preserve">
+    <value>Article tags</value>
+  </data>
+  <data name="PreviewAriaLabel" xml:space="preserve">
+    <value>Show more about the article {0}</value>
+  </data>
+  <data name="PreviewLink" xml:space="preserve">
+    <value>Read preview</value>
+  </data>
+  <data name="EmptyState" xml:space="preserve">
+    <value>We couldn't find any articles for the selected search and filter combination. Please adjust the criteria and try again.</value>
+  </data>
+  <data name="CtaHeading" xml:space="preserve">
+    <value>Advance your knowledge with related courses</value>
+  </data>
+  <data name="CtaDescription" xml:space="preserve">
+    <value>Each article links to practical courses that guide you through implementing standards step by step. Gain access to bonus materials, specialist Q&amp;A sessions and community workshops.</value>
+  </data>
+  <data name="CtaPrimaryButton" xml:space="preserve">
+    <value>Explore all courses</value>
+  </data>
+  <data name="CtaSecondaryButton" xml:space="preserve">
+    <value>Contact a consultant</value>
+  </data>
+  <data name="CtaHighlight" xml:space="preserve">
+    <value>Certified instructors and up-to-date syllabi</value>
   </data>
 </root>

--- a/Resources/Pages.Articles.Index.cshtml.resx
+++ b/Resources/Pages.Articles.Index.cshtml.resx
@@ -15,17 +15,32 @@
   <data name="Heading" xml:space="preserve">
     <value>Články</value>
   </data>
+  <data name="HeroBadge" xml:space="preserve">
+    <value>Inspirační knihovna</value>
+  </data>
+  <data name="HeroHeadline" xml:space="preserve">
+    <value>Články, které zefektivní vaše systémy řízení</value>
+  </data>
+  <data name="HeroSubheadline" xml:space="preserve">
+    <value>Vyberte si z kurátorovaného výběru článků o ISO normách, auditech i procesním řízení. Filtrujte podle kategorií, vyhledávejte klíčová témata a přepínejte mezi dlaždicovým a seznamovým zobrazením.</value>
+  </data>
   <data name="Next" xml:space="preserve">
     <value>Další</value>
   </data>
   <data name="PaginationAriaLabel" xml:space="preserve">
     <value>Stránkování článků</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>Články a inspirace</value>
+  </data>
   <data name="Previous" xml:space="preserve">
     <value>Předchozí</value>
   </data>
   <data name="SearchAriaLabel" xml:space="preserve">
     <value>Vyhledávání článků</value>
+  </data>
+  <data name="SearchLabel" xml:space="preserve">
+    <value>Hledat články</value>
   </data>
   <data name="SearchButton" xml:space="preserve">
     <value>Hledat</value>
@@ -34,15 +49,57 @@
     <value>Hledat články</value>
   </data>
   <data name="SearchHelpText" xml:space="preserve">
-    <value>Zadejte klíčové slovo nebo téma článku.</value>
+    <value>Vyhledáváme v názvu, perexu i značkách článků.</value>
   </data>
   <data name="SearchPlaceholder" xml:space="preserve">
-    <value>Hledat…</value>
+    <value>Zadejte název, téma nebo tag</value>
   </data>
   <data name="PageStatus" xml:space="preserve">
     <value>Stránka {0} z {1}</value>
   </data>
   <data name="Title" xml:space="preserve">
     <value>Články</value>
+  </data>
+  <data name="ToolbarAriaLabel" xml:space="preserve">
+    <value>Ovládací panel článků</value>
+  </data>
+  <data name="FilterLabel" xml:space="preserve">
+    <value>Filtrovat podle kategorií</value>
+  </data>
+  <data name="ViewToggleAriaLabel" xml:space="preserve">
+    <value>Přepnout zobrazení</value>
+  </data>
+  <data name="GridView" xml:space="preserve">
+    <value>Dlaždice</value>
+  </data>
+  <data name="ListView" xml:space="preserve">
+    <value>Seznam</value>
+  </data>
+  <data name="TagsAriaLabel" xml:space="preserve">
+    <value>Tagy článku</value>
+  </data>
+  <data name="PreviewAriaLabel" xml:space="preserve">
+    <value>Zobrazit více o článku {0}</value>
+  </data>
+  <data name="PreviewLink" xml:space="preserve">
+    <value>Číst náhled</value>
+  </data>
+  <data name="EmptyState" xml:space="preserve">
+    <value>Nenašli jsme žádné články pro zadanou kombinaci vyhledávání a filtrů. Upravte prosím podmínky a zkuste to znovu.</value>
+  </data>
+  <data name="CtaHeading" xml:space="preserve">
+    <value>Posuňte znalosti díky navazujícím kurzům</value>
+  </data>
+  <data name="CtaDescription" xml:space="preserve">
+    <value>Každý článek navazuje na praktické kurzy, které vás provedou implementací standardů krok za krokem. Získejte přístup k bonusovým materiálům, Q&amp;A se specialisty i komunitním workshopům.</value>
+  </data>
+  <data name="CtaPrimaryButton" xml:space="preserve">
+    <value>Prozkoumat všechny kurzy</value>
+  </data>
+  <data name="CtaSecondaryButton" xml:space="preserve">
+    <value>Spojit se s konzultantem</value>
+  </data>
+  <data name="CtaHighlight" xml:space="preserve">
+    <value>Certifikovaní lektoři a aktuální sylaby</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- inject the view localizer into the articles index page and replace hard-coded UI text with localized strings
- extend the Czech and English resource files with hero, toolbar, empty state, and CTA text so both languages render completely translated copy

## Testing
- Not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68de18baed508321b5046d946c9d1af6