### PR TITLE
Simplify hero section markup and unify localization

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -1,65 +1,33 @@
 @page
 @model IndexModel
-@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+@inject Microsoft.Extensions.Localization.IStringLocalizer<SysJaky_N.SharedResource> T
 @{
-    ViewData["Title"] = Localizer["Title"];
+    ViewData["Title"] = T["Title"];
 }
 
 <section class="py-5 gradient-hero text-white text-center rounded-4 mb-4 hero-section">
-    <div class="container-xl position-relative">
-        <h1 class="display-5 fw-bold mb-3">@Localizer["HeroMainHeading"]</h1>
-        <p class="lead mb-4 opacity-75 mx-auto" style="max-width: 56rem;">@Localizer["HeroSubheading"]</p>
+    <div class="container-xl">
+        <h1 class="display-5 fw-bold mb-2">@T["HeroMainHeading"]</h1>
+        <p class="lead mb-4 opacity-75 mx-auto" style="max-width: 42rem;">@T["HeroSubheading"]</p>
 
-        <ul class="list-unstyled d-flex flex-column flex-lg-row justify-content-center align-items-lg-center gap-3 mb-4">
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-patch-check-fill"></i></span>
-                <span class="fw-semibold">@Localizer["HeroUSP1"]</span>
-            </li>
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-award-fill"></i></span>
-                <span class="fw-semibold">@Localizer["HeroUSP2"]</span>
-            </li>
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-people-fill"></i></span>
-                <span class="fw-semibold">@Localizer["HeroUSP3"]</span>
-            </li>
-        </ul>
-
-        <div class="d-flex flex-column flex-sm-row justify-content-center gap-2 mb-4">
-            <a href="/Courses/Index" class="btn btn-light fw-semibold px-4">@Localizer["HeroPrimaryCTA"]</a>
-            <a href="/CorporateInquiry" class="btn btn-outline-light fw-semibold px-4">@Localizer["HeroSecondaryCTA"]</a>
+        <div class="d-flex flex-wrap justify-content-center gap-2 mb-4">
+            <a href="/Courses/Index" class="btn btn-light btn-lg fw-semibold">@T["HeroPrimaryCTA"]</a>
+            <a href="/CorporateInquiry" class="btn btn-outline-light btn-lg fw-semibold">@T["HeroSecondaryCTA"]</a>
         </div>
 
-        <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm" role="search" aria-label="@Localizer["HeroSearchAriaLabel"]">
-            <div class="col-12 col-md-3">
-                <label class="form-label visually-hidden" for="heroPersona">@Localizer["PersonaLabel"]</label>
-                <select id="heroPersona" name="persona" class="form-select filter-select" aria-describedby="heroPersonaHelp" persona-options></select>
-                <div id="heroPersonaHelp" class="visually-hidden">@Localizer["PersonaHelp"]</div>
-            </div>
-            <div class="col-12 col-md-3">
-                <label class="form-label visually-hidden" for="heroGoal">@Localizer["GoalLabel"]</label>
-                <select id="heroGoal" name="goal" class="form-select filter-select" aria-describedby="heroGoalHelp" goal-options></select>
-                <div id="heroGoalHelp" class="visually-hidden">@Localizer["GoalHelp"]</div>
-            </div>
-            <div class="col-12 col-md-4">
-                <div class="input-group">
-                    <span class="input-group-text" id="heroSearchLabel"><i class="bi bi-search" aria-hidden="true"></i><span class="visually-hidden">@Localizer["HeroSearchLabel"]</span></span>
-                    <input name="q" class="form-control" placeholder="@Localizer["HeroSearchPlaceholder"]" aria-labelledby="heroSearchLabel" />
-                </div>
-            </div>
-            <div class="col-12 col-md-2 d-grid">
-                <button class="btn btn-light fw-semibold" type="submit">@Localizer["HeroSubmit"]</button>
-            </div>
+        <form method="get" action="/Courses/Index" class="d-flex flex-wrap justify-content-center gap-2 mb-4" role="search" aria-label="@T["HeroSearchAriaLabel"]">
+            <input name="q" class="form-control w-auto" placeholder="@T["HeroSearchPlaceholder"]" aria-label="@T["HeroSearchLabel"]" />
+            <button class="btn btn-light fw-semibold" type="submit">@T["HeroSubmit"]</button>
         </form>
 
