### PR TITLE
Update hero localization messaging for ISO services

### DIFF
--- a/Resources/Pages.Index.cshtml.en.resx
+++ b/Resources/Pages.Index.cshtml.en.resx
@@ -19,7 +19,7 @@
     <value>Professional quality management training for your organization</value>
   </data>
   <data name="Home.Hero.Title" xml:space="preserve">
-    <value>ISO training, courses and certifications for your organization</value>
+    <value>Implementation, audits, and training for quality systems</value>
   </data>
   <data name="Home.Hero.Search.Placeholder" xml:space="preserve">
     <value>Search for a course, tool, or skill…</value>
@@ -31,25 +31,25 @@
     <value>Search</value>
   </data>
   <data name="Home.Hero.Subtitle" xml:space="preserve">
-    <value>Comprehensive preparation for certification and accreditation according to ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 and ISO 13485</value>
+    <value>We guide organizations through the entire ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949, and ISO 13485 lifecycle — from analysis to certification.</value>
   </data>
   <data name="Home.Hero.Search.Submit" xml:space="preserve">
     <value>Suggest courses</value>
   </data>
   <data name="Home.Hero.PrimaryCta" xml:space="preserve">
-    <value>View all courses</value>
+    <value>Browse ISO course offering</value>
   </data>
   <data name="Home.Hero.SecondaryCta" xml:space="preserve">
-    <value>Request in-company training</value>
+    <value>Request a tailored corporate solution</value>
   </data>
   <data name="Home.Hero.Usp1" xml:space="preserve">
-    <value>20+ years of experience in management systems</value>
+    <value>Seasoned auditors and consultants with years of experience</value>
   </data>
   <data name="Home.Hero.Usp2" xml:space="preserve">
-    <value>Certified courses with recognized credentials</value>
+    <value>Practical know-how drawn from real-world audits</value>
   </data>
   <data name="Home.Hero.Usp3" xml:space="preserve">
-    <value>Training on-site, online or directly at your company</value>
+    <value>Internal workshops delivered directly at your company</value>
   </data>
   <data name="HowItWorksTitle" xml:space="preserve">
     <value>How it works</value>
@@ -61,7 +61,7 @@
     <value>Select your role in the quality system</value>
   </data>
   <data name="Home.Hero.Persona.Help" xml:space="preserve">
-    <value>Helps us tailor course suggestions. For example, quality manager or internal auditor.</value>
+    <value>Helps us tailor course suggestions. For example, quality manager, internal auditor, accreditation preparation.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Analyze the current state</value>

--- a/Resources/Pages.Index.cshtml.resx
+++ b/Resources/Pages.Index.cshtml.resx
@@ -31,7 +31,7 @@
     <value>Vyhledávání</value>
   </data>
   <data name="Home.Hero.Subtitle" xml:space="preserve">
-    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 – od analýzy po certifikaci.</value>
+    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 — od analýzy po certifikaci.</value>
   </data>
   <data name="Home.Hero.Search.Submit" xml:space="preserve">
     <value>Navrhnout kurzy</value>
@@ -61,7 +61,7 @@
     <value>Vyberte svou roli v systému jakosti</value>
   </data>
   <data name="Home.Hero.Persona.Help" xml:space="preserve">
-    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor.</value>
+    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor, příprava na akreditaci.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Analyzujte aktuální stav</value>

--- a/Resources/Views.Shared._Hero.cshtml.en.resx
+++ b/Resources/Views.Shared._Hero.cshtml.en.resx
@@ -13,16 +13,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Home.Hero.Title" xml:space="preserve">
-    <value>Find the ideal training</value>
+    <value>Implementation, audits, and training for quality systems</value>
   </data>
   <data name="Home.Hero.Subtitle" xml:space="preserve">
-    <value>Courses, consulting and auditing in one place</value>
+    <value>We guide organizations through the entire ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949, and ISO 13485 lifecycle — from analysis to certification.</value>
   </data>
   <data name="Home.Hero.PrimaryCta" xml:space="preserve">
-    <value>Course overview</value>
+    <value>Browse ISO course offering</value>
   </data>
   <data name="Home.Hero.SecondaryCta" xml:space="preserve">
-    <value>Request a quote</value>
+    <value>Request a tailored corporate solution</value>
   </data>
   <data name="Home.Hero.SearchPlaceholder" xml:space="preserve">
     <value>Search for a course, standard or city…</value>
@@ -40,19 +40,19 @@
     <value>Suggest courses</value>
   </data>
   <data name="Home.Hero.Usp1" xml:space="preserve">
