### PR TITLE
Localize course form labels and placeholders

### DIFF
--- a/Pages/Courses/Shared/_CourseForm.cshtml
+++ b/Pages/Courses/Shared/_CourseForm.cshtml
@@ -77,73 +77,73 @@
 <div class="row g-3">
     <div class="col-md-4">
         <label asp-for="Course.IsoStandard" class="form-label">@Localizer["IsoStandardLabel"]</label>
-        <input asp-for="Course.IsoStandard" class="form-control" placeholder="ISO 9001" />
+        <input asp-for="Course.IsoStandard" class="form-control" placeholder="@Localizer["IsoStandardPlaceholder"]" />
         <span asp-validation-for="Course.IsoStandard" class="text-danger"></span>
     </div>
     <div class="col-md-4">
         <label asp-for="Course.DurationText" class="form-label">@Localizer["DurationTextLabel"]</label>
-        <input asp-for="Course.DurationText" class="form-control" placeholder="3 dny / 24 hodin" />
+        <input asp-for="Course.DurationText" class="form-control" placeholder="@Localizer["DurationTextPlaceholder"]" />
         <span asp-validation-for="Course.DurationText" class="text-danger"></span>
     </div>
     <div class="col-md-4">
         <label asp-for="Course.DeliveryForm" class="form-label">@Localizer["DeliveryFormLabel"]</label>
-        <input asp-for="Course.DeliveryForm" class="form-control" placeholder="Prezenční" />
+        <input asp-for="Course.DeliveryForm" class="form-control" placeholder="@Localizer["DeliveryFormPlaceholder"]" />
         <span asp-validation-for="Course.DeliveryForm" class="text-danger"></span>
     </div>
 </div>
 <div class="mb-3">
     <label asp-for="Course.TargetAudience" class="form-label">@Localizer["TargetAudienceLabel"]</label>
-    <textarea asp-for="Course.TargetAudience" class="form-control" rows="3" placeholder="manažeři kvality, vedoucí pracovníci"></textarea>
+    <textarea asp-for="Course.TargetAudience" class="form-control" rows="3" placeholder="@Localizer["TargetAudiencePlaceholder"]"></textarea>
     <span asp-validation-for="Course.TargetAudience" class="text-danger"></span>
 </div>
 <div class="row g-3">
     <div class="col-md-4">
         <label asp-for="Course.LearningOutcomes" class="form-label">@Localizer["LearningOutcomesLabel"]</label>
-        <textarea asp-for="Course.LearningOutcomes" class="form-control" rows="4" placeholder="Každý bod na nový řádek"></textarea>
+        <textarea asp-for="Course.LearningOutcomes" class="form-control" rows="4" placeholder="@Localizer["LearningOutcomesPlaceholder"]"></textarea>
         <span asp-validation-for="Course.LearningOutcomes" class="text-danger"></span>
     </div>
     <div class="col-md-4">
         <label asp-for="Course.CaseStudies" class="form-label">@Localizer["CaseStudiesLabel"]</label>
-        <textarea asp-for="Course.CaseStudies" class="form-control" rows="4" placeholder="Popis praktických cvičení"></textarea>
+        <textarea asp-for="Course.CaseStudies" class="form-control" rows="4" placeholder="@Localizer["CaseStudiesPlaceholder"]"></textarea>
         <span asp-validation-for="Course.CaseStudies" class="text-danger"></span>
     </div>
     <div class="col-md-4">
         <label asp-for="Course.Certifications" class="form-label">@Localizer["CertificationsLabel"]</label>
-        <textarea asp-for="Course.Certifications" class="form-control" rows="4" placeholder="Získaná osvědčení"></textarea>
+        <textarea asp-for="Course.Certifications" class="form-control" rows="4" placeholder="@Localizer["CertificationsPlaceholder"]"></textarea>
         <span asp-validation-for="Course.Certifications" class="text-danger"></span>
     </div>
 </div>
 <div class="mb-3">
     <label asp-for="Course.CourseProgram" class="form-label">@Localizer["CourseProgramLabel"]</label>
-    <textarea asp-for="Course.CourseProgram" class="form-control" rows="6" placeholder="1. den (9:00-16:00): ..."></textarea>
+    <textarea asp-for="Course.CourseProgram" class="form-control" rows="6" placeholder="@Localizer["CourseProgramPlaceholder"]"></textarea>
     <span asp-validation-for="Course.CourseProgram" class="text-danger"></span>
 </div>
 <div class="row g-3">
     <div class="col-md-6">
         <label asp-for="Course.InstructorName" class="form-label">@Localizer["InstructorNameLabel"]</label>
-        <input asp-for="Course.InstructorName" class="form-control" placeholder="Jméno lektora" />
+        <input asp-for="Course.InstructorName" class="form-control" placeholder="@Localizer["InstructorNamePlaceholder"]" />
         <span asp-validation-for="Course.InstructorName" class="text-danger"></span>
     </div>
     <div class="col-md-6">
         <label asp-for="Course.InstructorBio" class="form-label">@Localizer["InstructorBioLabel"]</label>
