### PR TITLE
Localize course details page content

### DIFF
--- a/Pages/Courses/Details.cshtml
+++ b/Pages/Courses/Details.cshtml
@@ -142,21 +142,21 @@
     var nextTerm = Model.Terms.FirstOrDefault();
     var nextTermText = nextTerm != null
         ? nextTerm.StartsAt.ToString("d", CultureInfo.CurrentCulture)
-        : "Termíny budou brzy doplněny";
+        : Localizer["NextTermPlaceholder"].Value;
 
     var tabs = new List<(string Id, string Title, bool HasContent)>
     {
-        ("audience", "Pro koho je kurz určen", targetAudienceList.Count > 0),
-        ("learning", "Co se naučíte", learningOutcomes.Count > 0 || caseStudies.Count > 0 || certifications.Count > 0),
-        ("program", "Program kurzu", programItems.Count > 0),
-        ("instructor", "Lektor", !string.IsNullOrWhiteSpace(Model.Course.InstructorName) || !string.IsNullOrWhiteSpace(Model.Course.InstructorBio)),
-        ("organization", "Organizační pokyny", organizationalNotes.Count > 0),
-        ("follow-up", "Navazující kurzy", followUpCourses.Count > 0),
-        ("certificate", "Certifikát", certificateItems.Count > 0)
+        ("audience", Localizer["TabAudienceTitle"].Value, targetAudienceList.Count > 0),
+        ("learning", Localizer["TabLearningTitle"].Value, learningOutcomes.Count > 0 || caseStudies.Count > 0 || certifications.Count > 0),
+        ("program", Localizer["TabProgramTitle"].Value, programItems.Count > 0),
+        ("instructor", Localizer["TabInstructorTitle"].Value, !string.IsNullOrWhiteSpace(Model.Course.InstructorName) || !string.IsNullOrWhiteSpace(Model.Course.InstructorBio)),
+        ("organization", Localizer["TabOrganizationTitle"].Value, organizationalNotes.Count > 0),
+        ("follow-up", Localizer["TabFollowUpTitle"].Value, followUpCourses.Count > 0),
+        ("certificate", Localizer["TabCertificateTitle"].Value, certificateItems.Count > 0)
     };
     var activeTabCandidate = tabs.FirstOrDefault(t => t.HasContent);
     var activeTabId = !string.IsNullOrEmpty(activeTabCandidate.Id) ? activeTabCandidate.Id : tabs[0].Id;
-    const string placeholderText = "Informace budou doplněny.";
+    var placeholderText = Localizer["PlaceholderText"].Value;
 }
 
 @if (TempData["CartError"] is string cartError && !string.IsNullOrWhiteSpace(cartError))
@@ -223,7 +223,7 @@
                 </ul>
                 <div class="tab-content pt-4">
                     <div class="tab-pane fade @(activeTabId == "audience" ? "show active" : string.Empty)" id="audience" role="tabpanel" aria-labelledby="audience-tab">
-                        <h2 class="h5 mb-3">Pro koho je kurz určen</h2>
+                        <h2 class="h5 mb-3">@Localizer["TabAudienceTitle"]</h2>
                         @if (targetAudienceList.Count > 0)
                         {
                             <ul class="list-unstyled mb-0">
@@ -242,10 +242,10 @@
                         }
                     </div>
                     <div class="tab-pane fade @(activeTabId == "learning" ? "show active" : string.Empty)" id="learning" role="tabpanel" aria-labelledby="learning-tab">
-                        <h2 class="h5 mb-4">Co se naučíte</h2>
+                        <h2 class="h5 mb-4">@Localizer["TabLearningTitle"]</h2>
                         <div class="row g-4">
                             <div class="col-md-4">
-                                <h3 class="h6 text-uppercase text-muted">Klíčové znalosti</h3>
+                                <h3 class="h6 text-uppercase text-muted">@Localizer["LearningKeyKnowledgeTitle"]</h3>
                                 @if (learningOutcomes.Count > 0)
                                 {
                                     <ul class="list-unstyled mb-0">
@@ -264,7 +264,7 @@
                                 }
                             </div>
                             <div class="col-md-4">
-                                <h3 class="h6 text-uppercase text-muted">Případové studie a cvičení</h3>
+                                <h3 class="h6 text-uppercase text-muted">@Localizer["LearningCaseStudiesTitle"]</h3>
                                 @if (caseStudies.Count > 0)
                                 {
                                     <ul class="list-unstyled mb-0">
@@ -283,7 +283,7 @@
                                 }
                             </div>
                             <div class="col-md-4">
