### PR TITLE
Use database-backed data on articles listing

### DIFF
--- a/Pages/Articles/Index.cshtml
+++ b/Pages/Articles/Index.cshtml
@@ -1,117 +1,93 @@
 @page
 @model SysJaky_N.Pages.Articles.IndexModel
-@using System.Collections.Generic
 @using System.Globalization
 @using System.Linq
+@using System.Text.RegularExpressions
 @using Microsoft.AspNetCore.Mvc.Localization
 @inject IViewLocalizer Localizer
 @functions {
     public record ArticleCard(
         int Id,
         string Title,
-        string Perex,
-        string Image,
-        string ImageAlt,
-        string ReadTime,
-        string Author,
+        string Excerpt,
         DateTime PublishedAt,
-        string Category,
+        string PublishedAtText,
         string CategoryKey,
-        string[] Tags,
-        string CtaText,
-        string CtaUrl
+        string CategoryLabel,
+        string SearchText
     );
 
     public record CategoryOption(string Name, string Key);
+
+    private static string CreateExcerpt(string content, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return string.Empty;
+        }
+
+        var withoutHtml = Regex.Replace(content, "<.*?>", " ");
+        var normalized = Regex.Replace(withoutHtml, "\\s+", " ").Trim();
+
+        if (normalized.Length <= maxLength)
+        {
+            return normalized;
+        }
+
+        var truncated = normalized[..Math.Min(normalized.Length, maxLength)].TrimEnd(' ', ',', '.', ';', ':');
+        return $"{truncated}…";
+    }
+
+    private static DateTime ToLocalPublicationTime(DateTime createdAt)
+    {
+        var kind = createdAt.Kind == DateTimeKind.Unspecified
+            ? DateTimeKind.Utc
+            : createdAt.Kind;
+
+        return DateTime.SpecifyKind(createdAt, kind).ToLocalTime();
+    }
+
+    private static string BuildSearchText(string title, string content, CultureInfo culture)
+    {
+        var withoutHtml = Regex.Replace(content ?? string.Empty, "<.*?>", " ");
+        var normalized = Regex.Replace(withoutHtml, "\\s+", " ").Trim();
+        return $"{title} {normalized}".ToLower(culture);
+    }
 }
 @{
     ViewData["Title"] = Localizer["PageTitle"];
     var culture = CultureInfo.CurrentUICulture;
+    var searchValue = Model.SearchString ?? string.Empty;
 
-    var sampleArticles = new List<ArticleCard>
-    {
-        new(
-            1,
-            "Jak připravit organizaci na certifikaci ISO 9001",
-            "Během pěti praktických kroků připravte firmu na certifikaci ISO9001 vyhněte se častým chybám a stáhněte checklist s časovým a finančním odhadem navíc.",
-            Url.Content("~/img/articles/iso9001-preparation.svg"),
-            "Kontrolní seznam k přípravě na certifikaci ISO 9001",
-            "7 minut čtení",
-            "Eva Malá",
-            new DateTime(2025, 3, 18),
-            "ISO 9001",
-            "iso-9001",
-            new[] { "ISO 9001", "certifikace", "management", "checklist" },
-            "Zjistit kurzy ISO 9001",
-            "/Courses/Index?search=ISO%209001"
-        ),
-        new(
-            2,
-            "Rozdíl mezi certifikací a akreditací",
-            "Zorientujte se v rozdílech mezi certifikací a akreditací zjistěte kdy potřebujete kterou a inspirujte se příklady z české praxe i zkušenostmi expertů.",
-            Url.Content("~/img/articles/cert-vs-accred.svg"),
-            "Srovnání certifikace a akreditace",
-            "5 minut čtení",
-            "Tomáš Král",
-            new DateTime(2025, 2, 6),
-            "Certifikace",
-            "certifikace",
-            new[] { "certifikace", "akreditace", "ISO", "rozdíly" },
-            "Vybrat kurz k certifikaci",
-            "/Courses/Index?search=certifikace"
-        ),
-        new(
-            3,
-            "Interní audit - jak na to",
-            "Praktický návod k internímu auditu nabízí jasné kroky, použitelné šablony a tipy auditorů které pomohou připravit tým a procesy bez zbytečného stresu.",
-            Url.Content("~/img/articles/internal-audit.svg"),
-            "Lupa nad dokumenty symbolizující interní audit",
-            "8 minut čtení",
-            "Lenka Karásková",
-            new DateTime(2025, 1, 22),
-            "Audity",
-            "audity",
-            new[] { "audit", "interní audit", "šablony", "ISO 19011" },
-            "Procvičit interní audit",
-            "/Courses/Index?search=intern%C3%AD%20audit"
-        ),
-        new(
-            4,
-            "Procesní řízení v praxi",
-            "Procesní řízení v praxi ukáže mapování procesů, KPI i kontinuální zlepšování aby role byly jasné všem data dostupná a výkonnost firmy stabilně rostla.",
-            Url.Content("~/img/articles/process-management.svg"),
-            "Schéma propojených procesů a ukazatelů",
-            "6 minut čtení",
-            "Jan Hrubý",
-            new DateTime(2024, 12, 11),
-            "Procesní řízení",
-            "procesni-rizeni",
-            new[] { "procesní řízení", "KPI", "zlepšování", "mapování" },
-            "Naučit se procesní řízení",
-            "/Courses/Index?search=procesn%C3%AD%20%C5%99%C3%ADzen%C3%AD"
-        ),
-        new(
-            5,
-            "ISO normy v automobilovém průmyslu",
-            "IATF 16949 a Core Tools v kostce pro automotive týmy. Článek shrnuje klíčové požadavky ISO zákaznická specifika a postupy jak sladit kvalitu i audity.",
-            Url.Content("~/img/articles/automotive-iso.svg"),
-            "Automobil se symbolem kvality IATF 16949",
-            "9 minut čtení",
-            "Klára Vránová",
-            new DateTime(2024, 11, 4),
-            "Automotive",
-            "automotive",
-            new[] { "IATF 16949", "automotive", "core tools", "dodavatelé" },
-            "Prohlédnout automotive kurzy",
-            "/Courses/Index?search=IATF%2016949"
-        )
-    };
+    var articleCards = Model.Articles
+        .Select(article =>
+        {
+            var publishedAt = ToLocalPublicationTime(article.CreatedAt);
+            var categoryKey = publishedAt.ToString("yyyy", CultureInfo.InvariantCulture);
 
-    var categories = sampleArticles
-        .Select(a => new CategoryOption(a.Category, a.CategoryKey))
-        .DistinctBy(c => c.Key)
-        .OrderBy(c => c.Name, StringComparer.Create(culture, ignoreCase: true))
+            return new ArticleCard(
+                article.Id,
+                article.Title,
+                CreateExcerpt(article.Content, 220),
+                publishedAt,
+                publishedAt.ToString("d. MMMM yyyy", culture),
+                categoryKey,
+                publishedAt.ToString("yyyy", culture),
+                BuildSearchText(article.Title, article.Content, culture)
+            );
+        })
         .ToList();
+
+    var categories = articleCards
+        .Select(a => new CategoryOption(a.CategoryLabel, a.CategoryKey))
+        .DistinctBy(c => c.Key)
+        .OrderByDescending(c => c.Key)
+        .ToList();
+
+    var showCategoryFilters = categories.Count > 1;
+    var currentPage = Math.Max(1, Model.PageNumber);
+    var totalPages = Model.TotalPages;
+    var searchRouteValue = string.IsNullOrWhiteSpace(searchValue) ? null : searchValue;
 }
 
 <section class="articles-hero">
