### PR TITLE
Fix hero chip localization keys

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -11,14 +11,14 @@
         Subtitle = T["Home.Hero.Subtitle"].Value,
         PrimaryCta = T["Home.Hero.PrimaryCta"].Value,
         SecondaryCta = T["Home.Hero.SecondaryCta"].Value,
-        SearchPlaceholder = T["Home.Hero.SearchPlaceholder"].Value,
+        SearchPlaceholder = T["Home.Hero.Search.Placeholder"].Value,
         Chips = new()
         {
-            T["Home.Hero.Chip.Online"].Value,
-            T["Home.Hero.Chip.Retraining"].Value,
-            T["Home.Hero.Chip.Certificate"].Value,
-            T["Home.Hero.Chip.Accreditation"].Value,
-            T["Home.Hero.Chip.InternalAudits"].Value
+            T["Home.Hero.Chips.Online"].Value,
+            T["Home.Hero.Chips.Retraining"].Value,
+            T["Home.Hero.Chips.Certificate"].Value,
+            T["Home.Hero.Chips.Accreditation"].Value,
+            T["Home.Hero.Chips.InternalAudits"].Value
         }
     })
 

--- a/Views/Shared/_Hero.cshtml
+++ b/Views/Shared/_Hero.cshtml
@@ -55,13 +55,13 @@
     {
         var fallbackChipDefinitions = new List<(string Url, string Label)>
         {
-            ("/Courses/Index?Mode=Online", GetString("Home.Hero.Chip.Online", "Home.Hero.Chips.Online")),
-            ("/Courses/Index?CourseGroupId=REKVAL", GetString("Home.Hero.Chip.Retraining", "Home.Hero.Chips.Retraining")),
-            ("/Courses/Index?Level=Beginner", GetString("Home.Hero.Chip.Beginner", "Home.Hero.Chips.Beginner")),
-            ("/Courses/Index?City=Praha", GetString("Home.Hero.Chip.Prague", "Home.Hero.Chips.Prague")),
-            ("/Courses/Index?HasCertificate=true", GetString("Home.Hero.Chip.Certificate", "Home.Hero.Chips.Certificate")),
-            ("/Courses/Index?q=akreditace", GetString("Home.Hero.Chip.Accreditation", "Home.Hero.Chips.Accreditation")),
-            ("/Courses/Index?q=intern%C3%AD%20audit", GetString("Home.Hero.Chip.InternalAudits", "Home.Hero.Chips.InternalAudits")),
+            ("/Courses/Index?Mode=Online", GetString("Home.Hero.Chips.Online", "Home.Hero.Chip.Online")),
+            ("/Courses/Index?CourseGroupId=REKVAL", GetString("Home.Hero.Chips.Retraining", "Home.Hero.Chip.Retraining")),
+            ("/Courses/Index?Level=Beginner", GetString("Home.Hero.Chips.Beginner", "Home.Hero.Chip.Beginner")),
+            ("/Courses/Index?City=Praha", GetString("Home.Hero.Chips.Prague", "Home.Hero.Chip.Prague")),
+            ("/Courses/Index?HasCertificate=true", GetString("Home.Hero.Chips.Certificate", "Home.Hero.Chip.Certificate")),
+            ("/Courses/Index?q=akreditace", GetString("Home.Hero.Chips.Accreditation", "Home.Hero.Chip.Accreditation")),
+            ("/Courses/Index?q=intern%C3%AD%20audit", GetString("Home.Hero.Chips.InternalAudits", "Home.Hero.Chip.InternalAudits")),
         };
 
         var lookup = fallbackChipDefinitions.ToDictionary(c => c.Label, c => c.Url, StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary
- request the correct `Home.Hero.Chips.*` resources in the home page so chip labels are localized
- update the hero partial fallback definitions to prefer the new chip resource keys

## Testing
- dotnet build --no-restore

------
https://chatgpt.com/codex/tasks/task_e_68e604fe06c08321aa9db1d4b8fbca28