### PR TITLE
Fix duplicate navigation markup in layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -151,25 +151,7 @@
                                 <span class="visually-hidden">@Localizer["Cart"]</span>
                             </a>
                         </li>
-                <div id="primaryNavigation" class="collapse navbar-collapse">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                        <li class="nav-item"><a class="nav-link" asp-page="/Index">@T["Nav.Home"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/About">@T["Nav.About"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Services">@T["Nav.Services"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Courses/Index">@T["Nav.Courses"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Articles/Index">@T["Nav.Articles"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/CorporateInquiry">@T["Nav.CorporateInquiry"]</a></li>
-                        <li class="nav-item"><a class="nav-link" asp-page="/Privacy">@T["Nav.Privacy"]</a></li>
                     </ul>
-                    <div class="d-flex align-items-center gap-3">
-                        <partial name="_LanguageSwitcher" />
-                        @if (!User.Identity.IsAuthenticated)
-                        {
-                            <button type="button" class="btn btn-outline-light ms-2" data-bs-toggle="modal" data-bs-target="#authModal">
-                                @T["LoginRegister"]
-                            </button>
-                        }
-                    </div>
                 </div>
             </div>
         </nav>


### PR DESCRIPTION
## Summary
- remove the redundant duplicate navbar block that repeated navigation links in the layout
- ensure the primary navigation markup closes correctly after the single navbar instance

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68dedfbaafe88321b059105607ee3ec0