### PR TITLE
Refactor hero section into shared partial view

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -5,64 +5,20 @@
     ViewData["Title"] = T["Title"];
 }
 
-<section class="py-5 gradient-hero text-white text-center rounded-4 mb-4 hero-section">
-    <div class="container-xl position-relative">
-        <h1 class="display-5 fw-bold mb-3">@T["Home.Hero.Title"]</h1>
-        <p class="lead mb-4 opacity-75 mx-auto" style="max-width: 56rem;">@T["Home.Hero.Subtitle"]</p>
-
-        <ul class="list-unstyled d-flex flex-column flex-lg-row justify-content-center align-items-lg-center gap-3 mb-4">
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-patch-check-fill"></i></span>
-                <span class="fw-semibold">@T["Home.Hero.Usp1"]</span>
-            </li>
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-award-fill"></i></span>
-                <span class="fw-semibold">@T["Home.Hero.Usp2"]</span>
-            </li>
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-people-fill"></i></span>
-                <span class="fw-semibold">@T["Home.Hero.Usp3"]</span>
-            </li>
-        </ul>
-
-        <div class="d-flex flex-column flex-sm-row justify-content-center gap-2 mb-4">
-            <a href="/Courses/Index" class="btn btn-light fw-semibold px-4">@T["Home.Hero.PrimaryCta"]</a>
-            <a href="/CorporateInquiry" class="btn btn-outline-light fw-semibold px-4">@T["Home.Hero.SecondaryCta"]</a>
-        </div>
-
-        <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm" role="search" aria-label="@T["Home.Hero.Search.AriaLabel"]">
-            <div class="col-12 col-md-3">
-                <label class="form-label visually-hidden" for="heroPersona">@T["Home.Hero.Persona.Label"]</label>
-                <select id="heroPersona" name="persona" class="form-select filter-select" aria-describedby="heroPersonaHelp" persona-options></select>
-                <div id="heroPersonaHelp" class="visually-hidden">@T["Home.Hero.Persona.Help"]</div>
-            </div>
-            <div class="col-12 col-md-3">
-                <label class="form-label visually-hidden" for="heroGoal">@T["Home.Hero.Goal.Label"]</label>
-                <select id="heroGoal" name="goal" class="form-select filter-select" aria-describedby="heroGoalHelp" goal-options></select>
-                <div id="heroGoalHelp" class="visually-hidden">@T["Home.Hero.Goal.Help"]</div>
-            </div>
-            <div class="col-12 col-md-4">
-                <div class="input-group">
-                    <span class="input-group-text" id="heroSearchLabel"><i class="bi bi-search" aria-hidden="true"></i><span class="visually-hidden">@T["Home.Hero.Search.Label"]</span></span>
-                    <input name="q" class="form-control" placeholder="@T["Home.Hero.Search.Placeholder"]" aria-labelledby="heroSearchLabel" />
-                </div>
-            </div>
-            <div class="col-12 col-md-2 d-grid">
-                <button class="btn btn-light fw-semibold" type="submit">@T["Home.Hero.Search.Submit"]</button>
-            </div>
-        </form>
-
-        <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
-            <a class="chip chip-light" href="/Courses/Index?Mode=Online">@T["Home.Hero.Chips.Online"]</a>
-            <a class="chip chip-light" href="/Courses/Index?CourseGroupId=REKVAL">@T["Home.Hero.Chips.Retraining"]</a>
-            <a class="chip chip-light" href="/Courses/Index?Level=Beginner">@T["Home.Hero.Chips.Beginner"]</a>
-            <a class="chip chip-light" href="/Courses/Index?City=Praha">@T["Home.Hero.Chips.Prague"]</a>
-            <a class="chip chip-light" href="/Courses/Index?HasCertificate=true">@T["Home.Hero.Chips.Certificate"]</a>
-            <a class="chip chip-light" href="/Courses/Index?q=akreditace">@T["Home.Hero.Chips.Accreditation"]</a>
-            <a class="chip chip-light" href="/Courses/Index?q=intern%C3%AD%20audit">@T["Home.Hero.Chips.InternalAudits"]</a>
-        </div>
-    </div>
-</section>
+@await Html.PartialAsync("_Hero", new HeroViewModel
+    {
+        Title = T["Home.Hero.Title"].Value,
+        Subtitle = T["Home.Hero.Subtitle"].Value,
+        PrimaryCta = T["Home.Hero.PrimaryCta"].Value,
+        SecondaryCta = T["Home.Hero.SecondaryCta"].Value,
+        SearchPlaceholder = T["Home.Hero.SearchPlaceholder"].Value,
+        Chips = new()
+        {
+            T["Home.Hero.Chip.Online"].Value,
+            T["Home.Hero.Chip.Retraining"].Value,
+            T["Home.Hero.Chip.Certificate"].Value
+        }
+    })
 
 <section class="container-xl mb-4">
     <div class="trust-stripe rounded-4 p-3">

