### PR TITLE
Improve navbar layout to prevent overflow

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -71,8 +71,8 @@
                         aria-expanded="false" aria-label='@Localizer["ToggleNavigation"]'>
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                <div id="primaryNavigation" class="navbar-collapse collapse d-lg-inline-flex justify-content-between">
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0 gap-lg-1">
+                <div id="primaryNavigation" class="navbar-collapse collapse">
+                    <ul class="navbar-nav primary-nav me-auto mb-2 mb-lg-0 gap-2 gap-lg-1">
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">@T["Nav.Home"]</a>
                         </li>
@@ -95,7 +95,7 @@
                             <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">@T["Nav.Privacy"]</a>
                         </li>
                     </ul>
-                    <ul class="navbar-nav navbar-actions ms-lg-auto align-items-lg-center gap-3 mb-2 mb-lg-0 flex-column flex-lg-row">
+                    <ul class="navbar-nav navbar-actions ms-lg-auto align-items-lg-center gap-2 gap-lg-3 mb-2 mb-lg-0 flex-column flex-lg-row flex-lg-wrap">
                         @if (canAccessAdmin)
                         {
                             <li class="nav-item">

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -233,6 +233,30 @@ button:focus-visible {
   box-shadow: 0 20px 45px rgba(37, 99, 235, 0.2);
 }
 
+.app-navbar .navbar-collapse {
+  gap: 1.25rem;
+}
+
+@media (min-width: 992px) {
+  .app-navbar .navbar-collapse {
+    display: flex !important;
+    align-items: center;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+  }
+
+  .app-navbar .primary-nav {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .app-navbar .primary-nav .nav-item {
+    flex: 0 0 auto;
+  }
+}
+
 .theme-toggle {
   min-width: 2.5rem;
   min-height: 2.5rem;
@@ -1984,6 +2008,13 @@ footer.app-footer a:focus {
 @media (min-width: 992px) {
   .navbar-actions {
     width: auto;
+    display: flex;
+    flex: 0 1 auto;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    row-gap: 0.5rem;
   }
 
   .navbar-actions > .nav-item {


### PR DESCRIPTION
## Summary
- add a `primary-nav` hook and adjust navbar markup so navigation blocks can wrap when expanded
- extend navbar styling to allow the primary links and action buttons to flex-wrap with tighter gaps on wide screens

## Testing
- `dotnet run --urls http://0.0.0.0:5000` *(fails: .NET 8 runtime is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e513b93fd48321b513cfd1a9399e85