-        <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
-            <a class="chip chip-light" href="/Courses/Index?Mode=Online">@Localizer["ChipOnline"]</a>
-            <a class="chip chip-light" href="/Courses/Index?CourseGroupId=REKVAL">@Localizer["ChipRetraining"]</a>
-            <a class="chip chip-light" href="/Courses/Index?Level=Beginner">@Localizer["ChipBeginner"]</a>
-            <a class="chip chip-light" href="/Courses/Index?City=Praha">@Localizer["ChipPrague"]</a>
-            <a class="chip chip-light" href="/Courses/Index?HasCertificate=true">@Localizer["ChipCertificate"]</a>
-            <a class="chip chip-light" href="/Courses/Index?q=akreditace">@Localizer["ChipAccreditation"]</a>
-            <a class="chip chip-light" href="/Courses/Index?q=intern%C3%AD%20audit">@Localizer["ChipInternalAudits"]</a>
+        <div class="d-flex flex-wrap justify-content-center gap-2">
+            <a class="chip chip-light" href="/Courses/Index?Mode=Online">@T["ChipOnline"]</a>
+            <a class="chip chip-light" href="/Courses/Index?CourseGroupId=REKVAL">@T["ChipRetraining"]</a>
+            <a class="chip chip-light" href="/Courses/Index?Level=Beginner">@T["ChipBeginner"]</a>
+            <a class="chip chip-light" href="/Courses/Index?City=Praha">@T["ChipPrague"]</a>
+            <a class="chip chip-light" href="/Courses/Index?HasCertificate=true">@T["ChipCertificate"]</a>
+            <a class="chip chip-light" href="/Courses/Index?q=akreditace">@T["ChipAccreditation"]</a>
+            <a class="chip chip-light" href="/Courses/Index?q=intern%C3%AD%20audit">@T["ChipInternalAudits"]</a>
         </div>
     </div>
 </section>
@@ -70,25 +38,25 @@
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2" role="status" aria-live="polite">
                     <i class="bi bi-star-fill"></i>
-                    <span>@Html.Raw(Localizer["TrustRating", "<span class=\"stat-number\" data-target=\"4.8\" data-decimals=\"1\" data-suffix=\"/5\">4.8</span>"])</span>
+                    <span>@Html.Raw(T["TrustRating", "<span class=\"stat-number\" data-target=\"4.8\" data-decimals=\"1\" data-suffix=\"/5\">4.8</span>"])</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2" role="status" aria-live="polite">
                     <i class="bi bi-people"></i>
-                    <span>@Html.Raw(Localizer["TrustGraduates", "<span class=\"stat-number\" data-target=\"10000\" data-suffix=\"+\">10 000</span>"])</span>
+                    <span>@Html.Raw(T["TrustGraduates", "<span class=\"stat-number\" data-target=\"10000\" data-suffix=\"+\">10 000</span>"])</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-shield-check"></i>
-                    <span>@Localizer["TrustGuarantee"]</span>
+                    <span>@T["TrustGuarantee"]</span>
                 </div>
             </div>
             <div class="col">
                 <div class="trust-item d-flex align-items-center justify-content-center justify-content-md-start gap-2">
                     <i class="bi bi-patch-check"></i>
-                    <span>@Localizer["TrustCertificate"]</span>
+                    <span>@T["TrustCertificate"]</span>
                 </div>
             </div>
         </div>