--- a/Pages/_ViewImports.cshtml
+++ b/Pages/_ViewImports.cshtml
@@ -1,6 +1,7 @@
 @using SysJaky_N
 @using SysJaky_N.Models
 @using SysJaky_N.Models.ViewModels
+@using SysJaky_N.ViewModels
 @using SysJaky_N.Pages.Account
 @using SysJaky_N.Extensions
 @using System.Collections.Generic

--- a/ViewModels/HeroViewModel.cs
+++ b/ViewModels/HeroViewModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace SysJaky_N.ViewModels;
+
+public class HeroViewModel
+{
+    public string? Title { get; init; }
+    public string? Subtitle { get; init; }
+    public string? PrimaryCta { get; init; }
+    public string? SecondaryCta { get; init; }
+    public string? SearchPlaceholder { get; init; }
+    public List<string> Chips { get; init; } = new();
+}

--- a/Views/Shared/_Hero.cshtml
+++ b/Views/Shared/_Hero.cshtml
@@ -1,0 +1,158 @@
+@using System
+@using System.Collections.Generic
+@using System.Linq
+@using Microsoft.AspNetCore.Mvc.Localization
+@model SysJaky_N.ViewModels.HeroViewModel
+@inject IViewLocalizer T
+
+@{
+    string GetString(string key, string? fallbackKey = null)
+    {
+        var localized = T[key];
+        var value = localized.Value;
+
+        if (string.Equals(value, key, StringComparison.Ordinal) && !string.IsNullOrEmpty(fallbackKey))
+        {
+            value = T[fallbackKey].Value;
+        }
+
+        return value;
+    }
+
+    var title = Model?.Title;
+    if (string.IsNullOrWhiteSpace(title) || string.Equals(title, "Home.Hero.Title", StringComparison.Ordinal))
+    {
+        title = GetString("Home.Hero.Title");
+    }
+
+    var subtitle = Model?.Subtitle;
+    if (string.IsNullOrWhiteSpace(subtitle) || string.Equals(subtitle, "Home.Hero.Subtitle", StringComparison.Ordinal))
+    {
+        subtitle = GetString("Home.Hero.Subtitle");
+    }
+
+    var primaryCta = Model?.PrimaryCta;
+    if (string.IsNullOrWhiteSpace(primaryCta) || string.Equals(primaryCta, "Home.Hero.PrimaryCta", StringComparison.Ordinal))
+    {
+        primaryCta = GetString("Home.Hero.PrimaryCta");
+    }
+
+    var secondaryCta = Model?.SecondaryCta;
+    if (string.IsNullOrWhiteSpace(secondaryCta) || string.Equals(secondaryCta, "Home.Hero.SecondaryCta", StringComparison.Ordinal))
+    {
+        secondaryCta = GetString("Home.Hero.SecondaryCta");
+    }
+
+    var searchPlaceholder = Model?.SearchPlaceholder;
+    if (string.IsNullOrWhiteSpace(searchPlaceholder) || string.Equals(searchPlaceholder, "Home.Hero.SearchPlaceholder", StringComparison.Ordinal))
+    {
+        searchPlaceholder = GetString("Home.Hero.SearchPlaceholder", "Home.Hero.Search.Placeholder");
+    }
+
+    var fallbackChipDefinitions = new List<(string Url, string Label)>
+    {
+        ("/Courses/Index?Mode=Online", GetString("Home.Hero.Chip.Online", "Home.Hero.Chips.Online")),
+        ("/Courses/Index?CourseGroupId=REKVAL", GetString("Home.Hero.Chip.Retraining", "Home.Hero.Chips.Retraining")),
+        ("/Courses/Index?Level=Beginner", GetString("Home.Hero.Chip.Beginner", "Home.Hero.Chips.Beginner")),
+        ("/Courses/Index?City=Praha", GetString("Home.Hero.Chip.Prague", "Home.Hero.Chips.Prague")),
+        ("/Courses/Index?HasCertificate=true", GetString("Home.Hero.Chip.Certificate", "Home.Hero.Chips.Certificate")),
+        ("/Courses/Index?q=akreditace", GetString("Home.Hero.Chip.Accreditation", "Home.Hero.Chips.Accreditation")),
+        ("/Courses/Index?q=intern%C3%AD%20audit", GetString("Home.Hero.Chip.InternalAudits", "Home.Hero.Chips.InternalAudits")),
+    };
+
+    var chips = new List<(string Url, string Label)>();
+
+    if (Model?.Chips?.Count > 0)
+    {
+        var lookup = fallbackChipDefinitions.ToDictionary(c => c.Label, c => c.Url, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var chip in Model.Chips)
+        {
+            if (string.IsNullOrWhiteSpace(chip))
+            {
+                continue;
+            }
+
+            var label = chip;
+            if (!lookup.TryGetValue(label, out var url))
+            {
+                var localizedChip = T[chip];
+                if (!string.Equals(localizedChip.Value, chip, StringComparison.Ordinal))
+                {
+                    label = localizedChip.Value;
+                    if (!lookup.TryGetValue(label, out url))
+                    {
+                        url = "#";
+                    }
+                }
+                else
+                {
+                    url = "#";
+                }
+            }
+
+            chips.Add((url, label));
+        }
+    }
+
+    if (chips.Count == 0)
+    {
+        chips = fallbackChipDefinitions;
+    }
+}
+
+<section class="py-5 gradient-hero text-white text-center rounded-4 mb-4 hero-section">
+    <div class="container-xl position-relative">
+        <h1 class="display-5 fw-bold mb-3">@title</h1>
+        <p class="lead mb-4 opacity-75 mx-auto" style="max-width: 56rem;">@subtitle</p>
+
+        <ul class="list-unstyled d-flex flex-column flex-lg-row justify-content-center align-items-lg-center gap-3 mb-4">
+            <li class="d-flex align-items-center gap-2">
+                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-patch-check-fill"></i></span>
+                <span class="fw-semibold">@T["Home.Hero.Usp1"]</span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-award-fill"></i></span>
+                <span class="fw-semibold">@T["Home.Hero.Usp2"]</span>
+            </li>
+            <li class="d-flex align-items-center gap-2">
+                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-people-fill"></i></span>
+                <span class="fw-semibold">@T["Home.Hero.Usp3"]</span>
+            </li>
+        </ul>
+
+        <div class="d-flex flex-column flex-sm-row justify-content-center gap-2 mb-4">
+            <a href="/Courses/Index" class="btn btn-light fw-semibold px-4">@primaryCta</a>
+            <a href="/CorporateInquiry" class="btn btn-outline-light fw-semibold px-4">@secondaryCta</a>
+        </div>
+
+        <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm" role="search" aria-label="@T["Home.Hero.Search.AriaLabel"]">
+            <div class="col-12 col-md-3">
+                <label class="form-label visually-hidden" for="heroPersona">@T["Home.Hero.Persona.Label"]</label>
+                <select id="heroPersona" name="persona" class="form-select filter-select" aria-describedby="heroPersonaHelp" persona-options></select>
+                <div id="heroPersonaHelp" class="visually-hidden">@T["Home.Hero.Persona.Help"]</div>
+            </div>
+            <div class="col-12 col-md-3">
+                <label class="form-label visually-hidden" for="heroGoal">@T["Home.Hero.Goal.Label"]</label>
+                <select id="heroGoal" name="goal" class="form-select filter-select" aria-describedby="heroGoalHelp" goal-options></select>
+                <div id="heroGoalHelp" class="visually-hidden">@T["Home.Hero.Goal.Help"]</div>
+            </div>
+            <div class="col-12 col-md-4">
+                <div class="input-group">
+                    <span class="input-group-text" id="heroSearchLabel"><i class="bi bi-search" aria-hidden="true"></i><span class="visually-hidden">@T["Home.Hero.Search.Label"]</span></span>
+                    <input name="q" class="form-control" placeholder="@searchPlaceholder" aria-labelledby="heroSearchLabel" />
+                </div>
+            </div>
+            <div class="col-12 col-md-2 d-grid">
+                <button class="btn btn-light fw-semibold" type="submit">@T["Home.Hero.Search.Submit"]</button>
+            </div>
+        </form>
+
+        <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
+            @foreach (var chip in chips)
+            {
+                <a class="chip chip-light" href="@chip.Url">@chip.Label</a>
+            }
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add a HeroViewModel to transport hero headline content and chip labels
- create a reusable _Hero partial that renders hero markup with localization fallbacks
- update the home page to supply hero content via the view model and import the namespace

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68de7e2e1b3883218cc8d7c3cba39b45