### PR TITLE
Ensure static bundle target runs before publish asset discovery

### DIFF
--- a/Docs/static-asset-bundling.md
+++ b/Docs/static-asset-bundling.md
@@ -19,7 +19,7 @@ The application now ships production CSS/JS bundles from `wwwroot/dist`. Bundles
 ## CI / publish pipelines
 
 * Ensure Node.js is installed before invoking `dotnet publish` (the build restores npm dependencies on demand via the `EnsureNodeModules` target, caching installs with `node_modules/.install-stamp`).
-* No extra steps are needed – the MSBuild target executes `npm run build:assets --silent` automatically before static web asset discovery/publish.
+* No extra steps are needed – the MSBuild target executes `npm run build:assets --silent` automatically before static web asset discovery (`ResolveCurrentProjectStaticWebAssets`) and again before files-to-publish are computed (`ComputeFilesToPublish`).
 * The generated files live under `wwwroot/dist` and are deployed like any other static asset. Nothing tries to mutate the web root at runtime.
 
 ## Read-only hosting environments

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -66,7 +66,7 @@
           DependsOnTargets="EnsureNodeModules"
           Inputs="@(StaticAssetBundleSource)"
           Outputs="@(StaticAssetBundleOutput)"
-          BeforeTargets="ResolveCurrentProjectStaticWebAssets;PrepareForPublish"
+          BeforeTargets="ResolveCurrentProjectStaticWebAssets;ComputeFilesToPublish"
           Condition="'$(NpmSkipStaticAssets)' != 'true'">
     <Message Importance="high" Text="Bundling static web assets" />
     <Exec Command="npm run build:assets --silent" WorkingDirectory="$(ProjectDir)" />


### PR DESCRIPTION
## Summary
- ensure the MSBuild bundling target executes before static web asset discovery and publish packaging
- document the additional ComputeFilesToPublish hook for CI guidance

## Testing
- npm run build:assets

------
https://chatgpt.com/codex/tasks/task_e_68e4b0b827c48321903314ad9e4e46b0