-    <value>20+ years of experience in management systems</value>
+    <value>Seasoned auditors and consultants with years of experience</value>
   </data>
   <data name="Home.Hero.Usp2" xml:space="preserve">
-    <value>Certified courses with recognized credentials</value>
+    <value>Practical know-how drawn from real-world audits</value>
   </data>
   <data name="Home.Hero.Usp3" xml:space="preserve">
-    <value>Training on-site, online or directly at your company</value>
+    <value>Internal workshops delivered directly at your company</value>
   </data>
   <data name="Home.Hero.Persona.Label" xml:space="preserve">
     <value>Select your role in the quality system</value>
   </data>
   <data name="Home.Hero.Persona.Help" xml:space="preserve">
-    <value>Helps us tailor course suggestions. For example, quality manager or internal auditor.</value>
+    <value>Helps us tailor course suggestions. For example, quality manager, internal auditor, accreditation preparation.</value>
   </data>
   <data name="Home.Hero.Goal.Label" xml:space="preserve">
     <value>Which goal do you want to achieve by meeting the standards?</value>

--- a/Resources/Views.Shared._Hero.cshtml.resx
+++ b/Resources/Views.Shared._Hero.cshtml.resx
@@ -16,7 +16,7 @@
     <value>Implementace, audity a školení systémů jakosti</value>
   </data>
   <data name="Home.Hero.Subtitle" xml:space="preserve">
-    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 – od analýzy po certifikaci.</value>
+    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 — od analýzy po certifikaci.</value>
   </data>
   <data name="Home.Hero.PrimaryCta" xml:space="preserve">
     <value>Prohlédnout nabídku kurzů ISO</value>
@@ -52,7 +52,7 @@
     <value>Vyberte svou roli v systému jakosti</value>
   </data>
   <data name="Home.Hero.Persona.Help" xml:space="preserve">
-    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor.</value>
+    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor, příprava na akreditaci.</value>
   </data>
   <data name="Home.Hero.Goal.Label" xml:space="preserve">
     <value>Jaký cíl chcete plněním norem dosáhnout?</value>

--- a/Resources/Views/Home/Index.cshtml.en.resx
+++ b/Resources/Views/Home/Index.cshtml.en.resx
@@ -31,25 +31,25 @@
     <value>Search</value>
   </data>
   <data name="HeroSubheading" xml:space="preserve">
-    <value>Comprehensive preparation for certification and accreditation according to ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 and ISO 13485</value>
+    <value>We guide organizations through the entire ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949, and ISO 13485 lifecycle — from analysis to certification.</value>
   </data>
   <data name="HeroSubmit" xml:space="preserve">
     <value>Suggest courses</value>
   </data>
   <data name="HeroPrimaryCTA" xml:space="preserve">
-    <value>View all courses</value>
+    <value>Browse ISO course offering</value>
   </data>
   <data name="HeroSecondaryCTA" xml:space="preserve">
-    <value>Request in-company training</value>
+    <value>Request a tailored corporate solution</value>
   </data>
   <data name="HeroUSP1" xml:space="preserve">
-    <value>20+ years of experience in management systems</value>
+    <value>Seasoned auditors and consultants with years of experience</value>
   </data>
   <data name="HeroUSP2" xml:space="preserve">
-    <value>Certified courses with recognized credentials</value>
+    <value>Practical know-how drawn from real-world audits</value>
   </data>
   <data name="HeroUSP3" xml:space="preserve">
-    <value>Training on-site, online or directly at your company</value>
+    <value>Internal workshops delivered directly at your company</value>
   </data>
   <data name="HowItWorksTitle" xml:space="preserve">
     <value>How it works</value>
@@ -61,7 +61,7 @@
     <value>Select your role in the quality system</value>
   </data>
   <data name="PersonaHelp" xml:space="preserve">
-    <value>Helps us tailor course suggestions. For example, quality manager or internal auditor.</value>
+    <value>Helps us tailor course suggestions. For example, quality manager, internal auditor, accreditation preparation.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Analyze the current state</value>
@@ -175,16 +175,16 @@
     <value>ISO 13485 — Medical Devices</value>
   </data>
   <data name="Home.Hero.Title" xml:space="preserve">
-    <value>Find the ideal training</value>
+    <value>Implementation, audits, and training for quality systems</value>
   </data>
   <data name="Home.Hero.Subtitle" xml:space="preserve">
-    <value>Courses, consulting and auditing in one place</value>
+    <value>We guide organizations through the entire ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949, and ISO 13485 lifecycle — from analysis to certification.</value>
   </data>
   <data name="Home.Hero.PrimaryCta" xml:space="preserve">
