### PR TITLE
Enable in-memory database option for development

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -12,6 +12,7 @@
     var canAccessAdmin = ApplicationRoles.AdminDashboardRoles.Any(role => User.IsInRole(role));
 
     var pushPublicKey = Configuration["PushNotifications:PublicKey"] ?? string.Empty;
+    var themeToggleText = Localizer["ThemeToggle"];
 }
 <!DOCTYPE html>
 <html lang="@currentCulture.TwoLetterISOLanguageName">

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +27,7 @@
     <PackageReference Include="RazorLight" Version="2.3.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="WebPush" Version="1.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "DetailedErrors": true,
+  "UseInMemoryDatabase": true,
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- add an optional in-memory EF Core configuration when `UseInMemoryDatabase` is enabled
- prevent build issues by disabling implicit embedded resource items and fixing localization setup
- wire up the theme toggle localization and include the EF Core InMemory provider package

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68de553c686883218411a0e6d6917e79