### PR TITLE
Add culture controller for language selection

### DIFF
--- a/Controllers/CultureController.cs
+++ b/Controllers/CultureController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+
+[Route("[controller]/[action]")]
+public class CultureController : Controller
+{
+    [HttpPost]
+    public IActionResult Set(string culture, string returnUrl = "/")
+    {
+        Response.Cookies.Append(
+            CookieRequestCultureProvider.DefaultCookieName,
+            CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+            new CookieOptions { IsEssential = true, Expires = DateTimeOffset.UtcNow.AddYears(1) });
+
+        return LocalRedirect(returnUrl);
+    }
+}


### PR DESCRIPTION
## Summary
- add a culture controller with a POST action to persist the selected language in a cookie
- return the user to the previous page after updating the culture cookie

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de4d5b46908321a829733ea4d882d8