### PR TITLE
Set ApplicationDbContext options lifetime to singleton

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -93,7 +93,8 @@ try
 
     // --- Hlavní app DB context ---
     builder.Services.AddDbContext<ApplicationDbContext>(options =>
-        ConfigureApplicationDbContext(options));
+            ConfigureApplicationDbContext(options),
+        optionsLifetime: ServiceLifetime.Singleton);
 
     // --- Tichá továrna pro DB sink (žádné EF logy) ---
     builder.Services.AddDbContextFactory<ApplicationDbContext>(options =>


### PR DESCRIPTION
## Summary
- configure ApplicationDbContext registration to use a singleton options lifetime so the DbContext factory can be resolved during startup

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e50bb18d408321a7be7d284bec75bb