### PR TITLE
Add localized package recommendations to corporate inquiry flow

### DIFF
--- a/Pages/CorporateInquiry/Partials/_StepTraining.cshtml
+++ b/Pages/CorporateInquiry/Partials/_StepTraining.cshtml
@@ -23,3 +23,29 @@
     }
     <div id="training-types-error" class="invalid-feedback d-block @errorClass">@trainingError</div>
 </div>
+
+@{
+    var packageKeys = new[] { "PackageIso9001Full", "PackageImsIntegrated", "PackageLabAccreditation" };
+}
+
+<div class="mt-4">
+    <h3 class="h5 mb-3">@Localizer["PackageRecommendationsTitle"]</h3>
+    <div class="row g-3">
+        @foreach (var packageKey in packageKeys)
+        {
+            var localized = Localizer[packageKey].Value ?? string.Empty;
+            var parts = localized.Split(new[] { "\r\n", "\n" }, System.StringSplitOptions.RemoveEmptyEntries);
+            var title = parts.Length > 0 ? parts[0] : localized;
+            var description = parts.Length > 1 ? string.Join(" ", parts, 1, parts.Length - 1) : string.Empty;
+            <div class="col-12 col-md-4">
+                <div class="border rounded p-3 h-100">
+                    <div class="fw-semibold mb-2">@title</div>
+                    @if (!string.IsNullOrEmpty(description))
+                    {
+                        <p class="mb-0 text-muted">@description</p>
+                    }
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/Resources/Pages.CorporateInquiry.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.en.resx
@@ -183,6 +183,21 @@
   <data name="ISO13485" xml:space="preserve">
     <value>ISO 13485 - Medical devices</value>
   </data>
+  <data name="PackageRecommendationsTitle" xml:space="preserve">
+    <value>Recommended service packages</value>
+  </data>
+  <data name="PackageIso9001Full" xml:space="preserve">
+    <value>ISO 9001 – Full implementation
+End-to-end engagement covering gap analysis, documentation, and certification readiness.</value>
+  </data>
+  <data name="PackageImsIntegrated" xml:space="preserve">
+    <value>Integrated management system (ISO 9001 + ISO 14001 + ISO 45001)
+Combined rollout of quality, environmental, and OH&amp;S standards with aligned processes and training.</value>
+  </data>
+  <data name="PackageLabAccreditation" xml:space="preserve">
+    <value>Laboratory accreditation (ISO/IEC 17025)
+Support with laboratory processes, calibration controls, and records to meet accreditation requirements.</value>
+  </data>
   <data name="ValidationServiceTypeRequired" xml:space="preserve">
     <value>Please select a service type.</value>
   </data>

--- a/Resources/Pages.CorporateInquiry.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.resx
@@ -183,6 +183,21 @@
   <data name="ISO13485" xml:space="preserve">
     <value>ISO 13485 - Zdravotnické prostředky</value>
   </data>
+  <data name="PackageRecommendationsTitle" xml:space="preserve">
+    <value>Doporučené balíčky služeb</value>
+  </data>
+  <data name="PackageIso9001Full" xml:space="preserve">
+    <value>ISO 9001 – Kompletní zavedení
+Komplexní projekt od úvodní analýzy přes tvorbu dokumentace až po přípravu na certifikační audit.</value>
+  </data>
+  <data name="PackageImsIntegrated" xml:space="preserve">
+    <value>Integrovaný systém řízení (ISO 9001 + ISO 14001 + ISO 45001)
+Koordinované zavedení kvality, environmentu a BOZP s jednotnou dokumentací a školením.</value>
+  </data>
+  <data name="PackageLabAccreditation" xml:space="preserve">
+    <value>Akreditace laboratoře (ISO/IEC 17025)
+Podpora při nastavení laboratorních procesů, kalibrací a evidence tak, abyste splnili požadavky ČIA.</value>
+  </data>
   <data name="ValidationServiceTypeRequired" xml:space="preserve">
     <value>Vyberte typ služby.</value>
   </data>


### PR DESCRIPTION
## Summary
- add Czech and English resource strings for recommended corporate inquiry packages
- surface the recommended packages with name and description cards on the training step

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e513c6c788832184a02a3478388824