-        <textarea asp-for="Course.InstructorBio" class="form-control" rows="3" placeholder="Kvalifikace a zkušenosti"></textarea>
+        <textarea asp-for="Course.InstructorBio" class="form-control" rows="3" placeholder="@Localizer["InstructorBioPlaceholder"]"></textarea>
         <span asp-validation-for="Course.InstructorBio" class="text-danger"></span>
     </div>
 </div>
 <div class="row g-3">
     <div class="col-md-4">
         <label asp-for="Course.OrganizationalNotes" class="form-label">@Localizer["OrganizationalNotesLabel"]</label>
-        <textarea asp-for="Course.OrganizationalNotes" class="form-control" rows="4" placeholder="Každý pokyn na nový řádek"></textarea>
+        <textarea asp-for="Course.OrganizationalNotes" class="form-control" rows="4" placeholder="@Localizer["OrganizationalNotesPlaceholder"]"></textarea>
         <span asp-validation-for="Course.OrganizationalNotes" class="text-danger"></span>
     </div>
     <div class="col-md-4">
         <label asp-for="Course.FollowUpCourses" class="form-label">@Localizer["FollowUpCoursesLabel"]</label>
-        <textarea asp-for="Course.FollowUpCourses" class="form-control" rows="4" placeholder="Doporučené kurzy"></textarea>
+        <textarea asp-for="Course.FollowUpCourses" class="form-control" rows="4" placeholder="@Localizer["FollowUpCoursesPlaceholder"]"></textarea>
         <span asp-validation-for="Course.FollowUpCourses" class="text-danger"></span>
     </div>
     <div class="col-md-4">
         <label asp-for="Course.CertificateInfo" class="form-label">@Localizer["CertificateInfoLabel"]</label>
-        <textarea asp-for="Course.CertificateInfo" class="form-control" rows="4" placeholder="Informace o certifikátu"></textarea>
+        <textarea asp-for="Course.CertificateInfo" class="form-control" rows="4" placeholder="@Localizer["CertificateInfoPlaceholder"]"></textarea>
         <span asp-validation-for="Course.CertificateInfo" class="text-danger"></span>
     </div>
 </div>

--- a/Resources/Pages.Courses.Shared._CourseForm.cshtml.en.resx
+++ b/Resources/Pages.Courses.Shared._CourseForm.cshtml.en.resx
@@ -81,4 +81,82 @@
   <data name="CoverImageLabel" xml:space="preserve">
     <value>Cover image</value>
   </data>
+  <data name="IsoStandardLabel" xml:space="preserve">
+    <value>ISO standard</value>
+  </data>
+  <data name="IsoStandardPlaceholder" xml:space="preserve">
+    <value>ISO 9001</value>
+  </data>
+  <data name="DurationTextLabel" xml:space="preserve">
+    <value>Duration (text)</value>
+  </data>
+  <data name="DurationTextPlaceholder" xml:space="preserve">
+    <value>3 days / 24 hours</value>
+  </data>
+  <data name="DeliveryFormLabel" xml:space="preserve">
+    <value>Delivery format</value>
+  </data>
+  <data name="DeliveryFormPlaceholder" xml:space="preserve">
+    <value>In person</value>
+  </data>
+  <data name="TargetAudienceLabel" xml:space="preserve">
+    <value>Target audience</value>
+  </data>
+  <data name="TargetAudiencePlaceholder" xml:space="preserve">
+    <value>quality managers, team leads</value>
+  </data>
+  <data name="LearningOutcomesLabel" xml:space="preserve">
+    <value>Learning outcomes</value>
+  </data>
+  <data name="LearningOutcomesPlaceholder" xml:space="preserve">
+    <value>Enter each item on a new line</value>
+  </data>
+  <data name="CaseStudiesLabel" xml:space="preserve">
+    <value>Case studies</value>
+  </data>
+  <data name="CaseStudiesPlaceholder" xml:space="preserve">
+    <value>Describe practical exercises</value>
+  </data>
+  <data name="CertificationsLabel" xml:space="preserve">
+    <value>Certifications</value>
+  </data>
+  <data name="CertificationsPlaceholder" xml:space="preserve">
+    <value>Certificates obtained</value>
+  </data>
+  <data name="CourseProgramLabel" xml:space="preserve">
+    <value>Course agenda</value>
+  </data>
+  <data name="CourseProgramPlaceholder" xml:space="preserve">
+    <value>Day 1 (9:00-16:00): ...</value>
+  </data>
+  <data name="InstructorNameLabel" xml:space="preserve">
+    <value>Instructor name</value>
+  </data>
+  <data name="InstructorNamePlaceholder" xml:space="preserve">
+    <value>Instructor name</value>
+  </data>
+  <data name="InstructorBioLabel" xml:space="preserve">
+    <value>Instructor bio</value>
+  </data>
+  <data name="InstructorBioPlaceholder" xml:space="preserve">
+    <value>Qualifications and experience</value>
+  </data>
+  <data name="OrganizationalNotesLabel" xml:space="preserve">
+    <value>Organizational notes</value>
+  </data>
+  <data name="OrganizationalNotesPlaceholder" xml:space="preserve">
+    <value>One instruction per line</value>
+  </data>
+  <data name="FollowUpCoursesLabel" xml:space="preserve">
+    <value>Follow-up courses</value>
+  </data>
+  <data name="FollowUpCoursesPlaceholder" xml:space="preserve">
+    <value>Recommended courses</value>
+  </data>
+  <data name="CertificateInfoLabel" xml:space="preserve">
+    <value>Certificate information</value>
+  </data>
+  <data name="CertificateInfoPlaceholder" xml:space="preserve">
+    <value>Details about the certificate</value>
+  </data>
 </root>