@@ -123,26 +99,42 @@
 </section>
 
 <section class="articles-toolbar" aria-label="@Localizer["ToolbarAriaLabel"]">
-    <div class="toolbar-group toolbar-group--search" role="search">
+    <form method="get" class="toolbar-group toolbar-group--search" role="search" aria-label="@Localizer["SearchAriaLabel"]">
+        <input type="hidden" name="PageNumber" value="1" />
         <label for="articleSearch" class="form-label fw-semibold">@Localizer["SearchLabel"]</label>
-        <input type="search" id="articleSearch" class="form-control" placeholder="@Localizer["SearchPlaceholder"]" data-articles-search aria-describedby="articleSearchHelp" />
+        <div class="input-group">
+            <input
+                type="search"
+                id="articleSearch"
+                name="SearchString"
+                value="@searchValue"
+                class="form-control"
+                placeholder="@Localizer["SearchPlaceholder"]"
+                data-articles-search
+                aria-describedby="articleSearchHelp"
+                aria-label="@Localizer["SearchInputAriaLabel"]" />
+            <button type="submit" class="btn btn-primary">@Localizer["SearchButton"]</button>
+        </div>
         <div id="articleSearchHelp" class="form-text">@Localizer["SearchHelpText"]</div>
-    </div>
-    <div class="toolbar-group toolbar-group--filters" role="group" aria-labelledby="articleFiltersLabel">
-        <div class="d-flex align-items-center gap-2 mb-2">
-            <i class="bi bi-filter fs-5 text-primary" aria-hidden="true"></i>
-            <span id="articleFiltersLabel" class="fw-semibold">@Localizer["FilterLabel"]</span>
+    </form>
+    @if (showCategoryFilters)
+    {
+        <div class="toolbar-group toolbar-group--filters" role="group" aria-labelledby="articleFiltersLabel">
+            <div class="d-flex align-items-center gap-2 mb-2">
+                <i class="bi bi-filter fs-5 text-primary" aria-hidden="true"></i>
+                <span id="articleFiltersLabel" class="fw-semibold">@Localizer["FilterLabel"]</span>
+            </div>
+            <div class="toolbar-filters" data-filter-checkboxes>
+                @foreach (var category in categories)
+                {
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" value="@category.Key" id="filter-@category.Key" checked data-category-filter />
+                        <label class="form-check-label" for="filter-@category.Key">@category.Name</label>
+                    </div>
+                }
+            </div>
         </div>
-        <div class="toolbar-filters" data-filter-checkboxes>
-            @foreach (var category in categories)
-            {
-                <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="checkbox" value="@category.Key" id="filter-@category.Key" checked data-category-filter />
-                    <label class="form-check-label" for="filter-@category.Key">@category.Name</label>
-                </div>
-            }
-        </div>
-    </div>
+    }
     <div class="toolbar-group toolbar-group--view" role="group" aria-label="@Localizer["ViewToggleAriaLabel"]">
         <button type="button" class="btn btn-outline-primary active" data-view-toggle="grid" aria-pressed="true">
             <i class="bi bi-grid" aria-hidden="true"></i>
