### PR TITLE
Refine build-time static asset bundling

### DIFF
--- a/Docs/static-asset-bundling.md
+++ b/Docs/static-asset-bundling.md
@@ -14,12 +14,12 @@ The application now ships production CSS/JS bundles from `wwwroot/dist`. Bundles
 
    This produces `wwwroot/dist/styles.min.css` and `wwwroot/dist/scripts.min.js` from Bootstrap, jQuery and the local `site.css`/`site.js` sources via [esbuild](https://esbuild.github.io/).
 
-3. Run `dotnet build`/`dotnet run` as usual. MSBuild automatically executes the `BuildStaticAssets` target unless you disable it with `-p:NpmSkipStaticAssets=true` (useful for CI agents without Node).
+3. Run `dotnet build`/`dotnet run` as usual. MSBuild automatically executes the `BundleStaticAssets` target (hooked before the static-web-asset manifest is generated and during publish) unless you disable it with `-p:NpmSkipStaticAssets=true` – handy for CI agents that already provide pre-built bundles.
 
 ## CI / publish pipelines
 
-* Ensure Node.js is installed before invoking `dotnet publish`.
-* No extra steps are needed – the MSBuild target restores npm packages (`npm install --no-audit --no-fund --silent`) and executes `npm run build:assets --silent` before the managed build.
+* Ensure Node.js is installed before invoking `dotnet publish` (the build restores npm dependencies on demand via the `EnsureNodeModules` target, caching installs with `node_modules/.install-stamp`).
+* No extra steps are needed – the MSBuild target executes `npm run build:assets --silent` automatically before static web asset discovery/publish.
 * The generated files live under `wwwroot/dist` and are deployed like any other static asset. Nothing tries to mutate the web root at runtime.
 
 ## Read-only hosting environments

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -36,9 +36,39 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="BuildStaticAssets" BeforeTargets="Build" Condition="'$(NpmSkipStaticAssets)' != 'true'">
-    <Message Importance="high" Text="Bundling static web assets with npm" />
+  <ItemGroup>
+    <StaticAssetBundleSource Include="wwwroot/css/site.css" />
+    <StaticAssetBundleSource Include="wwwroot/js/site.js" />
+    <StaticAssetBundleSource Include="wwwroot/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <StaticAssetBundleSource Include="wwwroot/lib/bootstrap/dist/js/bootstrap.bundle.min.js" />
+    <StaticAssetBundleSource Include="wwwroot/lib/jquery/dist/jquery.min.js" />
+    <StaticAssetBundleSource Include="build-assets.mjs" />
+    <StaticAssetBundleSource Include="package.json" />
+    <StaticAssetBundleSource Include="package-lock.json" />
+
+    <StaticAssetBundleOutput Include="wwwroot/dist/styles.min.css" />
+    <StaticAssetBundleOutput Include="wwwroot/dist/scripts.min.js" />
+
+    <NpmInstallInput Include="package.json" />
+    <NpmInstallInput Include="package-lock.json" />
+  </ItemGroup>
+
+  <Target Name="EnsureNodeModules"
+          Inputs="@(NpmInstallInput)"
+          Outputs="node_modules/.install-stamp"
+          Condition="'$(NpmSkipStaticAssets)' != 'true'">
+    <Message Importance="high" Text="Restoring npm packages for static asset bundling" />
     <Exec Command="npm install --no-audit --no-fund --silent" WorkingDirectory="$(ProjectDir)" />
+    <Touch Files="node_modules/.install-stamp" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="BundleStaticAssets"
+          DependsOnTargets="EnsureNodeModules"
+          Inputs="@(StaticAssetBundleSource)"
+          Outputs="@(StaticAssetBundleOutput)"
+          BeforeTargets="ResolveCurrentProjectStaticWebAssets;PrepareForPublish"
+          Condition="'$(NpmSkipStaticAssets)' != 'true'">
+    <Message Importance="high" Text="Bundling static web assets" />
     <Exec Command="npm run build:assets --silent" WorkingDirectory="$(ProjectDir)" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- replace the runtime bundling hook with MSBuild targets that restore npm packages, build the dist CSS/JS outputs, and execute before static web asset discovery/publish
- document the new bundle targets, incremental npm install stamp, and CI requirements for shipping the generated wwwroot/dist assets

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e3e33f6b108321a6ca949f0d1f9a2b