### PR TITLE
Update services navigation text and route

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -80,7 +80,7 @@
                             <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["Nav.About"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Services" aria-current="@(currentPage == "/Services" ? "page" : null)">@T["Nav.Services"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["NavServices"]</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@T["Nav.Courses"]</a>

--- a/Resources/Pages.Shared._Layout.cshtml.en.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.en.resx
@@ -37,7 +37,7 @@
     <value>Articles</value>
   </data>
   <data name="NavServices" xml:space="preserve">
-    <value>Services &amp; consulting</value>
+    <value>Consulting &amp; audits</value>
   </data>
   <data name="NavCorporateInquiry" xml:space="preserve">
     <value>Corporate inquiry</value>

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -40,7 +40,7 @@
     <value>Firemní poptávka / audit na míru</value>
   </data>
   <data name="NavServices" xml:space="preserve">
-    <value>Služby a poradenství</value>
+    <value>Poradenství a audity</value>
   </data>
   <data name="NavPrivacy" xml:space="preserve">
     <value>Ochrana soukromí</value>


### PR DESCRIPTION
## Summary
- update the Czech navigation resource to use "Poradenství a audity"
- mirror the English resource value with "Consulting & audits"
- point the services navigation link at the About page with the updated resource key

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e50f63c674832183bf254076282362