@@ -157,60 +149,77 @@
 
 <section class="articles-results" aria-live="polite">
     <div id="articlesLiveRegion" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
-    <div class="article-list article-list--grid" data-articles-list data-view="grid">
-        @foreach (var article in sampleArticles)
-        {
-            var searchText = string.Join(' ', new[]
+    @if (articleCards.Any())
+    {
+        <div class="article-list article-list--grid" data-articles-list data-view="grid" data-live-singular="@Localizer["LiveRegionSingular"]" data-live-plural="@Localizer["LiveRegionPlural"]">
+            @foreach (var article in articleCards)
             {
-                article.Title,
-                article.Perex,
-                string.Join(' ', article.Tags)
-            }).ToLower(culture);
-            <article class="article-card" data-article-card data-category="@article.CategoryKey" data-tags="@string.Join('|', article.Tags.Select(t => t.ToLower(culture)))" data-search-text="@searchText">
-                <figure class="article-card__media">
-                    <img src="@article.Image" alt="@article.ImageAlt" loading="lazy" width="600" height="400" class="article-card__image" />
-                </figure>
-                <div class="article-card__body">
-                    <div class="article-card__meta">
-                        <span class="badge bg-light text-primary border border-primary-subtle">@article.Category</span>
-                        <span class="text-muted">@article.ReadTime</span>
-                    </div>
-                    <h2 class="article-card__title">@article.Title</h2>
-                    <p class="article-card__perex">@article.Perex</p>
-                    <div class="article-card__details">
-                        <div class="d-flex align-items-center gap-2">
-                            <i class="bi bi-person-circle text-primary" aria-hidden="true"></i>
-                            <span class="fw-semibold">@article.Author</span>
+                <article class="article-card" data-article-card data-category="@article.CategoryKey" data-search-text="@article.SearchText">
+                    <div class="article-card__body">
+                        <div class="article-card__meta">
+                            @if (showCategoryFilters)
+                            {
+                                <span class="badge bg-light text-primary border border-primary-subtle">@article.CategoryLabel</span>
+                            }
+                            <div class="d-flex align-items-center gap-2 text-muted">
+                                <i class="bi bi-calendar-event" aria-hidden="true"></i>
+                                <time datetime="@article.PublishedAt:yyyy-MM-dd">@article.PublishedAtText</time>
+                            </div>
                         </div>
-                        <div class="d-flex align-items-center gap-2">
-                            <i class="bi bi-calendar-event text-primary" aria-hidden="true"></i>
-                            <time datetime="@article.PublishedAt:yyyy-MM-dd">@article.PublishedAt.ToString("d. MMMM yyyy", culture)</time>
-                        </div>
-                    </div>
-                    <div class="article-card__tags" aria-label="@Localizer["TagsAriaLabel"]">
-                        @foreach (var tag in article.Tags)
+                        <h2 class="article-card__title">
+                            <a asp-page="./Details" asp-route-id="@article.Id" class="stretched-link text-decoration-none">@article.Title</a>
+                        </h2>
+                        @if (!string.IsNullOrWhiteSpace(article.Excerpt))
                         {
-                            <span class="badge rounded-pill bg-primary-subtle text-primary">@tag</span>
+                            <p class="article-card__excerpt">@article.Excerpt</p>
                         }
                     </div>
-                </div>
-                <footer class="article-card__footer">
-                    <div class="d-flex flex-wrap align-items-center gap-3">
-                        <a class="btn btn-primary" href="@article.CtaUrl">@article.CtaText</a>
-                        <a class="link-primary d-flex align-items-center gap-1" href="#" role="button" aria-label="@Localizer["PreviewAriaLabel", article.Title]">
+                    <footer class="article-card__footer">
+                        <a class="btn btn-primary" asp-page="./Details" asp-route-id="@article.Id" aria-label="@Localizer["PreviewAriaLabel", article.Title]">
                             @Localizer["PreviewLink"]
-                            <i class="bi bi-arrow-right" aria-hidden="true"></i>
                         </a>
-                    </div>
-                </footer>
-            </article>
-        }
-    </div>
-    <div class="articles-empty alert alert-info d-none" data-empty-state role="status">
-        <i class="bi bi-info-circle" aria-hidden="true"></i>
-        <span>@Localizer["EmptyState"]</span>
-    </div>
+                    </footer>
+                </article>
+            }
+        </div>
+        <div class="articles-empty alert alert-info d-none" data-empty-state role="status">
+            <i class="bi bi-info-circle" aria-hidden="true"></i>
+            <span>@Localizer["EmptyState"]</span>
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-info" role="status">
+            <i class="bi bi-info-circle" aria-hidden="true"></i>
+            <span>@Localizer["EmptyState"]</span>
+        </div>
+    }
 </section>