--- a/Resources/Pages.Courses.Shared._CourseForm.cshtml.resx
+++ b/Resources/Pages.Courses.Shared._CourseForm.cshtml.resx
@@ -81,4 +81,82 @@
   <data name="CoverImageLabel" xml:space="preserve">
     <value>Úvodní obrázek</value>
   </data>
+  <data name="IsoStandardLabel" xml:space="preserve">
+    <value>Norma ISO</value>
+  </data>
+  <data name="IsoStandardPlaceholder" xml:space="preserve">
+    <value>ISO 9001</value>
+  </data>
+  <data name="DurationTextLabel" xml:space="preserve">
+    <value>Délka (text)</value>
+  </data>
+  <data name="DurationTextPlaceholder" xml:space="preserve">
+    <value>3 dny / 24 hodin</value>
+  </data>
+  <data name="DeliveryFormLabel" xml:space="preserve">
+    <value>Forma výuky</value>
+  </data>
+  <data name="DeliveryFormPlaceholder" xml:space="preserve">
+    <value>Prezenční</value>
+  </data>
+  <data name="TargetAudienceLabel" xml:space="preserve">
+    <value>Cílová skupina</value>
+  </data>
+  <data name="TargetAudiencePlaceholder" xml:space="preserve">
+    <value>manažeři kvality, vedoucí pracovníci</value>
+  </data>
+  <data name="LearningOutcomesLabel" xml:space="preserve">
+    <value>Cíle učení</value>
+  </data>
+  <data name="LearningOutcomesPlaceholder" xml:space="preserve">
+    <value>Každý bod na nový řádek</value>
+  </data>
+  <data name="CaseStudiesLabel" xml:space="preserve">
+    <value>Praktické příklady</value>
+  </data>
+  <data name="CaseStudiesPlaceholder" xml:space="preserve">
+    <value>Popis praktických cvičení</value>
+  </data>
+  <data name="CertificationsLabel" xml:space="preserve">
+    <value>Certifikace</value>
+  </data>
+  <data name="CertificationsPlaceholder" xml:space="preserve">
+    <value>Získaná osvědčení</value>
+  </data>
+  <data name="CourseProgramLabel" xml:space="preserve">
+    <value>Program kurzu</value>
+  </data>
+  <data name="CourseProgramPlaceholder" xml:space="preserve">
+    <value>1. den (9:00-16:00): ...</value>
+  </data>
+  <data name="InstructorNameLabel" xml:space="preserve">
+    <value>Jméno lektora</value>
+  </data>
+  <data name="InstructorNamePlaceholder" xml:space="preserve">
+    <value>Jméno lektora</value>
+  </data>
+  <data name="InstructorBioLabel" xml:space="preserve">
+    <value>Profil lektora</value>
+  </data>
+  <data name="InstructorBioPlaceholder" xml:space="preserve">
+    <value>Kvalifikace a zkušenosti</value>
+  </data>
+  <data name="OrganizationalNotesLabel" xml:space="preserve">
+    <value>Organizační informace</value>
+  </data>
+  <data name="OrganizationalNotesPlaceholder" xml:space="preserve">
+    <value>Každý pokyn na nový řádek</value>
+  </data>
+  <data name="FollowUpCoursesLabel" xml:space="preserve">
+    <value>Navazující kurzy</value>
+  </data>
+  <data name="FollowUpCoursesPlaceholder" xml:space="preserve">
+    <value>Doporučené kurzy</value>
+  </data>
+  <data name="CertificateInfoLabel" xml:space="preserve">
+    <value>Informace o certifikátu</value>
+  </data>
+  <data name="CertificateInfoPlaceholder" xml:space="preserve">
+    <value>Informace o certifikátu</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- use localized strings for course form placeholders instead of hard-coded Czech text
- add missing resource entries for course metadata labels in both Czech and English

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68dedfea5c088321910df02b12857d0a