### PR TITLE
Simplify hero styling and layout

### DIFF
--- a/Views/Shared/_Hero.cshtml
+++ b/Views/Shared/_Hero.cshtml
@@ -101,54 +101,58 @@
     }
 }
 
-<section class="py-5 gradient-hero text-white text-center rounded-4 mb-4 hero-section">
-    <div class="container-xl position-relative">
-        <h1 class="display-5 fw-bold mb-3">@title</h1>
-        <p class="lead mb-4 opacity-75 mx-auto" style="max-width: 56rem;">@subtitle</p>
+<section class="hero-section py-5 mb-4">
+    <div class="container-xl">
+        <div class="hero-wrapper">
+            <h1 class="hero-title display-5 fw-bold">@title</h1>
+            <p class="hero-subtitle lead">@subtitle</p>
 
-        <ul class="list-unstyled d-flex flex-column flex-lg-row justify-content-center align-items-lg-center gap-3 mb-4">
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-patch-check-fill"></i></span>
-                <span class="fw-semibold">@T["Home.Hero.Usp1"]</span>
-            </li>
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-award-fill"></i></span>
-                <span class="fw-semibold">@T["Home.Hero.Usp2"]</span>
-            </li>
-            <li class="d-flex align-items-center gap-2">
-                <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-people-fill"></i></span>
-                <span class="fw-semibold">@T["Home.Hero.Usp3"]</span>
-            </li>
-        </ul>
+            <ul class="hero-highlights list-unstyled d-flex flex-column flex-lg-row justify-content-center align-items-lg-center">
+                <li class="d-flex align-items-center gap-2">
+                    <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-patch-check-fill"></i></span>
+                    <span class="fw-semibold">@T["Home.Hero.Usp1"]</span>
+                </li>
+                <li class="d-flex align-items-center gap-2">
+                    <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-award-fill"></i></span>
+                    <span class="fw-semibold">@T["Home.Hero.Usp2"]</span>
+                </li>
+                <li class="d-flex align-items-center gap-2">
+                    <span class="badge rounded-pill text-bg-light text-primary-emphasis"><i class="bi bi-people-fill"></i></span>
+                    <span class="fw-semibold">@T["Home.Hero.Usp3"]</span>
+                </li>
+            </ul>
 
-        <div class="d-flex flex-column flex-sm-row justify-content-center gap-2 mb-4">
-            <a href="/Courses/Index" class="btn btn-light fw-semibold px-4">@primaryCta</a>
-            <a href="/CorporateInquiry" class="btn btn-outline-light fw-semibold px-4">@secondaryCta</a>
+            <div class="hero-actions d-flex flex-column flex-sm-row justify-content-center">
+                <a href="/Courses/Index" class="btn btn-primary fw-semibold px-4">@primaryCta</a>
+                <a href="/CorporateInquiry" class="btn btn-outline-primary fw-semibold px-4">@secondaryCta</a>
+            </div>
         </div>
 
-        <form method="get" action="/Courses/Index" class="row g-2 justify-content-center" id="heroForm" role="search" aria-label="@T["Home.Hero.Search.AriaLabel"]">
-            <div class="col-12 col-md-3">
-                <label class="form-label visually-hidden" for="heroPersona">@T["Home.Hero.Persona.Label"]</label>
-                <select id="heroPersona" name="persona" class="form-select filter-select" aria-describedby="heroPersonaHelp" persona-options></select>
-                <div id="heroPersonaHelp" class="visually-hidden">@T["Home.Hero.Persona.Help"]</div>
-            </div>
-            <div class="col-12 col-md-3">
-                <label class="form-label visually-hidden" for="heroGoal">@T["Home.Hero.Goal.Label"]</label>
-                <select id="heroGoal" name="goal" class="form-select filter-select" aria-describedby="heroGoalHelp" goal-options></select>
-                <div id="heroGoalHelp" class="visually-hidden">@T["Home.Hero.Goal.Help"]</div>
-            </div>
-            <div class="col-12 col-md-4">
-                <div class="input-group">
-                    <span class="input-group-text" id="heroSearchLabel"><i class="bi bi-search" aria-hidden="true"></i><span class="visually-hidden">@T["Home.Hero.Search.Label"]</span></span>
-                    <input name="q" class="form-control" placeholder="@searchPlaceholder" aria-labelledby="heroSearchLabel" />
+        <div class="hero-search">
+            <form method="get" action="/Courses/Index" class="row g-2 g-md-3 justify-content-center" id="heroForm" role="search" aria-label="@T["Home.Hero.Search.AriaLabel"]">
+                <div class="col-12 col-md-3">
+                    <label class="form-label visually-hidden" for="heroPersona">@T["Home.Hero.Persona.Label"]</label>
+                    <select id="heroPersona" name="persona" class="form-select filter-select" aria-describedby="heroPersonaHelp" persona-options></select>
+                    <div id="heroPersonaHelp" class="visually-hidden">@T["Home.Hero.Persona.Help"]</div>
                 </div>