+
+@if (totalPages > 1)
+{
+    <nav class="articles-pagination" aria-label="@Localizer["PaginationAriaLabel"]">
+        <ul class="pagination justify-content-center flex-wrap mb-2">
+            <li class="page-item @(currentPage <= 1 ? "disabled" : string.Empty)">
+                <a class="page-link" asp-page="./Index" asp-route-PageNumber="@(Math.Max(currentPage - 1, 1))" asp-route-SearchString="@searchRouteValue">
+                    @Localizer["Previous"]
+                </a>
+            </li>
+            @for (var page = 1; page <= totalPages; page++)
+            {
+                <li class="page-item @(page == currentPage ? "active" : string.Empty)">
+                    <a class="page-link" asp-page="./Index" asp-route-PageNumber="@page" asp-route-SearchString="@searchRouteValue">@page</a>
+                </li>
+            }
+            <li class="page-item @(currentPage >= totalPages ? "disabled" : string.Empty)">
+                <a class="page-link" asp-page="./Index" asp-route-PageNumber="@(Math.Min(currentPage + 1, totalPages))" asp-route-SearchString="@searchRouteValue">
+                    @Localizer["Next"]
+                </a>
+            </li>
+        </ul>
+        <p class="text-center text-muted mb-0">@Localizer["PageStatus", currentPage, totalPages]</p>
+    </nav>
+}
 
 <section class="articles-related" aria-labelledby="relatedCourses">
     <div class="card border-0 shadow-sm overflow-hidden">