-    <value>Course overview</value>
+    <value>Browse ISO course offering</value>
   </data>
   <data name="Home.Hero.SecondaryCta" xml:space="preserve">
-    <value>Request a quote</value>
+    <value>Request a tailored corporate solution</value>
   </data>
   <data name="Home.Hero.SearchPlaceholder" xml:space="preserve">
     <value>Search for a course, standard or city…</value>
@@ -202,13 +202,13 @@
     <value>Suggest courses</value>
   </data>
   <data name="Home.Hero.Usp1" xml:space="preserve">
-    <value>20+ years of experience in management systems</value>
+    <value>Seasoned auditors and consultants with years of experience</value>
   </data>
   <data name="Home.Hero.Usp2" xml:space="preserve">
-    <value>Certified courses with recognized credentials</value>
+    <value>Practical know-how drawn from real-world audits</value>
   </data>
   <data name="Home.Hero.Usp3" xml:space="preserve">
-    <value>Training on-site, online or directly at your company</value>
+    <value>Internal workshops delivered directly at your company</value>
   </data>
   <data name="Home.Hero.Persona.AriaLabel" xml:space="preserve">
     <value>I am</value>
@@ -217,7 +217,7 @@
     <value>Select your role in the quality system</value>
   </data>
   <data name="Home.Hero.Persona.Help" xml:space="preserve">
-    <value>Helps us tailor course suggestions. For example, quality manager or internal auditor.</value>
+    <value>Helps us tailor course suggestions. For example, quality manager, internal auditor, accreditation preparation.</value>
   </data>
   <data name="Home.Hero.Goal.AriaLabel" xml:space="preserve">
     <value>I want to</value>

--- a/Resources/Views/Home/Index.cshtml.resx
+++ b/Resources/Views/Home/Index.cshtml.resx
@@ -31,7 +31,7 @@
     <value>Vyhledávání</value>
   </data>
   <data name="HeroSubheading" xml:space="preserve">
-    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 – od analýzy po certifikaci.</value>
+    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 — od analýzy po certifikaci.</value>
   </data>
   <data name="HeroSubmit" xml:space="preserve">
     <value>Navrhnout kurzy</value>
@@ -61,7 +61,7 @@
     <value>Vyberte svou roli v systému jakosti</value>
   </data>
   <data name="PersonaHelp" xml:space="preserve">
-    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor.</value>
+    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor, příprava na akreditaci.</value>
   </data>
   <data name="StepSelectTitle" xml:space="preserve">
     <value>Analyzujte aktuální stav</value>
@@ -176,16 +176,16 @@
   </data>
 
   <data name="Home.Hero.Title" xml:space="preserve">
-    <value>Najděte ideální školení</value>
+    <value>Implementace, audity a školení systémů jakosti</value>
   </data>
   <data name="Home.Hero.Subtitle" xml:space="preserve">
-    <value>Kurzy, poradenství a audit na jednom místě</value>
+    <value>Provázíme organizace celým cyklem ISO 9001, ISO 14001, ISO/IEC 17025, ISO 15189, HACCP, ISO 45001, ISO 27001, IATF 16949 a ISO 13485 — od analýzy po certifikaci.</value>
   </data>
   <data name="Home.Hero.PrimaryCta" xml:space="preserve">
-    <value>Přehled kurzů</value>
+    <value>Prohlédnout nabídku kurzů ISO</value>
   </data>
   <data name="Home.Hero.SecondaryCta" xml:space="preserve">
-    <value>Nezávazná poptávka</value>
+    <value>Nechat si připravit firemní řešení</value>
   </data>
   <data name="Home.Hero.SearchPlaceholder" xml:space="preserve">
     <value>Hledat kurz, normu nebo město…</value>
@@ -218,7 +218,7 @@
     <value>Vyberte svou roli v systému jakosti</value>
   </data>
   <data name="Home.Hero.Persona.Help" xml:space="preserve">
-    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor.</value>
+    <value>Pomůže nám lépe doporučit kurzy. Například manažer kvality, interní auditor, příprava na akreditaci.</value>
   </data>
   <data name="Home.Hero.Goal.AriaLabel" xml:space="preserve">
     <value>Chci</value>


### PR DESCRIPTION
## Summary
- align the home hero title and subtitle across Czech and English resources with the new ISO lifecycle messaging
- refresh the primary and secondary calls-to-action plus USP bullet points to highlight auditor experience, practical know-how, and internal workshops
- extend the persona help copy with the accreditation preparation example in both languages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5104d68fc83218a1deadaf941737a