-            </div>
-            <div class="col-12 col-md-2 d-grid">
-                <button class="btn btn-light fw-semibold" type="submit">@T["Home.Hero.Search.Submit"]</button>
-            </div>
-        </form>
+                <div class="col-12 col-md-3">
+                    <label class="form-label visually-hidden" for="heroGoal">@T["Home.Hero.Goal.Label"]</label>
+                    <select id="heroGoal" name="goal" class="form-select filter-select" aria-describedby="heroGoalHelp" goal-options></select>
+                    <div id="heroGoalHelp" class="visually-hidden">@T["Home.Hero.Goal.Help"]</div>
+                </div>
+                <div class="col-12 col-md-4">
+                    <div class="input-group">
+                        <span class="input-group-text" id="heroSearchLabel"><i class="bi bi-search" aria-hidden="true"></i><span class="visually-hidden">@T["Home.Hero.Search.Label"]</span></span>
+                        <input name="q" class="form-control" placeholder="@searchPlaceholder" aria-labelledby="heroSearchLabel" />
+                    </div>
+                </div>
+                <div class="col-12 col-md-2 d-grid">
+                    <button class="btn btn-primary fw-semibold" type="submit">@T["Home.Hero.Search.Submit"]</button>
+                </div>
+            </form>
+        </div>
 
