### PR TITLE
Ensure chatbot widget defaults to enabled

### DIFF
--- a/ViewComponents/ChatbotWidgetViewComponent.cs
+++ b/ViewComponents/ChatbotWidgetViewComponent.cs
@@ -23,14 +23,23 @@ public class ChatbotWidgetViewComponent : ViewComponent
             .OrderBy(s => s.Id)
             .FirstOrDefaultAsync();
 
-        if (settings is null || !settings.IsEnabled)
+        var isEnabled = true;
+        var autoInitialize = true;
+
+        if (settings is not null)
+        {
+            isEnabled = settings.IsEnabled;
+            autoInitialize = settings.AutoInitialize;
+        }
+
+        if (!isEnabled)
         {
             return new HtmlContentViewComponentResult(new Microsoft.AspNetCore.Html.HtmlString(string.Empty));
         }
 
         var model = new ChatbotWidgetViewModel
         {
-            AutoInitialize = settings.AutoInitialize
+            AutoInitialize = autoInitialize
         };
 
         return View("/Pages/Shared/_Chatbot.cshtml", model);


### PR DESCRIPTION
## Summary
- fall back to enabled chatbot settings when no configuration has been saved so the launcher bubble renders
- preserve administrative toggle support while defaulting auto-initialization to on

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68deaf96b52c8321b542577c12c0c2c1