### PR TITLE
Fix localization build errors

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -5,13 +5,14 @@
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @inject Microsoft.Extensions.Configuration.IConfiguration Configuration
 @inject Microsoft.Extensions.Localization.IStringLocalizer<SysJaky_N.SharedResource> T
-@{
+@{ 
     var currentCulture = CultureInfo.CurrentUICulture;
     var isCzech = string.Equals(currentCulture.TwoLetterISOLanguageName, "cs", System.StringComparison.OrdinalIgnoreCase);
     var currentPage = ViewContext.RouteData.Values["page"]?.ToString();
     var canAccessAdmin = ApplicationRoles.AdminDashboardRoles.Any(role => User.IsInRole(role));
 
     var pushPublicKey = Configuration["PushNotifications:PublicKey"] ?? string.Empty;
+    var themeToggleText = Localizer["ToggleTheme"].Value;
 }
 <!DOCTYPE html>
 <html lang="@currentCulture.TwoLetterISOLanguageName">

--- a/Program.cs
+++ b/Program.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using DinkToPdf;
 using DinkToPdf.Contracts;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
@@ -156,7 +157,7 @@ try
     {
         options.Level = CompressionLevel.SmallestSize;
     });
-    var dataAnnotationsLocalizationOptions = new Action<DataAnnotationsLocalizationOptions>(options =>
+    var dataAnnotationsLocalizationOptions = new Action<MvcDataAnnotationsLocalizationOptions>(options =>
     {
         options.DataAnnotationLocalizerProvider = (type, factory) =>
             factory.Create(typeof(SysJaky_N.Resources.SharedResources));

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -35,9 +35,4 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources/SharedResource.resx" />
-    <EmbeddedResource Include="Resources/SharedResource.en-US.resx" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary
- add the missing MVC data annotations namespace and configure data annotation localization using the correct options type
- remove redundant manual inclusions of shared resource resx files to avoid duplicate build outputs
- introduce a localized theme toggle text variable in the shared layout so the markup can compile

## Testing
- dotnet build /clp:ErrorsOnly

------
https://chatgpt.com/codex/tasks/task_e_68de556ef3fc8321b4ecc5410c1edf9f