### PR TITLE
Add localized resources for corporate inquiry wizard partials

### DIFF
--- a/Resources/Pages.CorporateInquiry.Partials._StepCompany.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepCompany.cshtml.en.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step3Title" xml:space="preserve">
+    <value>Step 3 – Company information</value>
+  </data>
+  <data name="Step3Description" xml:space="preserve">
+    <value>Tell us about your company and the primary contact.</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepCompany.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepCompany.cshtml.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step3Title" xml:space="preserve">
+    <value>Krok 3 – Informace o společnosti</value>
+  </data>
+  <data name="Step3Description" xml:space="preserve">
+    <value>Vyplňte údaje o firmě a kontaktní osobě.</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepDetails.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepDetails.cshtml.en.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step2Title" xml:space="preserve">
+    <value>Step 2 – Training details</value>
+  </data>
+  <data name="Step2Description" xml:space="preserve">
+    <value>Provide the desired scope, delivery mode, and timing.</value>
+  </data>
+  <data name="ParticipantCountHint" xml:space="preserve">
+    <value>Use the slider (value 50 stands for 50+ participants).</value>
+  </data>
+  <data name="TrainingLevel_Basic" xml:space="preserve">
+    <value>Basic</value>
+  </data>
+  <data name="TrainingLevel_Advanced" xml:space="preserve">
+    <value>Advanced</value>
+  </data>
+  <data name="TrainingLevel_Certification" xml:space="preserve">
+    <value>Certification</value>
+  </data>
+  <data name="ModeOption_InPerson" xml:space="preserve">
+    <value>In person</value>
+  </data>
+  <data name="ModeOption_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="ModeOption_Hybrid" xml:space="preserve">
+    <value>Hybrid</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepDetails.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepDetails.cshtml.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step2Title" xml:space="preserve">
+    <value>Krok 2 – Detaily školení</value>
+  </data>
+  <data name="Step2Description" xml:space="preserve">
+    <value>Upřesněte rozsah školení, režim a preferovaný termín.</value>
+  </data>
+  <data name="ParticipantCountHint" xml:space="preserve">
+    <value>Posuňte posuvník (hodnota 50 znamená 50 a více účastníků).</value>
+  </data>
+  <data name="TrainingLevel_Basic" xml:space="preserve">
+    <value>Základní</value>
+  </data>
+  <data name="TrainingLevel_Advanced" xml:space="preserve">
+    <value>Pokročilé</value>
+  </data>
+  <data name="TrainingLevel_Certification" xml:space="preserve">
+    <value>Certifikační</value>
+  </data>
+  <data name="ModeOption_InPerson" xml:space="preserve">
+    <value>Prezenčně</value>
+  </data>
+  <data name="ModeOption_Online" xml:space="preserve">
+    <value>Online</value>
+  </data>
+  <data name="ModeOption_Hybrid" xml:space="preserve">
+    <value>Hybridně</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepServiceType.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepServiceType.cshtml.en.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step0Title" xml:space="preserve">
+    <value>Step 0 – Select service type</value>
+  </data>
+  <data name="Step0Description" xml:space="preserve">
+    <value>Choose the type of engagement you are interested in.</value>
+  </data>
+  <data name="ServiceType_CustomTraining" xml:space="preserve">
+    <value>Bespoke corporate training</value>
+  </data>
+  <data name="ServiceType_CertificationProject" xml:space="preserve">
+    <value>Certification readiness project</value>
+  </data>
+  <data name="ServiceType_PreAudit" xml:space="preserve">
+    <value>Pre-certification audit</value>
+  </data>
+  <data name="ServiceType_InternalAudit" xml:space="preserve">
+    <value>Internal audit</value>
+  </data>
+  <data name="ServiceType_Consulting" xml:space="preserve">
+    <value>Consulting &amp; advisory</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepServiceType.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepServiceType.cshtml.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step0Title" xml:space="preserve">
+    <value>Krok 0 – Výběr typu služby</value>
+  </data>
+  <data name="Step0Description" xml:space="preserve">
+    <value>Zvolte, s jakou službou vám můžeme pomoci.</value>
+  </data>
+  <data name="ServiceType_CustomTraining" xml:space="preserve">
+    <value>Firemní školení na míru</value>
+  </data>
+  <data name="ServiceType_CertificationProject" xml:space="preserve">
+    <value>Příprava k certifikaci (kompletní projekt)</value>
+  </data>
+  <data name="ServiceType_PreAudit" xml:space="preserve">
+    <value>Pre-audit před certifikací</value>
+  </data>
+  <data name="ServiceType_InternalAudit" xml:space="preserve">
+    <value>Interní audit</value>
+  </data>
+  <data name="ServiceType_Consulting" xml:space="preserve">
+    <value>Poradenství a konzultace</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepSummary.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepSummary.cshtml.en.resx
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step4Title" xml:space="preserve">
+    <value>Step 4 – Summary</value>
+  </data>
+  <data name="Step4Description" xml:space="preserve">
+    <value>Review the provided information and submit your inquiry.</value>
+  </data>
+  <data name="SummaryTitle" xml:space="preserve">
+    <value>Inquiry summary</value>
+  </data>
+  <data name="SummaryServiceType" xml:space="preserve">
+    <value>Service type</value>
+  </data>
+  <data name="SummaryTrainingTypes" xml:space="preserve">
+    <value>ISO standards</value>
+  </data>
+  <data name="SummaryParticipantCount" xml:space="preserve">
+    <value>Participants</value>
+  </data>
+  <data name="SummaryPreferredDate" xml:space="preserve">
+    <value>Preferred date</value>
+  </data>
+  <data name="SummaryMode" xml:space="preserve">
+    <value>Mode</value>
+  </data>
+  <data name="SummaryTrainingLevel" xml:space="preserve">
+    <value>Training level</value>
+  </data>
+  <data name="SummaryLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="SummarySpecialRequirements" xml:space="preserve">
+    <value>Special requirements</value>
+  </data>
+  <data name="SummaryCompanyId" xml:space="preserve">
+    <value>Company ID</value>
+  </data>
+  <data name="SummaryCompanyName" xml:space="preserve">
+    <value>Company name</value>
+  </data>
+  <data name="SummaryContactPerson" xml:space="preserve">
+    <value>Contact person</value>
+  </data>
+  <data name="SummaryContactEmail" xml:space="preserve">
+    <value>Contact e-mail</value>
+  </data>
+  <data name="SummaryContactPhone" xml:space="preserve">
+    <value>Contact phone</value>
+  </data>
+  <data name="SummaryPrice" xml:space="preserve">
+    <value>Estimated price</value>
+  </data>
+  <data name="SummaryPlaceholder" xml:space="preserve">
+    <value>Not provided</value>
+  </data>
+  <data name="PriceUnavailable" xml:space="preserve">
+    <value>Enter details</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepSummary.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepSummary.cshtml.resx
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step4Title" xml:space="preserve">
+    <value>Krok 4 – Shrnutí</value>
+  </data>
+  <data name="Step4Description" xml:space="preserve">
+    <value>Zkontrolujte zadané údaje a odešlete poptávku.</value>
+  </data>
+  <data name="SummaryTitle" xml:space="preserve">
+    <value>Rekapitulace poptávky</value>
+  </data>
+  <data name="SummaryServiceType" xml:space="preserve">
+    <value>Typ služby</value>
+  </data>
+  <data name="SummaryTrainingTypes" xml:space="preserve">
+    <value>ISO normy</value>
+  </data>
+  <data name="SummaryParticipantCount" xml:space="preserve">
+    <value>Počet účastníků</value>
+  </data>
+  <data name="SummaryPreferredDate" xml:space="preserve">
+    <value>Preferovaný termín</value>
+  </data>
+  <data name="SummaryMode" xml:space="preserve">
+    <value>Režim</value>
+  </data>
+  <data name="SummaryTrainingLevel" xml:space="preserve">
+    <value>Úroveň školení</value>
+  </data>
+  <data name="SummaryLocation" xml:space="preserve">
+    <value>Lokalita</value>
+  </data>
+  <data name="SummarySpecialRequirements" xml:space="preserve">
+    <value>Speciální požadavky</value>
+  </data>
+  <data name="SummaryCompanyId" xml:space="preserve">
+    <value>IČO</value>
+  </data>
+  <data name="SummaryCompanyName" xml:space="preserve">
+    <value>Název společnosti</value>
+  </data>
+  <data name="SummaryContactPerson" xml:space="preserve">
+    <value>Kontaktní osoba</value>
+  </data>
+  <data name="SummaryContactEmail" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="SummaryContactPhone" xml:space="preserve">
+    <value>Telefon</value>
+  </data>
+  <data name="SummaryPrice" xml:space="preserve">
+    <value>Odhadovaná cena</value>
+  </data>
+  <data name="SummaryPlaceholder" xml:space="preserve">
+    <value>Nezadáno</value>
+  </data>
+  <data name="PriceUnavailable" xml:space="preserve">
+    <value>Doplnit údaje</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.en.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step1Title" xml:space="preserve">
+    <value>Step 1 – Select standards</value>
+  </data>
+  <data name="Step1Description" xml:space="preserve">
+    <value>Select every standard you would like the training to cover.</value>
+  </data>
+  <data name="TrainingTypesLabel" xml:space="preserve">
+    <value>Select the desired ISO standards</value>
+  </data>
+  <data name="ISO9001" xml:space="preserve">
+    <value>ISO 9001 - Quality management</value>
+  </data>
+  <data name="ISO14001" xml:space="preserve">
+    <value>ISO 14001 - Environmental management</value>
+  </data>
+  <data name="ISO17025" xml:space="preserve">
+    <value>ISO/IEC 17025 - Laboratory accreditation</value>
+  </data>
+  <data name="ISO15189" xml:space="preserve">
+    <value>ISO 15189 - Medical laboratories</value>
+  </data>
+  <data name="HACCP" xml:space="preserve">
+    <value>HACCP - Food safety</value>
+  </data>
+  <data name="ISO45001" xml:space="preserve">
+    <value>ISO 45001 - Occupational health &amp; safety</value>
+  </data>
+  <data name="ISO27001" xml:space="preserve">
+    <value>ISO 27001 - Information security</value>
+  </data>
+  <data name="IATF16949" xml:space="preserve">
+    <value>IATF 16949 - Automotive</value>
+  </data>
+  <data name="ISO13485" xml:space="preserve">
+    <value>ISO 13485 - Medical devices</value>
+  </data>
+</root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.resx
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Step1Title" xml:space="preserve">
+    <value>Krok 1 – Výběr norem</value>
+  </data>
+  <data name="Step1Description" xml:space="preserve">
+    <value>Vyberte všechny normy, které chcete zahrnout do školení.</value>
+  </data>
+  <data name="TrainingTypesLabel" xml:space="preserve">
+    <value>Vyberte požadované ISO normy</value>
+  </data>
+  <data name="ISO9001" xml:space="preserve">
+    <value>ISO 9001 - Systém managementu kvality</value>
+  </data>
+  <data name="ISO14001" xml:space="preserve">
+    <value>ISO 14001 - Environmentální management</value>
+  </data>
+  <data name="ISO17025" xml:space="preserve">
+    <value>ISO/IEC 17025 - Akreditace laboratoří</value>
+  </data>
+  <data name="ISO15189" xml:space="preserve">
+    <value>ISO 15189 - Zdravotnické laboratoře</value>
+  </data>
+  <data name="HACCP" xml:space="preserve">
+    <value>HACCP - Bezpečnost potravin</value>
+  </data>
+  <data name="ISO45001" xml:space="preserve">
+    <value>ISO 45001 - BOZP</value>
+  </data>
+  <data name="ISO27001" xml:space="preserve">
+    <value>ISO 27001 - Informační bezpečnost</value>
+  </data>
+  <data name="IATF16949" xml:space="preserve">
+    <value>IATF 16949 - Automotive</value>
+  </data>
+  <data name="ISO13485" xml:space="preserve">
+    <value>ISO 13485 - Zdravotnické prostředky</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add localized resource files for each Corporate Inquiry partial view so they resolve localized strings per step
- populate the Czech and English resources with the headers, descriptions, and option labels previously stored on the main Corporate Inquiry page

## Testing
- dotnet run --no-launch-profile *(fails: missing Microsoft.NETCore.App 8.0.0 runtime in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e36e82aecc832191260b35a53cc731