### PR TITLE
Use view localizer for shared navigation labels

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
 @using SysJaky_N.Pages.Account
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @inject Microsoft.Extensions.Configuration.IConfiguration Configuration
-@inject Microsoft.Extensions.Localization.IStringLocalizer<SysJaky_N.SharedResource> T
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer T
 @{ 
     var currentCulture = CultureInfo.CurrentUICulture;
     var isCzech = string.Equals(currentCulture.TwoLetterISOLanguageName, "cs", System.StringComparison.OrdinalIgnoreCase);
@@ -74,25 +74,25 @@
                 <div id="primaryNavigation" class="navbar-collapse collapse d-lg-inline-flex justify-content-between">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0 gap-lg-1">
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">@T["NavHome"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">@T["Nav.Home"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["NavAbout"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["Nav.About"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Services" aria-current="@(currentPage == "/Services" ? "page" : null)">@T["NavServices"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Services" aria-current="@(currentPage == "/Services" ? "page" : null)">@T["Nav.Services"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@T["NavCourses"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@T["Nav.Courses"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(currentPage == "/Articles/Index" ? "page" : null)">@T["NavArticles"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(currentPage == "/Articles/Index" ? "page" : null)">@T["Nav.Articles"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/CorporateInquiry" aria-current="@(currentPage == "/CorporateInquiry" ? "page" : null)">@T["NavCorporateInquiry"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/CorporateInquiry" aria-current="@(currentPage == "/CorporateInquiry" ? "page" : null)">@T["Nav.CorporateInquiry"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">@T["NavPrivacy"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">@T["Nav.Privacy"]</a>
                         </li>
                     </ul>
                     <ul class="navbar-nav ms-auto align-items-center gap-3 mb-2 mb-lg-0">
@@ -153,13 +153,13 @@
                         </li>
                 <div id="primaryNavigation" class="collapse navbar-collapse">
                     <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                        <li class="nav-item"><a class="nav-link" asp-page="/Index">@T["NavHome"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/About">@T["NavAbout"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Services">@T["NavServices"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Courses/Index">@T["NavCourses"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Articles/Index">@T["NavArticles"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/CorporateInquiry">@T["NavCorporateInquiry"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Privacy">@T["NavPrivacy"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Index">@T["Nav.Home"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/About">@T["Nav.About"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Services">@T["Nav.Services"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Courses/Index">@T["Nav.Courses"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Articles/Index">@T["Nav.Articles"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/CorporateInquiry">@T["Nav.CorporateInquiry"]</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Privacy">@T["Nav.Privacy"]</a></li>
                     </ul>
                     <div class="d-flex align-items-center gap-3">
                         <partial name="_LanguageSwitcher" />

--- a/Resources/Views/Shared/_Layout.cshtml.en.resx
+++ b/Resources/Views/Shared/_Layout.cshtml.en.resx
@@ -24,25 +24,25 @@
   <data name="ToggleTheme" xml:space="preserve">
     <value>Toggle theme</value>
   </data>
-  <data name="NavHome" xml:space="preserve">
+  <data name="Nav.Home" xml:space="preserve">
     <value>Home</value>
   </data>
-  <data name="NavAbout" xml:space="preserve">
+  <data name="Nav.About" xml:space="preserve">
     <value>About</value>
   </data>
-  <data name="NavCourses" xml:space="preserve">
+  <data name="Nav.Courses" xml:space="preserve">
     <value>Courses &amp; Training</value>
   </data>
-  <data name="NavArticles" xml:space="preserve">
+  <data name="Nav.Articles" xml:space="preserve">
     <value>Articles</value>
   </data>
-  <data name="NavServices" xml:space="preserve">
+  <data name="Nav.Services" xml:space="preserve">
     <value>Services &amp; consulting</value>
   </data>
-  <data name="NavCorporateInquiry" xml:space="preserve">
+  <data name="Nav.CorporateInquiry" xml:space="preserve">
     <value>Corporate inquiry</value>
   </data>
-  <data name="NavPrivacy" xml:space="preserve">
+  <data name="Nav.Privacy" xml:space="preserve">
     <value>Privacy</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">

--- a/Resources/Views/Shared/_Layout.cshtml.resx
+++ b/Resources/Views/Shared/_Layout.cshtml.resx
@@ -24,25 +24,25 @@
   <data name="ToggleTheme" xml:space="preserve">
     <value>Přepnout vzhled</value>
   </data>
-  <data name="NavHome" xml:space="preserve">
+  <data name="Nav.Home" xml:space="preserve">
     <value>Úvod – poradenství systémů jakosti</value>
   </data>
-  <data name="NavAbout" xml:space="preserve">
+  <data name="Nav.About" xml:space="preserve">
     <value>O společnosti Systémy jakosti</value>
   </data>
-  <data name="NavCourses" xml:space="preserve">
+  <data name="Nav.Courses" xml:space="preserve">
     <value>Kurzy a školení ISO</value>
   </data>
-  <data name="NavArticles" xml:space="preserve">
+  <data name="Nav.Articles" xml:space="preserve">
     <value>Články a případové studie</value>
   </data>
-  <data name="NavCorporateInquiry" xml:space="preserve">
+  <data name="Nav.CorporateInquiry" xml:space="preserve">
     <value>Firemní poptávka / audit na míru</value>
   </data>
-  <data name="NavServices" xml:space="preserve">
+  <data name="Nav.Services" xml:space="preserve">
     <value>Služby a poradenství</value>
   </data>
-  <data name="NavPrivacy" xml:space="preserve">
+  <data name="Nav.Privacy" xml:space="preserve">
     <value>Ochrana soukromí</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">


### PR DESCRIPTION
## Summary
- inject the view localizer into the shared layout to provide navigation text
- rename navigation resource keys to the Nav.* pattern and reference them via the view localizer

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68de943bd82c8321a5270b4f7f3a1f4f