### PR TITLE
Add shared service overview snippets

### DIFF
--- a/Pages/About.cshtml
+++ b/Pages/About.cshtml
@@ -62,6 +62,8 @@
     </div>
 </section>
 
+@await Html.PartialAsync("/Pages/Shared/_ServiceOverviewSnippets.cshtml")
+
 <section class="py-5 bg-light rounded-4">
     <div class="container py-4">
         <div class="text-center mb-4">

--- a/Pages/Services.cshtml
+++ b/Pages/Services.cshtml
@@ -70,6 +70,8 @@
     </div>
 </section>
 
+@await Html.PartialAsync("/Pages/Shared/_ServiceOverviewSnippets.cshtml")
+
 <section class="py-5 bg-light rounded-4">
     <div class="container py-4">
         <div class="text-center mb-5">

--- a/Pages/Shared/_ServiceOverviewSnippets.cshtml
+++ b/Pages/Shared/_ServiceOverviewSnippets.cshtml
@@ -1,0 +1,48 @@
+@inject Microsoft.Extensions.Localization.IStringLocalizer<SharedResource> SharedLocalizer
+
+<section class="py-5 service-overview-snippets">
+    <div class="container">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-4">
+            <div class="col d-flex">
+                <article class="card shadow-sm border-0 w-100 h-100">
+                    <div class="card-body d-flex gap-3">
+                        <div class="icon-circle bg-primary-subtle text-primary flex-shrink-0">
+                            <i class="bi bi-lightbulb-fill fs-4" aria-hidden="true"></i>
+                        </div>
+                        <p class="mb-0 text-muted">@SharedLocalizer["ConsultingIntro"]</p>
+                    </div>
+                </article>
+            </div>
+            <div class="col d-flex">
+                <article class="card shadow-sm border-0 w-100 h-100">
+                    <div class="card-body d-flex gap-3">
+                        <div class="icon-circle bg-success-subtle text-success flex-shrink-0">
+                            <i class="bi bi-mortarboard-fill fs-4" aria-hidden="true"></i>
+                        </div>
+                        <p class="mb-0 text-muted">@SharedLocalizer["TrainingIntro"]</p>
+                    </div>
+                </article>
+            </div>
+            <div class="col d-flex">
+                <article class="card shadow-sm border-0 w-100 h-100">
+                    <div class="card-body d-flex gap-3">
+                        <div class="icon-circle bg-warning-subtle text-warning flex-shrink-0">
+                            <i class="bi bi-shield-check fs-4" aria-hidden="true"></i>
+                        </div>
+                        <p class="mb-0 text-muted">@SharedLocalizer["AuditSupport"]</p>
+                    </div>
+                </article>
+            </div>
+            <div class="col d-flex">
+                <article class="card shadow-sm border-0 w-100 h-100">
+                    <div class="card-body d-flex gap-3">
+                        <div class="icon-circle bg-info-subtle text-info flex-shrink-0">
+                            <i class="bi bi-files fs-4" aria-hidden="true"></i>
+                        </div>
+                        <p class="mb-0 text-muted">@SharedLocalizer["DocumentTemplates"]</p>
+                    </div>
+                </article>
+            </div>
+        </div>
+    </div>
+</section>

--- a/Resources/SharedResources.en.resx
+++ b/Resources/SharedResources.en.resx
@@ -195,6 +195,18 @@
   <data name="Models.VoucherType.Percentage.DisplayName" xml:space="preserve">
     <value>Percentage discount</value>
   </data>
+  <data name="ConsultingIntro" xml:space="preserve">
+    <value>Consulting engagements: We lead them from the initial process analysis through tailored improvements to a management system fully aligned with ISO and accreditation requirements.</value>
+  </data>
+  <data name="TrainingIntro" xml:space="preserve">
+    <value>Training and workshops: We coach quality managers, internal auditors, and specialists to apply the standards in daily operations and foster a culture of continual improvement.</value>
+  </data>
+  <data name="AuditSupport" xml:space="preserve">
+    <value>Audit support: We prepare you for internal and certification audits, deliver gap analyses, and assist with corrective actions as well as communication with the certification body.</value>
+  </data>
+  <data name="DocumentTemplates" xml:space="preserve">
+    <value>Documentation templates: We supply clear templates for policies, process maps, checklists, and records to accelerate documentation and simplify ongoing system maintenance.</value>
+  </data>
   <data name="Pages.Account.Register.Input.ConfirmPassword.DisplayName" xml:space="preserve">
     <value>Confirm password</value>
   </data>

--- a/Resources/SharedResources.resx
+++ b/Resources/SharedResources.resx
@@ -195,6 +195,18 @@
   <data name="Models.VoucherType.Percentage.DisplayName" xml:space="preserve">
     <value>Procentuální sleva</value>
   </data>
+  <data name="ConsultingIntro" xml:space="preserve">
+    <value>Poradenské projekty: Vedeme je od úvodní analýzy procesů přes návrh opatření až po zavedení systému řízení v souladu s požadavky ISO a akreditačních předpisů.</value>
+  </data>
+  <data name="TrainingIntro" xml:space="preserve">
+    <value>Školení a workshopy: Školíme manažery kvality, interní auditory i odborné pracovníky, aby dokázali normy aplikovat v praxi a podporovat kulturu neustálého zlepšování.</value>
+  </data>
+  <data name="AuditSupport" xml:space="preserve">
+    <value>Podpora auditů: Připravíme vás na interní i certifikační audity, provedeme gap analýzy a pomůžeme s nápravnými opatřeními i komunikací s certifikačním orgánem.</value>
+  </data>
+  <data name="DocumentTemplates" xml:space="preserve">
+    <value>Šablony dokumentace: Poskytujeme přehledné šablony směrnic, procesních map, checklistů a záznamů, které urychlí dokumentaci a usnadní následnou údržbu systému.</value>
+  </data>
   <data name="Pages.Account.Register.Input.ConfirmPassword.DisplayName" xml:space="preserve">
     <value>Potvrzení hesla</value>
   </data>


### PR DESCRIPTION
## Summary
- add shared Czech and English resource entries for consulting, training, audit support, and documentation templates
- introduce a reusable partial that surfaces the shared service snippets on both the About and Services pages

## Testing
- dotnet build -clp:Summary *(fails: command hung in container and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e60006007883218dd365f010fe13d4