### PR TITLE
Fix success URL query string handling for Stripe checkout

### DIFF
--- a/Services/PaymentService.cs
+++ b/Services/PaymentService.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -41,10 +42,11 @@ public class PaymentService
             return null;
 
         var service = new SessionService();
+        var successUrlWithSessionId = QueryHelpers.AddQueryString(successUrl, "session_id", "{CHECKOUT_SESSION_ID}");
         var sessionOptions = new SessionCreateOptions
         {
             Mode = "payment",
-            SuccessUrl = successUrl + "?session_id={CHECKOUT_SESSION_ID}",
+            SuccessUrl = successUrlWithSessionId,
             CancelUrl = cancelUrl,
             LineItems = new List<SessionLineItemOptions>
             {


### PR DESCRIPTION
## Summary
- append the Stripe session identifier to the success URL using QueryHelpers to respect existing query strings
- keep the rest of the session creation options unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e372286e8c83218a9bdc143adcac26