### PR TITLE
Render hero ISO chips only when data is available

### DIFF
--- a/Views/Shared/_Hero.cshtml
+++ b/Views/Shared/_Hero.cshtml
@@ -49,21 +49,21 @@
         searchPlaceholder = GetString("Home.Hero.SearchPlaceholder", "Home.Hero.Search.Placeholder");
     }
 
-    var fallbackChipDefinitions = new List<(string Url, string Label)>
-    {
-        ("/Courses/Index?Mode=Online", GetString("Home.Hero.Chip.Online", "Home.Hero.Chips.Online")),
-        ("/Courses/Index?CourseGroupId=REKVAL", GetString("Home.Hero.Chip.Retraining", "Home.Hero.Chips.Retraining")),
-        ("/Courses/Index?Level=Beginner", GetString("Home.Hero.Chip.Beginner", "Home.Hero.Chips.Beginner")),
-        ("/Courses/Index?City=Praha", GetString("Home.Hero.Chip.Prague", "Home.Hero.Chips.Prague")),
-        ("/Courses/Index?HasCertificate=true", GetString("Home.Hero.Chip.Certificate", "Home.Hero.Chips.Certificate")),
-        ("/Courses/Index?q=akreditace", GetString("Home.Hero.Chip.Accreditation", "Home.Hero.Chips.Accreditation")),
-        ("/Courses/Index?q=intern%C3%AD%20audit", GetString("Home.Hero.Chip.InternalAudits", "Home.Hero.Chips.InternalAudits")),
-    };
-
     var chips = new List<(string Url, string Label)>();
 
     if (Model?.Chips?.Count > 0)
     {
+        var fallbackChipDefinitions = new List<(string Url, string Label)>
+        {
+            ("/Courses/Index?Mode=Online", GetString("Home.Hero.Chip.Online", "Home.Hero.Chips.Online")),
+            ("/Courses/Index?CourseGroupId=REKVAL", GetString("Home.Hero.Chip.Retraining", "Home.Hero.Chips.Retraining")),
+            ("/Courses/Index?Level=Beginner", GetString("Home.Hero.Chip.Beginner", "Home.Hero.Chips.Beginner")),
+            ("/Courses/Index?City=Praha", GetString("Home.Hero.Chip.Prague", "Home.Hero.Chips.Prague")),
+            ("/Courses/Index?HasCertificate=true", GetString("Home.Hero.Chip.Certificate", "Home.Hero.Chips.Certificate")),
+            ("/Courses/Index?q=akreditace", GetString("Home.Hero.Chip.Accreditation", "Home.Hero.Chips.Accreditation")),
+            ("/Courses/Index?q=intern%C3%AD%20audit", GetString("Home.Hero.Chip.InternalAudits", "Home.Hero.Chips.InternalAudits")),
+        };
+
         var lookup = fallbackChipDefinitions.ToDictionary(c => c.Label, c => c.Url, StringComparer.OrdinalIgnoreCase);
 
         foreach (var chip in Model.Chips)
@@ -93,11 +93,6 @@
 
             chips.Add((url, label));
         }
-    }
-
-    if (chips.Count == 0)
-    {
-        chips = fallbackChipDefinitions;
     }
 }
 
@@ -148,11 +143,14 @@
             </div>
         </form>
 
-        <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
-            @foreach (var chip in chips)
-            {
-                <a class="chip chip-light" href="@chip.Url">@chip.Label</a>
-            }
-        </div>
+        @if (Model?.Chips?.Any() == true && chips.Count > 0)
+        {
+            <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
+                @foreach (var chip in chips)
+                {
+                    <a class="chip chip-light" href="@chip.Url">@chip.Label</a>
+                }
+            </div>
+        }
     </div>
 </section>


### PR DESCRIPTION
## Summary
- stop rendering hero ISO chips when the page model does not provide chip data
- keep chip URL mapping logic for provided chips without falling back to hard-coded defaults

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de94ba8f4c8321809df6f01d6ad273