### PR TITLE
Fix login/register modal trigger

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -163,7 +163,12 @@
                     </ul>
                     <div class="d-flex align-items-center gap-3">
                         <partial name="_LanguageSwitcher" />
-                        <a class="btn btn-outline-light ms-2" asp-page="/Account/Login">@T["LoginRegister"]</a>
+                        @if (!User.Identity.IsAuthenticated)
+                        {
+                            <button type="button" class="btn btn-outline-light ms-2" data-bs-toggle="modal" data-bs-target="#authModal">
+                                @T["LoginRegister"]
+                            </button>
+                        }
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update the secondary navigation login/register control to open the authentication modal instead of navigating away
- only render the modal trigger for unauthenticated visitors to keep the header state consistent

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68de78c7ed1c8321a6536a0f2d811a4c