@@ -257,6 +266,14 @@
             box-shadow: 0 0.125rem 0.75rem rgba(11, 123, 179, 0.08);
         }
 
+        .toolbar-group--search .input-group {
+            align-items: stretch;
+        }
+
+        .toolbar-group--filters {
+            min-height: 100%;
+        }
+
         .toolbar-group--view {
             display: flex;
             gap: 0.75rem;
@@ -301,9 +318,10 @@
             border-radius: 1rem;
             border: 1px solid var(--bs-border-color);
             box-shadow: 0 0.75rem 2rem rgba(11, 123, 179, 0.08);
-            overflow: hidden;
             display: flex;
             flex-direction: column;
+            position: relative;
+            overflow: hidden;
             transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
 
@@ -311,17 +329,6 @@
         .article-card:focus-within {
             transform: translateY(-4px);
             box-shadow: 0 1.25rem 2.25rem rgba(11, 123, 179, 0.14);
-        }
-
-        .article-card__media {
-            aspect-ratio: 3 / 2;
-            margin: 0;
-        }
-
-        .article-card__image {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
         }
 
         .article-card__body {
@@ -333,10 +340,10 @@
 
         .article-card__meta {
             display: flex;
-            justify-content: space-between;
             align-items: center;
+            justify-content: space-between;
             flex-wrap: wrap;
-            gap: 0.5rem;
+            gap: 0.5rem 1rem;
         }
 
         .article-card__title {
@@ -345,22 +352,13 @@
             margin: 0;
         }
 
-        .article-card__perex {
+        .article-card__title a {
+            color: inherit;
+        }
+
+        .article-card__excerpt {
             margin-bottom: 0;
             color: var(--bs-secondary-color);
-        }
-
-        .article-card__details {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1rem 2rem;
-            color: var(--bs-secondary-color);
-        }
-
-        .article-card__tags {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 0.5rem;
         }
 
         .article-card__footer {
@@ -381,7 +379,16 @@
             margin-top: 3rem;
         }
 
-        @@media (max-width: 767.98px) {
+        .articles-pagination {
+            margin-top: 2rem;
+        }
+
+        .articles-pagination .page-link {
+            min-width: 2.5rem;
+            text-align: center;
+        }
+
+        @media (max-width: 767.98px) {
             .article-card__title {
                 font-size: 1.25rem;
             }
@@ -408,29 +415,32 @@
             const liveRegion = document.getElementById('articlesLiveRegion');
             const viewButtons = Array.from(document.querySelectorAll('[data-view-toggle]'));
 
-            if (!listElement || !searchInput) {
-                return;
-            }
-
             const updateAnnouncement = (visible) => {
-                if (!liveRegion) {
+                if (!liveRegion || !listElement) {
                     return;
                 }
 
+                const singular = listElement.dataset.liveSingular ?? '';
+                const pluralTemplate = listElement.dataset.livePlural ?? '';
+
                 liveRegion.textContent = visible === 1
-                    ? 'Zobrazuje se 1 článek.'
-                    : `Zobrazuje se ${visible} článků.`;
+                    ? singular
+                    : pluralTemplate.replace('{0}', visible.toString());
             };
 
             const applyFilters = () => {
-                const query = searchInput.value.trim().toLowerCase();
+                if (!listElement) {
+                    return;
+                }
+
+                const query = (searchInput?.value ?? '').trim().toLowerCase();
                 const activeCategories = filterInputs
                     .filter(input => input.checked)
                     .map(input => input.value.toLowerCase());
 
                 let visibleCount = 0;
                 articleCards.forEach(card => {
-                    const category = card.dataset.category ?? '';
+                    const category = (card.dataset.category ?? '').toLowerCase();
                     const searchable = card.dataset.searchText ?? '';
                     const matchesCategory = activeCategories.length === 0 || activeCategories.includes(category);
                     const matchesQuery = query.length === 0 || searchable.includes(query);
@@ -468,11 +478,13 @@
                 });
             };
 
-            searchInput.addEventListener('input', () => applyFilters());
+            searchInput?.addEventListener('input', () => applyFilters());
             filterInputs.forEach(input => input.addEventListener('change', () => applyFilters()));
-            viewButtons.forEach(button => button.addEventListener('click', () => switchView(button.dataset.viewToggle)));
+            viewButtons.forEach(button => button.addEventListener('click', () => switchView(button.dataset.viewToggle ?? 'grid')));
 
-            applyFilters();
+            if (listElement && articleCards.length > 0) {
+                applyFilters();
+            }
         });
     </script>
 }

--- a/Resources/Pages.Articles.Index.cshtml.en.resx
+++ b/Resources/Pages.Articles.Index.cshtml.en.resx
@@ -84,6 +84,12 @@
   <data name="PreviewLink" xml:space="preserve">
     <value>Read preview</value>
   </data>
+  <data name="LiveRegionSingular" xml:space="preserve">
+    <value>Showing 1 article.</value>
+  </data>
+  <data name="LiveRegionPlural" xml:space="preserve">
+    <value>Showing {0} articles.</value>
+  </data>
   <data name="EmptyState" xml:space="preserve">
     <value>We couldn't find any articles for the selected search and filter combination. Please adjust the criteria and try again.</value>
   </data>

--- a/Resources/Pages.Articles.Index.cshtml.resx
+++ b/Resources/Pages.Articles.Index.cshtml.resx
@@ -84,6 +84,12 @@
   <data name="PreviewLink" xml:space="preserve">
     <value>Číst náhled</value>
   </data>
+  <data name="LiveRegionSingular" xml:space="preserve">
+    <value>Zobrazuje se 1 článek.</value>
+  </data>
+  <data name="LiveRegionPlural" xml:space="preserve">
+    <value>Zobrazuje se {0} článků.</value>
+  </data>
   <data name="EmptyState" xml:space="preserve">
     <value>Nenašli jsme žádné články pro zadanou kombinaci vyhledávání a filtrů. Upravte prosím podmínky a zkuste to znovu.</value>
   </data>


### PR DESCRIPTION
## Summary
- replace the hard-coded sample article collection with projections built from `Model.Articles`
- add a server-backed search form, pagination links, and client-side year filters that work with database data
- supply localized live-region messages to keep the dynamic filtering accessible

## Testing
- not run (dotnet CLI is not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68de1a255790832188de67ea5546f22c