### PR TITLE
Fix navigation localization keys in layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -74,25 +74,25 @@
                 <div id="primaryNavigation" class="navbar-collapse collapse">
                     <ul class="navbar-nav primary-nav me-auto mb-2 mb-lg-0 gap-2 gap-lg-1">
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">@T["Nav.Home"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Index" aria-current="@(currentPage == "/Index" ? "page" : null)">@T["NavHome"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["Nav.About"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["NavAbout"]</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-page="/About" aria-current="@(currentPage == "/About" ? "page" : null)">@T["NavServices"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@T["Nav.Courses"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Courses/Index" aria-current="@(currentPage == "/Courses/Index" ? "page" : null)">@T["NavCourses"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(currentPage == "/Articles/Index" ? "page" : null)">@T["Nav.Articles"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Articles/Index" aria-current="@(currentPage == "/Articles/Index" ? "page" : null)">@T["NavArticles"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/CorporateInquiry" aria-current="@(currentPage == "/CorporateInquiry" ? "page" : null)">@T["Nav.CorporateInquiry"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/CorporateInquiry" aria-current="@(currentPage == "/CorporateInquiry" ? "page" : null)">@T["NavCorporateInquiry"]</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">@T["Nav.Privacy"]</a>
+                            <a class="nav-link" asp-area="" asp-page="/Privacy" aria-current="@(currentPage == "/Privacy" ? "page" : null)">@T["NavPrivacy"]</a>
                         </li>
                     </ul>
                     <ul class="navbar-nav navbar-actions ms-lg-auto align-items-lg-center gap-2 gap-lg-3 mb-2 mb-lg-0 flex-column flex-lg-row flex-lg-wrap">


### PR DESCRIPTION
## Summary
- update the layout navigation links to use the undotted localization keys so that the Razor view matches the resource files

## Testing
- dotnet run --urls http://0.0.0.0:5000 *(fails: missing Microsoft.NETCore.App 8.0 runtime in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e604fcbd588321ae13e898eae0c395