### PR TITLE
Fix checkout session event constant usage

### DIFF
--- a/Services/PaymentService.cs
+++ b/Services/PaymentService.cs
@@ -142,7 +142,9 @@ public class PaymentService
         try
         {
             var stripeEvent = EventUtility.ConstructEvent(json, request.Headers["Stripe-Signature"], _options.WebhookSecret);
-            if (stripeEvent.Type == Events.CheckoutSessionCompleted)
+            const string checkoutSessionCompletedEventType = "checkout.session.completed";
+
+            if (stripeEvent.Type == checkoutSessionCompletedEventType)
             {
                 var alreadyProcessed = await _context.PaymentIds.AnyAsync(p => p.Id == stripeEvent.Id);
                 if (alreadyProcessed)


### PR DESCRIPTION
## Summary
- replace the undefined `Events.CheckoutSessionCompleted` reference with the Stripe checkout session completed event type string to restore compilation

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de2a7332f48321a4a3451bb8ff5bcd