### PR TITLE
Remove hard-coded order status translations duplication

### DIFF
--- a/Extensions/OrderStatusExtensions.cs
+++ b/Extensions/OrderStatusExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using SysJaky_N.Models;
+
+namespace SysJaky_N.Extensions;
+
+public static class OrderStatusExtensions
+{
+    public static string GetLocalizationKeySuffix(this OrderStatus status) => status switch
+    {
+        OrderStatus.Pending => "Pending",
+        OrderStatus.Paid => "Paid",
+        OrderStatus.Cancelled => "Cancelled",
+        OrderStatus.Refunded => "Refunded",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+    };
+
+    public static IReadOnlyDictionary<OrderStatus, string> CreateTranslationMap(Func<OrderStatus, string> translationFactory)
+    {
+        ArgumentNullException.ThrowIfNull(translationFactory);
+
+        var statuses = Enum.GetValues<OrderStatus>();
+        var translations = new Dictionary<OrderStatus, string>(statuses.Length);
+
+        foreach (var status in statuses)
+        {
+            translations[status] = translationFactory(status);
+        }
+
+        return translations;
+    }
+}

--- a/Models/ViewModels/OrderDetailsViewModel.cs
+++ b/Models/ViewModels/OrderDetailsViewModel.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using SysJaky_N.Extensions;
 using SysJaky_N.Models;
 
 namespace SysJaky_N.Models.ViewModels;
@@ -22,7 +24,8 @@ public class OrderDetailsViewModel
     public string VatLabel { get; init; } = string.Empty;
     public string TotalLabel { get; init; } = string.Empty;
 
-    public IDictionary<OrderStatus, string> StatusTranslations { get; init; } = new Dictionary<OrderStatus, string>();
+    public IReadOnlyDictionary<OrderStatus, string> StatusTranslations { get; init; }
+        = OrderStatusExtensions.CreateTranslationMap(static _ => string.Empty);
 
     public string SeatTokensHeading { get; init; } = string.Empty;
     public string CourseFallbackFormat { get; init; } = "Course {0}";

--- a/Pages/Account/Manage.cshtml
+++ b/Pages/Account/Manage.cshtml
@@ -4,13 +4,8 @@
 @using System.Collections.Generic
 @{
     ViewData["Title"] = Localizer["Title"].Value;
-    var orderStatusTexts = new Dictionary<OrderStatus, string>
-    {
-        [OrderStatus.Pending] = Localizer["OrderStatusPending"].Value,
-        [OrderStatus.Paid] = Localizer["OrderStatusPaid"].Value,
-        [OrderStatus.Cancelled] = Localizer["OrderStatusCancelled"].Value,
-        [OrderStatus.Refunded] = Localizer["OrderStatusRefunded"].Value,
-    };
+    var orderStatusTexts = OrderStatusExtensions.CreateTranslationMap(
+        status => Localizer[$"OrderStatus{status.GetLocalizationKeySuffix()}"].Value);
 }
 
 <h1 class="mb-4">@Localizer["Title"]</h1>

--- a/Pages/Admin/Orders/Details.cshtml
+++ b/Pages/Admin/Orders/Details.cshtml
@@ -5,6 +5,14 @@
 @using SysJaky_N.Models.ViewModels
 @{
     ViewData["Title"] = $"Objednávka {Model.Order.Id}";
+    var statusTexts = new Dictionary<string, string>
+    {
+        ["Pending"] = "Čeká na platbu",
+        ["Paid"] = "Zaplaceno",
+        ["Cancelled"] = "Zrušeno",
+        ["Refunded"] = "Vráceno"
+    };
+
     var orderResources = new OrderDetailsViewModel
     {
         Order = Model.Order,
@@ -27,13 +35,10 @@
         QrCodeAltText = "QR kód",
         PayButtonText = "Spustit platbu",
         DownloadInvoiceText = "Stáhnout fakturu",
-        StatusTranslations = new Dictionary<OrderStatus, string>
-        {
-            [OrderStatus.Pending] = "Čeká na platbu",
-            [OrderStatus.Paid] = "Zaplaceno",
-            [OrderStatus.Cancelled] = "Zrušeno",
-            [OrderStatus.Refunded] = "Vráceno"
-        }
+        StatusTranslations = OrderStatusExtensions.CreateTranslationMap(status =>
+            statusTexts.TryGetValue(status.GetLocalizationKeySuffix(), out var text)
+                ? text
+                : status.ToString())
     };
 }
 

--- a/Pages/Orders/Details.cshtml
+++ b/Pages/Orders/Details.cshtml
@@ -26,13 +26,8 @@
         QrCodeAltText = Localizer["QrCodeAltText"].Value,
         PayButtonText = Localizer["PayButtonText"].Value,
         DownloadInvoiceText = Localizer["DownloadInvoiceText"].Value,
-        StatusTranslations = new Dictionary<OrderStatus, string>
-        {
-            [OrderStatus.Pending] = Localizer["StatusPending"].Value,
-            [OrderStatus.Paid] = Localizer["StatusPaid"].Value,
-            [OrderStatus.Cancelled] = Localizer["StatusCancelled"].Value,
-            [OrderStatus.Refunded] = Localizer["StatusRefunded"].Value,
-        }
+        StatusTranslations = OrderStatusExtensions.CreateTranslationMap(
+            status => Localizer[$"Status{status.GetLocalizationKeySuffix()}"].Value)
     };
 }
 


### PR DESCRIPTION
## Summary
- introduce shared `OrderStatusExtensions` to generate translation maps and localization key suffixes
- update the order-related Razor pages to consume the helper instead of duplicating hard-coded dictionaries
- expose the translation map on `OrderDetailsViewModel` as a read-only dictionary backed by the helper

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68de5a0ae3208321a327c307e640baae