### PR TITLE
Refine analytics aggregation and integration tests

### DIFF
--- a/Services/CourseReminderService.cs
+++ b/Services/CourseReminderService.cs
@@ -32,7 +32,8 @@ public class CourseReminderService : ScopedRecurringBackgroundService<CourseRemi
         var todayDateTime = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
         var courses = await context.Courses
             .Where(c => c.ReminderDays > 0)
-            .Where(c => EF.Functions.DateDiffDay(todayDateTime, c.Date) == c.ReminderDays)
+            .Where(c => c.Date >= todayDateTime.AddDays(c.ReminderDays)
+                && c.Date < todayDateTime.AddDays(c.ReminderDays + 1))
             .ToListAsync(stoppingToken);
 
         foreach (var course in courses)

--- a/SysJaky_N.Tests/SysJaky_N.Tests.csproj
+++ b/SysJaky_N.Tests/SysJaky_N.Tests.csproj
@@ -2,13 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>SysJaky_N.TestsHarness</AssemblyName>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update the analytics dashboard to derive orders, top courses, and trend data from SQL aggregations while keeping the SalesStats fallback for long ranges
- switch the course reminder query away from provider-specific DateDiff usage
- expand the test harness to run the new analytics integration on SQLite and update the test project configuration

## Testing
- dotnet run --project SysJaky_N.Tests/SysJaky_N.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e4a59b5050832186c5d8cdf207e303