@@ -98,40 +66,6 @@
 <script>
     (function () {
         const locale = document.documentElement.lang || 'cs';
-
-        const restoreSelections = () => {
-            const form = document.getElementById('heroForm');
-            const pSel = form?.querySelector('select[name="persona"]');
-            const gSel = form?.querySelector('select[name="goal"]');
-            if (pSel && localStorage.persona) pSel.value = localStorage.persona;
-            if (gSel && localStorage.goal) gSel.value = localStorage.goal;
-            form?.addEventListener('submit', () => {
-                if (pSel) localStorage.persona = pSel.value || "";
-                if (gSel) localStorage.goal = gSel.value || "";
-            });
-        };
-
-        const runTypewriter = () => {
-            const el = document.querySelector('.typewriter');
-            if (!el) return;
-            const text = el.getAttribute('data-typewriter-text') || '';
-            let index = 0;
-            el.classList.add('is-typing');
-            el.textContent = '';
-
-            const step = () => {
-                if (index <= text.length) {
-                    el.textContent = text.slice(0, index);
-                    index += 1;
-                    window.setTimeout(step, 100);
-                } else {
-                    el.classList.remove('is-typing');
-                    el.classList.add('typewriter-complete');
-                }
-            };
-
-            step();
-        };
 
         const animateStats = () => {
             const stats = document.querySelectorAll('.stat-number');
@@ -188,8 +122,6 @@
         };
 
         const init = () => {
-            restoreSelections();
-            runTypewriter();
             animateStats();
         };
 
@@ -210,8 +142,8 @@
     <div class="col-lg-8">
       <div class="feature-card h-100 p-3">
         <div class="d-flex justify-content-between align-items-center mb-2">
-          <h2 class="h5 mb-0">@Localizer["RecommendedForYou"]</h2>
-          <a class="btn btn-sm btn-outline-secondary" href="/Courses/Index">@Localizer["RecommendedViewAll"]</a>
+          <h2 class="h5 mb-0">@T["RecommendedForYou"]</h2>
+          <a class="btn btn-sm btn-outline-secondary" href="/Courses/Index">@T["RecommendedViewAll"]</a>
         </div>
         <div class="row g-3">
           @foreach (var c in Model.PicksForPersona)
@@ -222,7 +154,7 @@
           }
           @if (!Model.PicksForPersona.Any())
           {
-            <div class="col-12 text-muted">@Localizer["RecommendedEmpty"]</div>
+            <div class="col-12 text-muted">@T["RecommendedEmpty"]</div>
           }
         </div>
       </div>
@@ -230,7 +162,7 @@
 
     <div class="col-lg-4">
       <div class="feature-card h-100 p-3">
-        <h2 class="h6">@Localizer["StartingSoon"]</h2>
+        <h2 class="h6">@T["StartingSoon"]</h2>
         <ul class="list-unstyled small mb-3">
           @foreach (var c in Model.FastSoonest)
           {
@@ -240,7 +172,7 @@
             </li>
           }
         </ul>
-        <a class="btn btn-outline-primary btn-sm" href="/Courses/Calendar"><i class="bi bi-calendar3"></i> @Localizer["CalendarButton"]</a>
+        <a class="btn btn-outline-primary btn-sm" href="/Courses/Calendar"><i class="bi bi-calendar3"></i> @T["CalendarButton"]</a>
       </div>
     </div>
   </div>
@@ -248,7 +180,7 @@
   <div class="row g-3 mt-1">
     <div class="col-12">
       <div class="feature-card p-3">
-        <h2 class="h6 mb-2">@Localizer["NewsHeading"]</h2>
+        <h2 class="h6 mb-2">@T["NewsHeading"]</h2>
         <div class="d-flex flex-wrap gap-3">
           @foreach (var a in Model.FreshNews)
           {
@@ -262,15 +194,15 @@
 
 <section class="app-section">
     <div class="container-xl">
-        <h2 class="section-title text-center">@Localizer["HowItWorksTitle"]</h2>
+        <h2 class="section-title text-center">@T["HowItWorksTitle"]</h2>
         <div class="row g-4 text-center">
             <div class="col-md-4">
                 <div class="feature-card h-100 p-4">
                     <div class="icon-circle mx-auto mb-3">
                         <i class="bi bi-clipboard-data" aria-hidden="true"></i>
                     </div>
-                    <h3 class="h5">@Localizer["StepSelectTitle"]</h3>
-                    <p class="mb-0">@Localizer["StepSelectDescription"]</p>
+                    <h3 class="h5">@T["StepSelectTitle"]</h3>
+                    <p class="mb-0">@T["StepSelectDescription"]</p>
                 </div>
             </div>
             <div class="col-md-4">
@@ -278,8 +210,8 @@
                     <div class="icon-circle mx-auto mb-3">
                         <i class="bi bi-calendar-check" aria-hidden="true"></i>
                     </div>
-                    <h3 class="h5">@Localizer["StepRegisterTitle"]</h3>
-                    <p class="mb-0">@Localizer["StepRegisterDescription"]</p>
+                    <h3 class="h5">@T["StepRegisterTitle"]</h3>
+                    <p class="mb-0">@T["StepRegisterDescription"]</p>
                 </div>
             </div>
             <div class="col-md-4">
@@ -287,8 +219,8 @@
                     <div class="icon-circle mx-auto mb-3">
                         <i class="bi bi-patch-check" aria-hidden="true"></i>
                     </div>
-                    <h3 class="h5">@Localizer["StepPayTitle"]</h3>
-                    <p class="mb-0">@Localizer["StepPayDescription"]</p>
+                    <h3 class="h5">@T["StepPayTitle"]</h3>
+                    <p class="mb-0">@T["StepPayDescription"]</p>
                 </div>
             </div>
         </div>
@@ -297,8 +229,8 @@
 
 <section class="app-section app-section-alt">
     <div class="container-xl text-center">
-        <h2 class="section-title mb-3">@Localizer["WhyChooseHeading"]</h2>
-        <p class="mx-auto app-section-description">@Localizer["WhyChooseDescription"]</p>
+        <h2 class="section-title mb-3">@T["WhyChooseHeading"]</h2>
+        <p class="mx-auto app-section-description">@T["WhyChooseDescription"]</p>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary
- simplify the hero layout into a single flex-based grid for calls to action, search and topic chips
- switch the index page to use the shared resource string localizer for all hero and content strings
- drop unused hero personalization scripts now that the simplified layout no longer needs them

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5369411083218d2d459b58b282d1