### PR TITLE
Add localized hero intro text to articles page

### DIFF
--- a/Pages/Articles/Index.cshtml
+++ b/Pages/Articles/Index.cshtml
@@ -94,6 +94,7 @@
     <div class="articles-hero__content">
         <p class="text-uppercase fw-semibold text-primary mb-2">@Localizer["HeroBadge"]</p>
         <h1 class="display-5 fw-bold mb-3">@Localizer["HeroHeadline"]</h1>
+        <p class="mb-3">@Localizer["HeroIntro"]</p>
         <p class="lead text-muted mb-0">@Localizer["HeroSubheadline"]</p>
     </div>
 </section>

--- a/Resources/Pages.Articles.Index.cshtml.en.resx
+++ b/Resources/Pages.Articles.Index.cshtml.en.resx
@@ -21,6 +21,9 @@
   <data name="HeroHeadline" xml:space="preserve">
     <value>Articles that streamline your management systems</value>
   </data>
+  <data name="HeroIntro" xml:space="preserve">
+    <value>Discover best practices for ISO 9001 and ISO 14001, download auditor checklists, and stay current with legislative changes affecting your certifications.</value>
+  </data>
   <data name="HeroSubheadline" xml:space="preserve">
     <value>Browse a curated selection of articles on ISO standards, audits and process management. Filter by category, search key topics and switch between grid and list views.</value>
   </data>

--- a/Resources/Pages.Articles.Index.cshtml.resx
+++ b/Resources/Pages.Articles.Index.cshtml.resx
@@ -21,6 +21,9 @@
   <data name="HeroHeadline" xml:space="preserve">
     <value>Články, které zefektivní vaše systémy řízení</value>
   </data>
+  <data name="HeroIntro" xml:space="preserve">
+    <value>Zjistěte osvědčené postupy pro ISO 9001 a ISO 14001, stáhněte si kontrolní seznamy pro auditory a sledujte legislativní novinky ovlivňující vaše certifikace.</value>
+  </data>
   <data name="HeroSubheadline" xml:space="preserve">
     <value>Vyberte si z kurátorovaného výběru článků o ISO normách, auditech i procesním řízení. Filtrujte podle kategorií, vyhledávejte klíčová témata a přepínejte mezi dlaždicovým a seznamovým zobrazením.</value>
   </data>


### PR DESCRIPTION
## Summary
- add a localized introductory paragraph under the articles hero heading
- provide Czech and English resource strings covering ISO best practices, auditor checklists, and legislative updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e600081e008321aec43495c8e821ff