### PR TITLE
Localize course preview modal strings

### DIFF
--- a/Pages/Shared/_CoursePreviewModal.cshtml
+++ b/Pages/Shared/_CoursePreviewModal.cshtml
@@ -3,44 +3,44 @@
     <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="coursePreviewModalLabel" data-course-modal="title">Název kurzu</h5>
+                <h5 class="modal-title" id="coursePreviewModalLabel" data-course-modal="title">@Localizer["CourseTitle"]</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="@Localizer["Close"]"></button>
             </div>
             <div class="modal-body">
                 <p class="text-muted mb-3" data-course-modal="subtitle"></p>
                 <dl class="row g-3">
                     <div class="col-sm-6">
-                        <dt>Začátek</dt>
+                        <dt>@Localizer["StartLabel"]</dt>
                         <dd data-course-modal="start"></dd>
                     </div>
                     <div class="col-sm-6">
-                        <dt>Konec</dt>
+                        <dt>@Localizer["EndLabel"]</dt>
                         <dd data-course-modal="end"></dd>
                     </div>
                     <div class="col-sm-6">
-                        <dt>Město</dt>
+                        <dt>@Localizer["CityLabel"]</dt>
                         <dd data-course-modal="city"></dd>
                     </div>
                     <div class="col-sm-6">
-                        <dt>Režim</dt>
+                        <dt>@Localizer["ModeLabel"]</dt>
                         <dd data-course-modal="mode"></dd>
                     </div>
                     <div class="col-12">
-                        <dt>Popis</dt>
+                        <dt>@Localizer["DescriptionLabel"]</dt>
                         <dd data-course-modal="description" class="mb-0"></dd>
                     </div>
                     <div class="col-12">
-                        <dt>Dostupnost</dt>
+                        <dt>@Localizer["AvailabilityLabel"]</dt>
                         <dd data-course-modal="availability"></dd>
                     </div>
                 </dl>
                 <div class="d-flex flex-wrap gap-2" data-course-modal="badges"></div>
             </div>
             <div class="modal-footer flex-wrap gap-2">
-                <a class="btn btn-outline-secondary me-auto" data-course-modal="details-link" href="#" target="_blank" rel="noopener">Detail kurzu</a>
+                <a class="btn btn-outline-secondary me-auto" data-course-modal="details-link" href="#" target="_blank" rel="noopener">@Localizer["CourseDetails"]</a>
                 <div class="btn-group" role="group">
-                    <button type="button" class="btn btn-primary" data-course-modal="google">Přidat do Google kalendáře</button>
-                    <button type="button" class="btn btn-outline-primary" data-course-modal="ics">Exportovat ICS</button>
+                    <button type="button" class="btn btn-primary" data-course-modal="google">@Localizer["AddToGoogleCalendar"]</button>
+                    <button type="button" class="btn btn-outline-primary" data-course-modal="ics">@Localizer["ExportIcs"]</button>
                 </div>
             </div>
         </div>

--- a/Resources/Pages.Shared._CoursePreviewModal.cshtml.en.resx
+++ b/Resources/Pages.Shared._CoursePreviewModal.cshtml.en.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="CourseTitle" xml:space="preserve">
+    <value>Course title</value>
+  </data>
+  <data name="StartLabel" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="EndLabel" xml:space="preserve">
+    <value>End</value>
+  </data>
+  <data name="CityLabel" xml:space="preserve">
+    <value>City</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Mode</value>
+  </data>
+  <data name="DescriptionLabel" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="AvailabilityLabel" xml:space="preserve">
+    <value>Availability</value>
+  </data>
+  <data name="CourseDetails" xml:space="preserve">
+    <value>Course details</value>
+  </data>
+  <data name="AddToGoogleCalendar" xml:space="preserve">
+    <value>Add to Google Calendar</value>
+  </data>
+  <data name="ExportIcs" xml:space="preserve">
+    <value>Export ICS</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._CoursePreviewModal.cshtml.resx
+++ b/Resources/Pages.Shared._CoursePreviewModal.cshtml.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>Zavřít</value>
+  </data>
+  <data name="CourseTitle" xml:space="preserve">
+    <value>Název kurzu</value>
+  </data>
+  <data name="StartLabel" xml:space="preserve">
+    <value>Začátek</value>
+  </data>
+  <data name="EndLabel" xml:space="preserve">
+    <value>Konec</value>
+  </data>
+  <data name="CityLabel" xml:space="preserve">
+    <value>Město</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Režim</value>
+  </data>
+  <data name="DescriptionLabel" xml:space="preserve">
+    <value>Popis</value>
+  </data>
+  <data name="AvailabilityLabel" xml:space="preserve">
+    <value>Dostupnost</value>
+  </data>
+  <data name="CourseDetails" xml:space="preserve">
+    <value>Detail kurzu</value>
+  </data>
+  <data name="AddToGoogleCalendar" xml:space="preserve">
+    <value>Přidat do Google kalendáře</value>
+  </data>
+  <data name="ExportIcs" xml:space="preserve">
+    <value>Exportovat ICS</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add localized resource files for the course preview modal in Czech and English
- update the modal partial to use the localized strings for all labels and buttons

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e36e878984832193dc3537a88c4c19