### PR TITLE
Add language controller for culture selection

### DIFF
--- a/Controllers/LanguageController.cs
+++ b/Controllers/LanguageController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace SysJaky_N.Controllers
+{
+    public class LanguageController : Controller
+    {
+        [HttpPost]
+        public IActionResult Set(string culture, string returnUrl = "/")
+        {
+            Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(new RequestCulture(culture)),
+                new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1), IsEssential = true });
+
+            return LocalRedirect(returnUrl);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a language controller to update the request culture via cookies
- redirect the user back to the original URL after updating the culture cookie

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7abef9c883219dfab7a9ae423cb1