-                                <h3 class="h6 text-uppercase text-muted">Certifikace</h3>
+                                <h3 class="h6 text-uppercase text-muted">@Localizer["LearningCertificationsTitle"]</h3>
                                 @if (certifications.Count > 0)
                                 {
                                     <ul class="list-unstyled mb-0">
@@ -304,7 +304,7 @@
                         </div>
                     </div>
                     <div class="tab-pane fade @(activeTabId == "program" ? "show active" : string.Empty)" id="program" role="tabpanel" aria-labelledby="program-tab">
-                        <h2 class="h5 mb-3">Program kurzu</h2>
+                        <h2 class="h5 mb-3">@Localizer["TabProgramTitle"]</h2>
                         @if (programItems.Count > 0)
                         {
                             <ol class="list-group list-group-numbered">
@@ -320,7 +320,7 @@
                         }
                     </div>
                     <div class="tab-pane fade @(activeTabId == "instructor" ? "show active" : string.Empty)" id="instructor" role="tabpanel" aria-labelledby="instructor-tab">
-                        <h2 class="h5 mb-3">Lektor</h2>
+                        <h2 class="h5 mb-3">@Localizer["TabInstructorTitle"]</h2>
                         @if (!string.IsNullOrWhiteSpace(Model.Course.InstructorName))
                         {
                             <p class="fw-semibold mb-1">@Model.Course.InstructorName</p>
@@ -335,7 +335,7 @@
                         }
                     </div>
                     <div class="tab-pane fade @(activeTabId == "organization" ? "show active" : string.Empty)" id="organization" role="tabpanel" aria-labelledby="organization-tab">
-                        <h2 class="h5 mb-3">Organizační pokyny</h2>
+                        <h2 class="h5 mb-3">@Localizer["TabOrganizationTitle"]</h2>
                         @if (organizationalNotes.Count > 0)
                         {
                             <ul class="list-unstyled mb-0">
@@ -354,7 +354,7 @@
                         }
                     </div>
                     <div class="tab-pane fade @(activeTabId == "follow-up" ? "show active" : string.Empty)" id="follow-up" role="tabpanel" aria-labelledby="follow-up-tab">
-                        <h2 class="h5 mb-3">Navazující kurzy</h2>
+                        <h2 class="h5 mb-3">@Localizer["TabFollowUpTitle"]</h2>
                         @if (followUpCourses.Count > 0)
                         {
                             <ul class="list-group list-group-flush">
@@ -370,7 +370,7 @@
                         }
                     </div>
                     <div class="tab-pane fade @(activeTabId == "certificate" ? "show active" : string.Empty)" id="certificate" role="tabpanel" aria-labelledby="certificate-tab">
-                        <h2 class="h5 mb-3">Certifikát</h2>
+                        <h2 class="h5 mb-3">@Localizer["TabCertificateTitle"]</h2>
                         @if (certificateItems.Count > 0)
                         {
                             <ul class="list-unstyled mb-0">
@@ -523,7 +523,7 @@
                 <div class="card-body">
                     <div class="d-flex justify-content-between align-items-center mb-3">
                         <div>
-                            <div class="text-muted small">Cena kurzu</div>
+                            <div class="text-muted small">@Localizer["CoursePriceLabel"]</div>
                             <div class="fs-5 fw-bold">@Model.Course.Price.ToString("C")</div>
                         </div>
                         <span class="badge bg-light text-dark">@displayedDelivery</span>
@@ -544,7 +544,7 @@
                     </ul>
                     <div class="d-grid gap-2">
                         <form method="post">
-                            <button type="submit" class="btn btn-primary">Přihlásit se</button>
+                            <button type="submit" class="btn btn-primary">@Localizer["EnrollButton"]</button>
                         </form>
                         <a class="btn btn-outline-secondary" asp-page="/Contact" asp-route-subject="@Localizer["ContactSubject", Model.Course.Title]">@Localizer["TeamButton"]</a>
                     </div>
@@ -552,7 +552,7 @@
             </div>
             <div class="card border-0 shadow-sm mb-3">
                 <div class="card-header bg-transparent border-bottom-0">
-                    <h2 class="h6 mb-0">Dostupné termíny</h2>
+                    <h2 class="h6 mb-0">@Localizer["AvailableTermsHeading"]</h2>
                 </div>
                 <div class="list-group list-group-flush">
                     @if (Model.Terms.Any())
@@ -596,7 +596,7 @@
                     }
                     else
                     {
-                        <div class="list-group-item text-muted">Termíny budou doplněny.</div>
+                        <div class="list-group-item text-muted">@Localizer["TermsComingSoon"]</div>
                     }
                 </div>
             </div>

--- a/Resources/Pages.Courses.Details.cshtml.en.resx
+++ b/Resources/Pages.Courses.Details.cshtml.en.resx
@@ -138,11 +138,47 @@
   <data name="MinutesValue" xml:space="preserve">
     <value>{0} min</value>
   </data>
+  <data name="NextTermPlaceholder" xml:space="preserve">
+    <value>Dates will be announced soon.</value>
+  </data>
   <data name="DetailLevelLabel" xml:space="preserve">
     <value>Level</value>
   </data>
   <data name="DetailModeLabel" xml:space="preserve">
     <value>Format</value>
+  </data>
+  <data name="PlaceholderText" xml:space="preserve">
+    <value>Information will be added soon.</value>
+  </data>
+  <data name="TabAudienceTitle" xml:space="preserve">
+    <value>Who the course is for</value>
+  </data>
+  <data name="TabLearningTitle" xml:space="preserve">
+    <value>What you will learn</value>
+  </data>
+  <data name="TabProgramTitle" xml:space="preserve">
+    <value>Course program</value>
+  </data>
+  <data name="TabInstructorTitle" xml:space="preserve">
+    <value>Instructor</value>
+  </data>
+  <data name="TabOrganizationTitle" xml:space="preserve">
+    <value>Organizational guidelines</value>
+  </data>
+  <data name="TabFollowUpTitle" xml:space="preserve">
+    <value>Follow-up courses</value>
+  </data>
+  <data name="TabCertificateTitle" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="LearningKeyKnowledgeTitle" xml:space="preserve">
+    <value>Key knowledge</value>
+  </data>
+  <data name="LearningCaseStudiesTitle" xml:space="preserve">
+    <value>Case studies and exercises</value>
+  </data>
+  <data name="LearningCertificationsTitle" xml:space="preserve">
+    <value>Certifications</value>
   </data>
   <data name="BlockHeading" xml:space="preserve">
     <value>Part of a learning block</value>
@@ -195,6 +231,9 @@
   <data name="PriceHeading" xml:space="preserve">
     <value>Price</value>
   </data>
+  <data name="CoursePriceLabel" xml:space="preserve">
+    <value>Course price</value>
+  </data>
   <data name="PriceBenefitCertificate" xml:space="preserve">
     <value>Certificate included (where available)</value>
   </data>
@@ -215,6 +254,12 @@
   </data>
   <data name="WishlistButton" xml:space="preserve">
     <value>Add to wishlist</value>
+  </data>
+  <data name="AvailableTermsHeading" xml:space="preserve">
+    <value>Available dates</value>
+  </data>
+  <data name="TermsComingSoon" xml:space="preserve">
+    <value>Dates will be added soon.</value>
   </data>
   <data name="ReviewsHeading" xml:space="preserve">
     <value>Reviews</value>

--- a/Resources/Pages.Courses.Details.cshtml.resx
+++ b/Resources/Pages.Courses.Details.cshtml.resx
@@ -138,11 +138,47 @@
   <data name="MinutesValue" xml:space="preserve">
     <value>{0} min</value>
   </data>
+  <data name="NextTermPlaceholder" xml:space="preserve">
+    <value>Termíny budou brzy doplněny.</value>
+  </data>
   <data name="DetailLevelLabel" xml:space="preserve">
     <value>Úroveň</value>
   </data>
   <data name="DetailModeLabel" xml:space="preserve">
     <value>Forma</value>
+  </data>
+  <data name="PlaceholderText" xml:space="preserve">
+    <value>Informace budou doplněny.</value>
+  </data>
+  <data name="TabAudienceTitle" xml:space="preserve">
+    <value>Pro koho je kurz určen</value>
+  </data>
+  <data name="TabLearningTitle" xml:space="preserve">
+    <value>Co se naučíte</value>
+  </data>
+  <data name="TabProgramTitle" xml:space="preserve">
+    <value>Program kurzu</value>
+  </data>
+  <data name="TabInstructorTitle" xml:space="preserve">
+    <value>Lektor</value>
+  </data>
+  <data name="TabOrganizationTitle" xml:space="preserve">
+    <value>Organizační pokyny</value>
+  </data>
+  <data name="TabFollowUpTitle" xml:space="preserve">
+    <value>Navazující kurzy</value>
+  </data>
+  <data name="TabCertificateTitle" xml:space="preserve">
+    <value>Certifikát</value>
+  </data>
+  <data name="LearningKeyKnowledgeTitle" xml:space="preserve">
+    <value>Klíčové znalosti</value>
+  </data>
+  <data name="LearningCaseStudiesTitle" xml:space="preserve">
+    <value>Případové studie a cvičení</value>
+  </data>
+  <data name="LearningCertificationsTitle" xml:space="preserve">
+    <value>Certifikace</value>
   </data>
   <data name="BlockHeading" xml:space="preserve">
     <value>Součást vzdělávacího bloku</value>
@@ -195,6 +231,9 @@
   <data name="PriceHeading" xml:space="preserve">
     <value>Cena</value>
   </data>
+  <data name="CoursePriceLabel" xml:space="preserve">
+    <value>Cena kurzu</value>
+  </data>
   <data name="PriceBenefitCertificate" xml:space="preserve">
     <value>Certifikát v ceně (pokud je u termínu uvedeno)</value>
   </data>
@@ -215,6 +254,12 @@
   </data>
   <data name="WishlistButton" xml:space="preserve">
     <value>Přidat do wishlistu</value>
+  </data>
+  <data name="AvailableTermsHeading" xml:space="preserve">
+    <value>Dostupné termíny</value>
+  </data>
+  <data name="TermsComingSoon" xml:space="preserve">
+    <value>Termíny budou doplněny.</value>
   </data>
   <data name="ReviewsHeading" xml:space="preserve">
     <value>Hodnocení</value>


### PR DESCRIPTION
## Summary
- replace hardcoded course detail headings, labels, and buttons with localized strings
- add Czech and English resource entries for placeholders and schedule messaging on the course details page

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de18bc1fc483219f62133e9b94e5c2