-        <div class="d-flex flex-wrap gap-2 justify-content-center mt-3">
+        <div class="hero-chips chips justify-content-center">
             @foreach (var chip in chips)
             {
                 <a class="chip chip-light" href="@chip.Url">@chip.Label</a>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1329,99 +1329,48 @@ button:focus-visible {
   overflow: hidden;
 }
 
-.hero,
-.gradient-hero {
-  background: radial-gradient(1200px 400px at 50% -120px, rgba(255, 255, 255, 0.12), transparent),
-              linear-gradient(135deg, #2563eb 0%, #06b6d4 55%, #f59e0b 130%);
-}
-
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.18), transparent 55%),
-              radial-gradient(circle at bottom left, rgba(6, 182, 212, 0.18), transparent 60%);
-  pointer-events: none;
-}
-
-.hero .container-xl {
-  position: relative;
-  z-index: 1;
-}
-
-.hero .lead {
-  max-width: 60ch;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.hero .display-4 {
-  font-family: 'Fraunces', 'Merriweather', serif;
-  font-weight: 600;
-  letter-spacing: -0.015em;
-}
-
 .underline-accent {
   background: linear-gradient(transparent 65%, rgba(245, 158, 11, 0.65) 0);
 }
 
 .hero-section {
-  position: relative;
-  overflow: hidden;
+  background-color: var(--surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-soft);
 }
 
-.hero-section .container-xl {
-  position: relative;
-  z-index: 2;
+.hero-wrapper {
+  max-width: 56rem;
+  margin: 0 auto 2.5rem;
+  text-align: center;
 }
 
-.hero-section::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 1;
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMjAgMTIwJz48ZGVmcz48cmFkaWFsR3JhZGllbnQgaWQ9J2cxJyBjeD0nNTAlJyBjeT0nMzUlJyByPSc2NSUnPjxzdG9wIG9mZnNldD0nMCUnIHN0b3AtY29sb3I9JyNmZmZmZmYnIHN0b3Atb3BhY2l0eT0nMC45NScvPjxzdG9wIG9mZnNldD0nMTAwJScgc3RvcC1jb2xvcj0nI2Q5ZjFmZicgc3RvcC1vcGFjaXR5PScwLjYnLz48L3JhZGlhbEdyYWRpZW50PjwvZGVmcz48Y2lyY2xlIGN4PSc2MCcgY3k9JzYwJyByPSc1MicgZmlsbD0ndXJsKCNnMSknIHN0cm9rZT0nIzBmMTcyYScgc3Ryb2tlLW9wYWNpdHk9JzAuMTInIHN0cm9rZS13aWR0aD0nMycvPjx0ZXh0IHg9JzYwJyB5PSc1MicgdGV4dC1hbmNob3I9J21pZGRsZScgZm9udC1mYW1pbHk9J1NlZ29lIFVJLCBzYW5zLXNlcmlmJyBmb250LXNpemU9JzIyJyBmb250LXdlaWdodD0nNzAwJyBmaWxsPScjMGYxNzJhJyBmaWxsLW9wYWNpdHk9JzAuNyc+SVNPPC90ZXh0Pjx0ZXh0IHg9JzYwJyB5PSc4NCcgdGV4dC1hbmNob3I9J21pZGRsZScgZm9udC1mYW1pbHk9J1NlZ29lIFVJLCBzYW5zLXNlcmlmJyBmb250LXNpemU9JzIwJyBmb250LXdlaWdodD0nNjAwJyBsZXR0ZXItc3BhY2luZz0nMycgZmlsbD0nIzBmMTcyYScgZmlsbC1vcGFjaXR5PScwLjY1Jz45MDAxPC90ZXh0Pjwvc3ZnPg=="),
-    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMjAgMTIwJz48ZGVmcz48cmFkaWFsR3JhZGllbnQgaWQ9J2cyJyBjeD0nNDUlJyBjeT0nMzAlJyByPSc2MCUnPjxzdG9wIG9mZnNldD0nMCUnIHN0b3AtY29sb3I9JyNmZmZmZmYnIHN0b3Atb3BhY2l0eT0nMC45Jy8+PHN0b3Agb2Zmc2V0PScxMDAlJyBzdG9wLWNvbG9yPScjZmZmMWNjJyBzdG9wLW9wYWNpdHk9JzAuNycvPjwvcmFkaWFsR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9JzEyJyB5PScxMicgd2lkdGg9Jzk2JyBoZWlnaHQ9Jzk2JyByeD0nMjgnIGZpbGw9J3VybCgjZzIpJyBzdHJva2U9JyMwZjE3MmEnIHN0cm9rZS1vcGFjaXR5PScwLjEyJyBzdHJva2Utd2lkdGg9JzMnLz48dGV4dCB4PSc2MCcgeT0nNTAnIHRleHQtYW5jaG9yPSdtaWRkbGUnIGZvbnQtZmFtaWx5PSdTZWdvZSBVSSwgc2Fucy1zZXJpZicgZm9udC1zaXplPScyMicgZm9udC13ZWlnaHQ9JzcwMCcgZmlsbD0nIzBmMTcyYScgZmlsbC1vcGFjaXR5PScwLjcyJz5JU088L3RleHQ+PHRleHQgeD0nNjAnIHk9JzgyJyB0ZXh0LWFuY2hvcj0nbWlkZGxlJyBmb250LWZhbWlseT0nU2Vnb2UgVUksIHNhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMjAnIGZvbnQtd2VpZ2h0PSc2MDAnIGxldHRlci1zcGFjaW5nPSczJyBmaWxsPScjMGYxNzJhJyBmaWxsLW9wYWNpdHk9JzAuNic+MTQwMDE8L3RleHQ+PC9zdmc+"),
-    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMjAgMTIwJz48ZGVmcz48cmFkaWFsR3JhZGllbnQgaWQ9J2czJyBjeD0nNTUlJyBjeT0nMzUlJyByPSc2MCUnPjxzdG9wIG9mZnNldD0nMCUnIHN0b3AtY29sb3I9JyNmZmZmZmYnIHN0b3Atb3BhY2l0eT0nMC45MicvPjxzdG9wIG9mZnNldD0nMTAwJScgc3RvcC1jb2xvcj0nI2U1ZjhmZicgc3RvcC1vcGFjaXR5PScwLjU1Jy8+PC9yYWRpYWxHcmFkaWVudD48L2RlZnM+PGNpcmNsZSBjeD0nNjAnIGN5PSc2MCcgcj0nNTAnIGZpbGw9J3VybCgjZzMpJyBzdHJva2U9JyMwZjE3MmEnIHN0cm9rZS1vcGFjaXR5PScwLjEnIHN0cm9rZS13aWR0aD0nMycvPjx0ZXh0IHg9JzYwJyB5PSc1MCcgdGV4dC1hbmNob3I9J21pZGRsZScgZm9udC1mYW1pbHk9J1NlZ29lIFVJLCBzYW5zLXNlcmlmJyBmb250LXNpemU9JzIyJyBmb250LXdlaWdodD0nNzAwJyBmaWxsPScjMGYxNzJhJyBmaWxsLW9wYWNpdHk9JzAuNzInPklTTzwvdGV4dD48dGV4dCB4PSc2MCcgeT0nODInIHRleHQtYW5jaG9yPSdtaWRkbGUnIGZvbnQtZmFtaWx5PSdTZWdvZSBVSSwgc2Fucy1zZXJpZicgZm9udC1zaXplPScyMCcgZm9udC13ZWlnaHQ9JzYwMCcgbGV0dGVyLXNwYWNpbmc9JzMnIGZpbGw9JyMwZjE3MmEnIGZpbGwtb3BhY2l0eT0nMC42Mic+NDUwMDE8L3RleHQ+PC9zdmc+"),
-    url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMjAgMTIwJz48ZGVmcz48cmFkaWFsR3JhZGllbnQgaWQ9J2c0JyBjeD0nNDUlJyBjeT0nMzAlJyByPSc2MCUnPjxzdG9wIG9mZnNldD0nMCUnIHN0b3AtY29sb3I9JyNmZmZmZmYnIHN0b3Atb3BhY2l0eT0nMC45Jy8+PHN0b3Agb2Zmc2V0PScxMDAlJyBzdG9wLWNvbG9yPScjZThmM2ZmJyBzdG9wLW9wYWNpdHk9JzAuNjUnLz48L3JhZGlhbEdyYWRpZW50PjwvZGVmcz48cmVjdCB4PScxNScgeT0nMTUnIHdpZHRoPSc5MCcgaGVpZ2h0PSc5MCcgcng9JzI2JyBmaWxsPSd1cmwoI2c0KScgc3Ryb2tlPScjMGYxNzJhJyBzdHJva2Utb3BhY2l0eT0nMC4xJyBzdHJva2Utd2lkdGg9JzMnLz48dGV4dCB4PSc2MCcgeT0nNDgnIHRleHQtYW5jaG9yPSdtaWRkbGUnIGZvbnQtZmFtaWx5PSdTZWdvZSBVSSwgc2Fucy1zZXJpZicgZm9udC1zaXplPScyMicgZm9udC13ZWlnaHQ9JzcwMCcgZmlsbD0nIzBmMTcyYScgZmlsbC1vcGFjaXR5PScwLjcyJz5JU088L3RleHQ+PHRleHQgeD0nNjAnIHk9JzgwJyB0ZXh0LWFuY2hvcj0nbWlkZGxlJyBmb250LWZhbWlseT0nU2Vnb2UgVUksIHNhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMjAnIGZvbnQtd2VpZ2h0PSc2MDAnIGxldHRlci1zcGFjaW5nPSczJyBmaWxsPScjMGYxNzJhJyBmaWxsLW9wYWNpdHk9JzAuNic+MjcwMDE8L3RleHQ+PC9zdmc+"),
-    radial-gradient(circle at 15% 18%, rgba(255, 255, 255, 0.08), transparent 45%),
-    radial-gradient(circle at 82% 25%, rgba(245, 158, 11, 0.12), transparent 60%),
-    radial-gradient(circle at 22% 82%, rgba(6, 182, 212, 0.14), transparent 55%);
-  background-size: clamp(5rem, 10vw, 6.5rem), clamp(5rem, 11vw, 7rem), clamp(5rem, 11vw, 7rem), clamp(5rem, 11vw, 7rem), 100% 100%, 100% 100%, 100% 100%;
-  background-repeat: no-repeat;
-  background-position:
-    10% 18%,
-    88% 22%,
-    18% 80%,
-    78% 70%,
-    20% 28%,
-    84% 30%,
-    26% 85%;
-  animation: heroIconsFloat 18s ease-in-out infinite;
+.hero-title {
+  margin-bottom: 1rem;
 }
 
-@keyframes heroIconsFloat {
-  0%,
-  100% {
-    background-position:
-      10% 18%,
-      88% 22%,
-      18% 80%,
-      78% 70%,
-      20% 28%,
-      84% 30%,
-      26% 85%;
-  }
-  50% {
-    background-position:
-      10% calc(18% - 14px),
-      88% calc(22% - 18px),
-      18% calc(80% - 12px),
-      78% calc(70% - 16px),
-      20% 28%,
-      84% 30%,
-      26% 85%;
-  }
+.hero-subtitle {
+  margin: 0 auto 1.5rem;
+  max-width: 48rem;
+  color: var(--neutral-500);
+}
+
+.hero-highlights {
+  gap: 1.5rem;
+  margin: 0 auto 2rem;
+}
+
+.hero-actions {
+  gap: 0.75rem;
+}
+
+.hero-search {
+  max-width: 62rem;
+  margin: 0 auto;
+}
+
+.hero-chips {
+  margin-top: 1.5rem;
 }
 
 .typewriter {


### PR DESCRIPTION
## Summary
- Simplified the hero partial with a wrapper, dedicated search area, and centered chips while removing temporary gradients.
- Added focused hero layout styles in `site.css` to unify spacing and present a clean call-to-action stack.

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68deac4543b88321840883f6a34721e3