### PR TITLE
Localize data annotations

### DIFF
--- a/Models/CompanyProfile.cs
+++ b/Models/CompanyProfile.cs
@@ -6,17 +6,17 @@ public class CompanyProfile
 {
     public int Id { get; set; }
 
-    [Required(ErrorMessage = "Pole {0} je povinné.")]
-    [StringLength(200, ErrorMessage = "Pole {0} může mít maximálně {1} znaků.")]
-    [Display(Name = "Název")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(200, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.CompanyProfile.Name.DisplayName")]
     public string Name { get; set; } = string.Empty;
 
-    [Required(ErrorMessage = "Pole {0} je povinné.")]
-    [StringLength(64, ErrorMessage = "Pole {0} může mít maximálně {1} znaků.")]
-    [Display(Name = "Referenční kód")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(64, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.CompanyProfile.ReferenceCode.DisplayName")]
     public string ReferenceCode { get; set; } = string.Empty;
 
-    [Display(Name = "Správce")]
+    [Display(Name = "Models.CompanyProfile.ManagerId.DisplayName")]
     public string? ManagerId { get; set; }
     public ApplicationUser? Manager { get; set; }
     public List<ApplicationUser> Users { get; set; } = new();

--- a/Models/CourseBlock.cs
+++ b/Models/CourseBlock.cs
@@ -1,19 +1,23 @@
 namespace SysJaky_N.Models;
 
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 public class CourseBlock
 {
     public int Id { get; set; }
 
-    [Required(ErrorMessage = "Název je povinný.")]
-    [StringLength(100, ErrorMessage = "Název může mít nejvýše 100 znaků.")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(100, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.CourseBlock.Title.DisplayName")]
     public string Title { get; set; } = string.Empty;
 
-    [StringLength(1000, ErrorMessage = "Popis může mít nejvýše 1000 znaků.")]
+    [StringLength(1000, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.CourseBlock.Description.DisplayName")]
     public string? Description { get; set; }
 
-    [Range(0, double.MaxValue, ErrorMessage = "Cena musí být nezáporná.")]
+    [Range(0, double.MaxValue, ErrorMessage = "Validation.NonNegativeNumber")]
+    [Display(Name = "Models.CourseBlock.Price.DisplayName")]
     public decimal Price { get; set; }
 
     public ICollection<Course> Modules { get; set; } = new List<Course>();

--- a/Models/CourseTerm.cs
+++ b/Models/CourseTerm.cs
@@ -7,34 +7,34 @@ public class CourseTerm
 {
     public int Id { get; set; }
 
-    [Required]
-    [Display(Name = "Course")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [Display(Name = "Models.CourseTerm.CourseId.DisplayName")]
     public int CourseId { get; set; }
     public Course? Course { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Validation.Required")]
     [DataType(DataType.DateTime)]
-    [Display(Name = "Start (UTC)")]
+    [Display(Name = "Models.CourseTerm.StartUtc.DisplayName")]
     public DateTime StartUtc { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Validation.Required")]
     [DataType(DataType.DateTime)]
-    [Display(Name = "End (UTC)")]
+    [Display(Name = "Models.CourseTerm.EndUtc.DisplayName")]
     public DateTime EndUtc { get; set; }
 
-    [Range(1, int.MaxValue, ErrorMessage = "Capacity must be at least 1.")]
+    [Range(1, int.MaxValue, ErrorMessage = "Validation.PositiveInteger")]
     public int Capacity { get; set; }
 
-    [Display(Name = "Seats taken")]
-    [Range(0, int.MaxValue)]
+    [Display(Name = "Models.CourseTerm.SeatsTaken.DisplayName")]
+    [Range(0, int.MaxValue, ErrorMessage = "Validation.NonNegativeNumber")]
     public int SeatsTaken { get; set; }
 
-    [Display(Name = "Active")]
+    [Display(Name = "Models.CourseTerm.IsActive.DisplayName")]
     public bool IsActive { get; set; } = true;
 
     public DateTime? ReviewRequestSentAtUtc { get; set; }
 
-    [Display(Name = "Instructor")]
+    [Display(Name = "Models.CourseTerm.InstructorId.DisplayName")]
     public int? InstructorId { get; set; }
     public Instructor? Instructor { get; set; }
 

--- a/Models/Instructor.cs
+++ b/Models/Instructor.cs
@@ -7,23 +7,23 @@ public class Instructor
 {
     public int Id { get; set; }
 
-    [Required(ErrorMessage = "Pole {0} je povinné.")]
-    [StringLength(200, ErrorMessage = "Pole {0} může mít maximálně {1} znaků.")]
-    [Display(Name = "Celé jméno")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(200, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Instructor.FullName.DisplayName")]
     public string FullName { get; set; } = string.Empty;
 
-    [EmailAddress(ErrorMessage = "Zadejte platnou e-mailovou adresu.")]
-    [StringLength(200, ErrorMessage = "Pole {0} může mít maximálně {1} znaků.")]
-    [Display(Name = "E-mail")]
+    [EmailAddress(ErrorMessage = "Validation.EmailAddress")]
+    [StringLength(200, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Instructor.Email.DisplayName")]
     public string? Email { get; set; }
 
-    [Phone(ErrorMessage = "Zadejte platné telefonní číslo.")]
-    [Display(Name = "Telefon")]
-    [StringLength(50, ErrorMessage = "Pole {0} může mít maximálně {1} znaků.")]
+    [Phone(ErrorMessage = "Validation.Phone")]
+    [Display(Name = "Models.Instructor.PhoneNumber.DisplayName")]
+    [StringLength(50, ErrorMessage = "Validation.StringLength")]
     public string? PhoneNumber { get; set; }
 
-    [StringLength(4000, ErrorMessage = "Pole {0} může mít maximálně {1} znaků.")]
-    [Display(Name = "Životopis")]
+    [StringLength(4000, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Instructor.Bio.DisplayName")]
     [DataType(DataType.MultilineText)]
     public string? Bio { get; set; }
 

--- a/Models/Order.cs
+++ b/Models/Order.cs
@@ -62,15 +62,15 @@ public class OrderItem
 
 public enum OrderStatus
 {
-    [Display(Name = "Čeká na platbu")]
+    [Display(Name = "Models.OrderStatus.Pending.DisplayName")]
     Pending,
 
-    [Display(Name = "Zaplaceno")]
+    [Display(Name = "Models.OrderStatus.Paid.DisplayName")]
     Paid,
 
-    [Display(Name = "Zrušeno")]
+    [Display(Name = "Models.OrderStatus.Cancelled.DisplayName")]
     Cancelled,
 
-    [Display(Name = "Vráceno")]
+    [Display(Name = "Models.OrderStatus.Refunded.DisplayName")]
     Refunded
 }

--- a/Models/PriceSchedule.cs
+++ b/Models/PriceSchedule.cs
@@ -6,22 +6,22 @@ public class PriceSchedule
 {
     public int Id { get; set; }
 
-    [Required(ErrorMessage = "Kurz je povinný.")]
-    [Display(Name = "Kurz")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [Display(Name = "Models.PriceSchedule.CourseId.DisplayName")]
     public int CourseId { get; set; }
 
     public Course? Course { get; set; }
 
     [DataType(DataType.DateTime)]
-    [Display(Name = "Platí od")]
+    [Display(Name = "Models.PriceSchedule.FromUtc.DisplayName")]
     public DateTime FromUtc { get; set; }
 
     [DataType(DataType.DateTime)]
-    [Display(Name = "Platí do")]
+    [Display(Name = "Models.PriceSchedule.ToUtc.DisplayName")]
     public DateTime ToUtc { get; set; }
 
-    [Range(0.01, double.MaxValue, ErrorMessage = "Nová cena musí být větší než nula.")]
+    [Range(0.01, double.MaxValue, ErrorMessage = "Validation.NewPricePositive")]
     [DataType(DataType.Currency)]
-    [Display(Name = "Nová cena (bez DPH)")]
+    [Display(Name = "Models.PriceSchedule.NewPriceExcl.DisplayName")]
     public decimal NewPriceExcl { get; set; }
 }

--- a/Models/Testimonial.cs
+++ b/Models/Testimonial.cs
@@ -6,46 +6,46 @@ public class Testimonial
 {
     public int Id { get; set; }
 
-    [Required]
-    [StringLength(120)]
-    [Display(Name = "Jméno a příjmení")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(120, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Testimonial.FullName.DisplayName")]
     public string FullName { get; set; } = string.Empty;
 
-    [Required]
-    [StringLength(80)]
-    [Display(Name = "Pozice")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(80, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Testimonial.Position.DisplayName")]
     public string Position { get; set; } = string.Empty;
 
-    [Required]
-    [StringLength(120)]
-    [Display(Name = "Společnost")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(120, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Testimonial.Company.DisplayName")]
     public string Company { get; set; } = string.Empty;
 
-    [StringLength(256)]
-    [Url]
-    [Display(Name = "URL fotografie")]
+    [StringLength(256, ErrorMessage = "Validation.StringLength")]
+    [Url(ErrorMessage = "Validation.Url")]
+    [Display(Name = "Models.Testimonial.PhotoUrl.DisplayName")]
     public string? PhotoUrl { get; set; }
 
-    [Required]
-    [StringLength(150)]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(150, ErrorMessage = "Validation.StringLength")]
     [DataType(DataType.MultilineText)]
-    [Display(Name = "Citace")]
+    [Display(Name = "Models.Testimonial.Quote.DisplayName")]
     public string Quote { get; set; } = string.Empty;
 
-    [Range(1, 5)]
-    [Display(Name = "Hodnocení")]
+    [Range(1, 5, ErrorMessage = "Validation.Range")]
+    [Display(Name = "Models.Testimonial.Rating.DisplayName")]
     public int Rating { get; set; } = 5;
 
-    [Display(Name = "Publikovat")]
+    [Display(Name = "Models.Testimonial.IsPublished.DisplayName")]
     public bool IsPublished { get; set; }
 
-    [Display(Name = "Souhlas se zpracováním osobních údajů")]
+    [Display(Name = "Models.Testimonial.ConsentGranted.DisplayName")]
     public bool ConsentGranted { get; set; }
 
     [DataType(DataType.DateTime)]
     public DateTime? ConsentGrantedAtUtc { get; set; }
 
-    [StringLength(180)]
-    [Display(Name = "Alternativní text fotografie")]
+    [StringLength(180, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Testimonial.PhotoAltText.DisplayName")]
     public string? PhotoAltText { get; set; }
 }

--- a/Models/Voucher.cs
+++ b/Models/Voucher.cs
@@ -4,10 +4,10 @@ namespace SysJaky_N.Models;
 
 public enum VoucherType
 {
-    [Display(Name = "Procentuální sleva")]
+    [Display(Name = "Models.VoucherType.Percentage.DisplayName")]
     Percentage,
 
-    [Display(Name = "Fixní částka")]
+    [Display(Name = "Models.VoucherType.FixedAmount.DisplayName")]
     FixedAmount
 }
 
@@ -15,33 +15,33 @@ public class Voucher
 {
     public int Id { get; set; }
 
-    [Required]
-    [StringLength(100)]
-    [Display(Name = "Kód")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [StringLength(100, ErrorMessage = "Validation.StringLength")]
+    [Display(Name = "Models.Voucher.Code.DisplayName")]
     public string Code { get; set; } = string.Empty;
 
-    [Required]
-    [Display(Name = "Typ voucheru")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [Display(Name = "Models.Voucher.Type.DisplayName")]
     public VoucherType Type { get; set; }
 
-    [Range(0, double.MaxValue)]
-    [Display(Name = "Hodnota")]
+    [Range(0, double.MaxValue, ErrorMessage = "Validation.NonNegativeNumber")]
+    [Display(Name = "Models.Voucher.Value.DisplayName")]
     public decimal Value { get; set; }
 
     [DataType(DataType.DateTime)]
-    [Display(Name = "Platnost (UTC)")]
+    [Display(Name = "Models.Voucher.ExpiresUtc.DisplayName")]
     public DateTime? ExpiresUtc { get; set; }
 
-    [Range(1, int.MaxValue, ErrorMessage = "Maximální počet uplatnění musí být větší než nula.")]
-    [Display(Name = "Maximální počet uplatnění")]
+    [Range(1, int.MaxValue, ErrorMessage = "Validation.PositiveInteger")]
+    [Display(Name = "Models.Voucher.MaxRedemptions.DisplayName")]
     public int? MaxRedemptions { get; set; }
 
-    [Range(0, int.MaxValue)]
-    [Display(Name = "Počet uplatnění")]
+    [Range(0, int.MaxValue, ErrorMessage = "Validation.NonNegativeNumber")]
+    [Display(Name = "Models.Voucher.UsedCount.DisplayName")]
     public int UsedCount { get; set; }
 
     public int? AppliesToCourseId { get; set; }
 
-    [Display(Name = "Platí pro kurz")]
+    [Display(Name = "Models.Voucher.AppliesToCourse.DisplayName")]
     public Course? AppliesToCourse { get; set; }
 }

--- a/Pages/Account/Login.cshtml.cs
+++ b/Pages/Account/Login.cshtml.cs
@@ -25,14 +25,14 @@ public class LoginModel : PageModel
 
     public class InputModel
     {
-        [Required]
-        [EmailAddress]
+        [Required(ErrorMessage = "Validation.Required")]
+        [EmailAddress(ErrorMessage = "Validation.EmailAddress")]
         public string Email { get; set; } = string.Empty;
 
-        [Required]
+        [Required(ErrorMessage = "Validation.Required")]
         [DataType(DataType.Password)]
-        [StringLength(100, MinimumLength = 6)]
-        [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Password must contain upper and lower case letters and numbers.")]
+        [StringLength(100, MinimumLength = 6, ErrorMessage = "Validation.StringLengthRange")]
+        [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Validation.PasswordComplexity")]
         public string Password { get; set; } = string.Empty;
 
         public bool RememberMe { get; set; }

--- a/Pages/Account/Register.cshtml.cs
+++ b/Pages/Account/Register.cshtml.cs
@@ -31,23 +31,23 @@ public class RegisterModel : PageModel
 
     public class InputModel
     {
-        [Required]
-        [EmailAddress]
+        [Required(ErrorMessage = "Validation.Required")]
+        [EmailAddress(ErrorMessage = "Validation.EmailAddress")]
         public string Email { get; set; } = string.Empty;
 
-        [Required]
+        [Required(ErrorMessage = "Validation.Required")]
         [DataType(DataType.Password)]
-        [StringLength(100, MinimumLength = 6)]
-        [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Password must contain upper and lower case letters and numbers.")]
+        [StringLength(100, MinimumLength = 6, ErrorMessage = "Validation.StringLengthRange")]
+        [RegularExpression("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$", ErrorMessage = "Validation.PasswordComplexity")]
         public string Password { get; set; } = string.Empty;
 
         [DataType(DataType.Password)]
-        [Display(Name = "Confirm password")]
-        [Compare(nameof(Password))]
+        [Display(Name = "Pages.Account.Register.Input.ConfirmPassword.DisplayName")]
+        [Compare(nameof(Password), ErrorMessage = "Validation.PasswordMismatch")]
         public string ConfirmPassword { get; set; } = string.Empty;
         public string Captcha { get; set; } = string.Empty;
 
-        [Display(Name = "Referral code")]
+        [Display(Name = "Pages.Account.Register.Input.ReferralCode.DisplayName")]
         public string? ReferralCode { get; set; }
     }
 

--- a/Pages/Admin/CourseTerms/CourseTermInputModel.cs
+++ b/Pages/Admin/CourseTerms/CourseTermInputModel.cs
@@ -5,26 +5,26 @@ namespace SysJaky_N.Pages.Admin.CourseTerms;
 
 public class CourseTermInputModel
 {
-    [Required]
-    [Display(Name = "Course")]
+    [Required(ErrorMessage = "Validation.Required")]
+    [Display(Name = "Pages.Admin.CourseTerms.Input.CourseId.DisplayName")]
     public int CourseId { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Validation.Required")]
     [DataType(DataType.DateTime)]
-    [Display(Name = "Start time")]
+    [Display(Name = "Pages.Admin.CourseTerms.Input.StartUtc.DisplayName")]
     public DateTime StartUtc { get; set; }
 
-    [Required]
+    [Required(ErrorMessage = "Validation.Required")]
     [DataType(DataType.DateTime)]
-    [Display(Name = "End time")]
+    [Display(Name = "Pages.Admin.CourseTerms.Input.EndUtc.DisplayName")]
     public DateTime EndUtc { get; set; }
 
-    [Range(1, int.MaxValue, ErrorMessage = "Capacity must be at least 1.")]
+    [Range(1, int.MaxValue, ErrorMessage = "Validation.PositiveInteger")]
     public int Capacity { get; set; } = 1;
 
-    [Display(Name = "Active")]
+    [Display(Name = "Pages.Admin.CourseTerms.Input.IsActive.DisplayName")]
     public bool IsActive { get; set; } = true;
 
-    [Display(Name = "Instructor")]
+    [Display(Name = "Pages.Admin.CourseTerms.Input.InstructorId.DisplayName")]
     public int? InstructorId { get; set; }
 }

--- a/Pages/Admin/Users/Edit.cshtml.cs
+++ b/Pages/Admin/Users/Edit.cshtml.cs
@@ -30,16 +30,16 @@ public class EditModel : PageModel
 
     public class InputModel
     {
-        [Required(ErrorMessage = "Pole {0} je povinné.")]
-        [EmailAddress(ErrorMessage = "Zadejte platnou e-mailovou adresu.")]
-        [Display(Name = "E-mail")]
+        [Required(ErrorMessage = "Validation.Required")]
+        [EmailAddress(ErrorMessage = "Validation.EmailAddress")]
+        [Display(Name = "Pages.Admin.Users.Edit.Input.Email.DisplayName")]
         public string Email { get; set; } = string.Empty;
 
-        [Phone(ErrorMessage = "Zadejte platné telefonní číslo.")]
-        [Display(Name = "Telefonní číslo")]
+        [Phone(ErrorMessage = "Validation.Phone")]
+        [Display(Name = "Pages.Admin.Users.Edit.Input.PhoneNumber.DisplayName")]
         public string? PhoneNumber { get; set; }
 
-        [Display(Name = "Účet zablokován")]
+        [Display(Name = "Pages.Admin.Users.Edit.Input.IsLocked.DisplayName")]
         public bool IsLocked { get; set; }
         public List<RoleSelection> Roles { get; set; } = new();
     }

--- a/Pages/Api/Newsletter.cshtml.cs
+++ b/Pages/Api/Newsletter.cshtml.cs
@@ -163,10 +163,10 @@ public class NewsletterModel : PageModel
 
     public class InputModel
     {
-        [Display(Name = "email")]
+        [Display(Name = "Pages.Api.Newsletter.Input.Email.DisplayName")]
         public string Email { get; set; } = string.Empty;
 
-        [Display(Name = "consent")]
+        [Display(Name = "Pages.Api.Newsletter.Input.Consent.DisplayName")]
         public bool Consent { get; set; }
     }
 }

--- a/Resources/SharedResources.en.resx
+++ b/Resources/SharedResources.en.resx
@@ -33,4 +33,202 @@
   <data name="Range" xml:space="preserve">
     <value>The field {0} must be between {1} and {2}.</value>
   </data>
+  <data name="Validation.Required" xml:space="preserve">
+    <value>The {0} field is required.</value>
+  </data>
+  <data name="Validation.StringLength" xml:space="preserve">
+    <value>The {0} field must be at most {1} characters long.</value>
+  </data>
+  <data name="Validation.StringLengthRange" xml:space="preserve">
+    <value>The {0} field must be between {2} and {1} characters long.</value>
+  </data>
+  <data name="Validation.EmailAddress" xml:space="preserve">
+    <value>The {0} field must contain a valid email address.</value>
+  </data>
+  <data name="Validation.Phone" xml:space="preserve">
+    <value>The {0} field must contain a valid phone number.</value>
+  </data>
+  <data name="Validation.Url" xml:space="preserve">
+    <value>The {0} field must contain a valid URL.</value>
+  </data>
+  <data name="Validation.Range" xml:space="preserve">
+    <value>The {0} field must be between {1} and {2}.</value>
+  </data>
+  <data name="Validation.PositiveInteger" xml:space="preserve">
+    <value>The {0} field must be greater than zero.</value>
+  </data>
+  <data name="Validation.NonNegativeNumber" xml:space="preserve">
+    <value>The {0} field must be non-negative.</value>
+  </data>
+  <data name="Validation.NewPricePositive" xml:space="preserve">
+    <value>The new price must be greater than zero.</value>
+  </data>
+  <data name="Validation.PasswordComplexity" xml:space="preserve">
+    <value>The password must contain upper and lower case letters and numbers.</value>
+  </data>
+  <data name="Validation.PasswordMismatch" xml:space="preserve">
+    <value>The {0} and {1} fields must match.</value>
+  </data>
+  <data name="Models.CompanyProfile.ManagerId.DisplayName" xml:space="preserve">
+    <value>Manager</value>
+  </data>
+  <data name="Models.CompanyProfile.Name.DisplayName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Models.CompanyProfile.ReferenceCode.DisplayName" xml:space="preserve">
+    <value>Reference code</value>
+  </data>
+  <data name="Models.CourseBlock.Description.DisplayName" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Models.CourseBlock.Price.DisplayName" xml:space="preserve">
+    <value>Price</value>
+  </data>
+  <data name="Models.CourseBlock.Title.DisplayName" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="Models.CourseTerm.CourseId.DisplayName" xml:space="preserve">
+    <value>Course</value>
+  </data>
+  <data name="Models.CourseTerm.EndUtc.DisplayName" xml:space="preserve">
+    <value>End (UTC)</value>
+  </data>
+  <data name="Models.CourseTerm.InstructorId.DisplayName" xml:space="preserve">
+    <value>Instructor</value>
+  </data>
+  <data name="Models.CourseTerm.IsActive.DisplayName" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="Models.CourseTerm.SeatsTaken.DisplayName" xml:space="preserve">
+    <value>Seats taken</value>
+  </data>
+  <data name="Models.CourseTerm.StartUtc.DisplayName" xml:space="preserve">
+    <value>Start (UTC)</value>
+  </data>
+  <data name="Models.Instructor.Bio.DisplayName" xml:space="preserve">
+    <value>Bio</value>
+  </data>
+  <data name="Models.Instructor.Email.DisplayName" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Models.Instructor.FullName.DisplayName" xml:space="preserve">
+    <value>Full name</value>
+  </data>
+  <data name="Models.Instructor.PhoneNumber.DisplayName" xml:space="preserve">
+    <value>Phone</value>
+  </data>
+  <data name="Models.OrderStatus.Cancelled.DisplayName" xml:space="preserve">
+    <value>Cancelled</value>
+  </data>
+  <data name="Models.OrderStatus.Paid.DisplayName" xml:space="preserve">
+    <value>Paid</value>
+  </data>
+  <data name="Models.OrderStatus.Pending.DisplayName" xml:space="preserve">
+    <value>Pending payment</value>
+  </data>
+  <data name="Models.OrderStatus.Refunded.DisplayName" xml:space="preserve">
+    <value>Refunded</value>
+  </data>
+  <data name="Models.PriceSchedule.CourseId.DisplayName" xml:space="preserve">
+    <value>Course</value>
+  </data>
+  <data name="Models.PriceSchedule.FromUtc.DisplayName" xml:space="preserve">
+    <value>Valid from</value>
+  </data>
+  <data name="Models.PriceSchedule.NewPriceExcl.DisplayName" xml:space="preserve">
+    <value>New price (excl. VAT)</value>
+  </data>
+  <data name="Models.PriceSchedule.ToUtc.DisplayName" xml:space="preserve">
+    <value>Valid until</value>
+  </data>
+  <data name="Models.Testimonial.Company.DisplayName" xml:space="preserve">
+    <value>Company</value>
+  </data>
+  <data name="Models.Testimonial.ConsentGranted.DisplayName" xml:space="preserve">
+    <value>Consent granted</value>
+  </data>
+  <data name="Models.Testimonial.FullName.DisplayName" xml:space="preserve">
+    <value>Full name</value>
+  </data>
+  <data name="Models.Testimonial.IsPublished.DisplayName" xml:space="preserve">
+    <value>Publish</value>
+  </data>
+  <data name="Models.Testimonial.PhotoAltText.DisplayName" xml:space="preserve">
+    <value>Photo alternative text</value>
+  </data>
+  <data name="Models.Testimonial.PhotoUrl.DisplayName" xml:space="preserve">
+    <value>Photo URL</value>
+  </data>
+  <data name="Models.Testimonial.Position.DisplayName" xml:space="preserve">
+    <value>Position</value>
+  </data>
+  <data name="Models.Testimonial.Quote.DisplayName" xml:space="preserve">
+    <value>Quote</value>
+  </data>
+  <data name="Models.Testimonial.Rating.DisplayName" xml:space="preserve">
+    <value>Rating</value>
+  </data>
+  <data name="Models.Voucher.AppliesToCourse.DisplayName" xml:space="preserve">
+    <value>Applies to course</value>
+  </data>
+  <data name="Models.Voucher.Code.DisplayName" xml:space="preserve">
+    <value>Code</value>
+  </data>
+  <data name="Models.Voucher.ExpiresUtc.DisplayName" xml:space="preserve">
+    <value>Expires (UTC)</value>
+  </data>
+  <data name="Models.Voucher.MaxRedemptions.DisplayName" xml:space="preserve">
+    <value>Max redemptions</value>
+  </data>
+  <data name="Models.Voucher.Type.DisplayName" xml:space="preserve">
+    <value>Voucher type</value>
+  </data>
+  <data name="Models.Voucher.UsedCount.DisplayName" xml:space="preserve">
+    <value>Redemptions used</value>
+  </data>
+  <data name="Models.Voucher.Value.DisplayName" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="Models.VoucherType.FixedAmount.DisplayName" xml:space="preserve">
+    <value>Fixed amount</value>
+  </data>
+  <data name="Models.VoucherType.Percentage.DisplayName" xml:space="preserve">
+    <value>Percentage discount</value>
+  </data>
+  <data name="Pages.Account.Register.Input.ConfirmPassword.DisplayName" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="Pages.Account.Register.Input.ReferralCode.DisplayName" xml:space="preserve">
+    <value>Referral code</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.CourseId.DisplayName" xml:space="preserve">
+    <value>Course</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.EndUtc.DisplayName" xml:space="preserve">
+    <value>End time</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.InstructorId.DisplayName" xml:space="preserve">
+    <value>Instructor</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.IsActive.DisplayName" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.StartUtc.DisplayName" xml:space="preserve">
+    <value>Start time</value>
+  </data>
+  <data name="Pages.Admin.Users.Edit.Input.Email.DisplayName" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="Pages.Admin.Users.Edit.Input.IsLocked.DisplayName" xml:space="preserve">
+    <value>Account locked</value>
+  </data>
+  <data name="Pages.Admin.Users.Edit.Input.PhoneNumber.DisplayName" xml:space="preserve">
+    <value>Phone number</value>
+  </data>
+  <data name="Pages.Api.Newsletter.Input.Consent.DisplayName" xml:space="preserve">
+    <value>Consent</value>
+  </data>
+  <data name="Pages.Api.Newsletter.Input.Email.DisplayName" xml:space="preserve">
+    <value>Email</value>
+  </data>
 </root>

--- a/Resources/SharedResources.resx
+++ b/Resources/SharedResources.resx
@@ -33,4 +33,202 @@
   <data name="Range" xml:space="preserve">
     <value>Pole {0} musí být mezi {1} a {2}.</value>
   </data>
+  <data name="Validation.Required" xml:space="preserve">
+    <value>Pole {0} je povinné.</value>
+  </data>
+  <data name="Validation.StringLength" xml:space="preserve">
+    <value>Pole {0} může mít maximálně {1} znaků.</value>
+  </data>
+  <data name="Validation.StringLengthRange" xml:space="preserve">
+    <value>Pole {0} musí mít délku mezi {2} a {1} znaky.</value>
+  </data>
+  <data name="Validation.EmailAddress" xml:space="preserve">
+    <value>Pole {0} musí obsahovat platnou e-mailovou adresu.</value>
+  </data>
+  <data name="Validation.Phone" xml:space="preserve">
+    <value>Pole {0} musí obsahovat platné telefonní číslo.</value>
+  </data>
+  <data name="Validation.Url" xml:space="preserve">
+    <value>Pole {0} musí obsahovat platnou URL adresu.</value>
+  </data>
+  <data name="Validation.Range" xml:space="preserve">
+    <value>Pole {0} musí být mezi {1} a {2}.</value>
+  </data>
+  <data name="Validation.PositiveInteger" xml:space="preserve">
+    <value>Pole {0} musí být větší než nula.</value>
+  </data>
+  <data name="Validation.NonNegativeNumber" xml:space="preserve">
+    <value>Pole {0} musí být nezáporné.</value>
+  </data>
+  <data name="Validation.NewPricePositive" xml:space="preserve">
+    <value>Nová cena musí být větší než nula.</value>
+  </data>
+  <data name="Validation.PasswordComplexity" xml:space="preserve">
+    <value>Heslo musí obsahovat malá a velká písmena a čísla.</value>
+  </data>
+  <data name="Validation.PasswordMismatch" xml:space="preserve">
+    <value>Pole {0} a {1} se musí shodovat.</value>
+  </data>
+  <data name="Models.CompanyProfile.ManagerId.DisplayName" xml:space="preserve">
+    <value>Správce</value>
+  </data>
+  <data name="Models.CompanyProfile.Name.DisplayName" xml:space="preserve">
+    <value>Název</value>
+  </data>
+  <data name="Models.CompanyProfile.ReferenceCode.DisplayName" xml:space="preserve">
+    <value>Referenční kód</value>
+  </data>
+  <data name="Models.CourseBlock.Description.DisplayName" xml:space="preserve">
+    <value>Popis</value>
+  </data>
+  <data name="Models.CourseBlock.Price.DisplayName" xml:space="preserve">
+    <value>Cena</value>
+  </data>
+  <data name="Models.CourseBlock.Title.DisplayName" xml:space="preserve">
+    <value>Název</value>
+  </data>
+  <data name="Models.CourseTerm.CourseId.DisplayName" xml:space="preserve">
+    <value>Kurz</value>
+  </data>
+  <data name="Models.CourseTerm.EndUtc.DisplayName" xml:space="preserve">
+    <value>Konec (UTC)</value>
+  </data>
+  <data name="Models.CourseTerm.InstructorId.DisplayName" xml:space="preserve">
+    <value>Lektor</value>
+  </data>
+  <data name="Models.CourseTerm.IsActive.DisplayName" xml:space="preserve">
+    <value>Aktivní</value>
+  </data>
+  <data name="Models.CourseTerm.SeatsTaken.DisplayName" xml:space="preserve">
+    <value>Obsazená místa</value>
+  </data>
+  <data name="Models.CourseTerm.StartUtc.DisplayName" xml:space="preserve">
+    <value>Začátek (UTC)</value>
+  </data>
+  <data name="Models.Instructor.Bio.DisplayName" xml:space="preserve">
+    <value>Životopis</value>
+  </data>
+  <data name="Models.Instructor.Email.DisplayName" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Models.Instructor.FullName.DisplayName" xml:space="preserve">
+    <value>Celé jméno</value>
+  </data>
+  <data name="Models.Instructor.PhoneNumber.DisplayName" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="Models.OrderStatus.Cancelled.DisplayName" xml:space="preserve">
+    <value>Zrušeno</value>
+  </data>
+  <data name="Models.OrderStatus.Paid.DisplayName" xml:space="preserve">
+    <value>Zaplaceno</value>
+  </data>
+  <data name="Models.OrderStatus.Pending.DisplayName" xml:space="preserve">
+    <value>Čeká na platbu</value>
+  </data>
+  <data name="Models.OrderStatus.Refunded.DisplayName" xml:space="preserve">
+    <value>Vráceno</value>
+  </data>
+  <data name="Models.PriceSchedule.CourseId.DisplayName" xml:space="preserve">
+    <value>Kurz</value>
+  </data>
+  <data name="Models.PriceSchedule.FromUtc.DisplayName" xml:space="preserve">
+    <value>Platí od</value>
+  </data>
+  <data name="Models.PriceSchedule.NewPriceExcl.DisplayName" xml:space="preserve">
+    <value>Nová cena (bez DPH)</value>
+  </data>
+  <data name="Models.PriceSchedule.ToUtc.DisplayName" xml:space="preserve">
+    <value>Platí do</value>
+  </data>
+  <data name="Models.Testimonial.Company.DisplayName" xml:space="preserve">
+    <value>Společnost</value>
+  </data>
+  <data name="Models.Testimonial.ConsentGranted.DisplayName" xml:space="preserve">
+    <value>Souhlas se zpracováním osobních údajů</value>
+  </data>
+  <data name="Models.Testimonial.FullName.DisplayName" xml:space="preserve">
+    <value>Jméno a příjmení</value>
+  </data>
+  <data name="Models.Testimonial.IsPublished.DisplayName" xml:space="preserve">
+    <value>Publikovat</value>
+  </data>
+  <data name="Models.Testimonial.PhotoAltText.DisplayName" xml:space="preserve">
+    <value>Alternativní text fotografie</value>
+  </data>
+  <data name="Models.Testimonial.PhotoUrl.DisplayName" xml:space="preserve">
+    <value>URL fotografie</value>
+  </data>
+  <data name="Models.Testimonial.Position.DisplayName" xml:space="preserve">
+    <value>Pozice</value>
+  </data>
+  <data name="Models.Testimonial.Quote.DisplayName" xml:space="preserve">
+    <value>Citace</value>
+  </data>
+  <data name="Models.Testimonial.Rating.DisplayName" xml:space="preserve">
+    <value>Hodnocení</value>
+  </data>
+  <data name="Models.Voucher.AppliesToCourse.DisplayName" xml:space="preserve">
+    <value>Platí pro kurz</value>
+  </data>
+  <data name="Models.Voucher.Code.DisplayName" xml:space="preserve">
+    <value>Kód</value>
+  </data>
+  <data name="Models.Voucher.ExpiresUtc.DisplayName" xml:space="preserve">
+    <value>Platnost (UTC)</value>
+  </data>
+  <data name="Models.Voucher.MaxRedemptions.DisplayName" xml:space="preserve">
+    <value>Maximální počet uplatnění</value>
+  </data>
+  <data name="Models.Voucher.Type.DisplayName" xml:space="preserve">
+    <value>Typ voucheru</value>
+  </data>
+  <data name="Models.Voucher.UsedCount.DisplayName" xml:space="preserve">
+    <value>Počet uplatnění</value>
+  </data>
+  <data name="Models.Voucher.Value.DisplayName" xml:space="preserve">
+    <value>Hodnota</value>
+  </data>
+  <data name="Models.VoucherType.FixedAmount.DisplayName" xml:space="preserve">
+    <value>Fixní částka</value>
+  </data>
+  <data name="Models.VoucherType.Percentage.DisplayName" xml:space="preserve">
+    <value>Procentuální sleva</value>
+  </data>
+  <data name="Pages.Account.Register.Input.ConfirmPassword.DisplayName" xml:space="preserve">
+    <value>Potvrzení hesla</value>
+  </data>
+  <data name="Pages.Account.Register.Input.ReferralCode.DisplayName" xml:space="preserve">
+    <value>Referenční kód</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.CourseId.DisplayName" xml:space="preserve">
+    <value>Kurz</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.EndUtc.DisplayName" xml:space="preserve">
+    <value>Konec</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.InstructorId.DisplayName" xml:space="preserve">
+    <value>Lektor</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.IsActive.DisplayName" xml:space="preserve">
+    <value>Aktivní</value>
+  </data>
+  <data name="Pages.Admin.CourseTerms.Input.StartUtc.DisplayName" xml:space="preserve">
+    <value>Začátek</value>
+  </data>
+  <data name="Pages.Admin.Users.Edit.Input.Email.DisplayName" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Pages.Admin.Users.Edit.Input.IsLocked.DisplayName" xml:space="preserve">
+    <value>Účet zablokován</value>
+  </data>
+  <data name="Pages.Admin.Users.Edit.Input.PhoneNumber.DisplayName" xml:space="preserve">
+    <value>Telefonní číslo</value>
+  </data>
+  <data name="Pages.Api.Newsletter.Input.Consent.DisplayName" xml:space="preserve">
+    <value>Souhlas</value>
+  </data>
+  <data name="Pages.Api.Newsletter.Input.Email.DisplayName" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- update data annotations across models and page models to use shared resource keys for display names and validation messages
- extend shared resource files with localized display and validation strings for the new keys
- ensure course block metadata is localized and aligned with the shared validation messages

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68deac3aabd48321a8c32ca4e27cf1c5