### PR TITLE
Ensure corporate inquiry training packages use localized strings

### DIFF
--- a/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.en.resx
@@ -48,4 +48,19 @@
   <data name="ISO13485" xml:space="preserve">
     <value>ISO 13485 - Medical devices</value>
   </data>
+  <data name="PackageRecommendationsTitle" xml:space="preserve">
+    <value>Recommended service packages</value>
+  </data>
+  <data name="PackageIso9001Full" xml:space="preserve">
+    <value>ISO 9001 – Full implementation
+End-to-end engagement covering gap analysis, documentation, and certification readiness.</value>
+  </data>
+  <data name="PackageImsIntegrated" xml:space="preserve">
+    <value>Integrated management system (ISO 9001 + ISO 14001 + ISO 45001)
+Combined rollout of quality, environmental, and OH&amp;S standards with aligned processes and training.</value>
+  </data>
+  <data name="PackageLabAccreditation" xml:space="preserve">
+    <value>Laboratory accreditation (ISO/IEC 17025)
+Support with laboratory processes, calibration controls, and records to meet accreditation requirements.</value>
+  </data>
 </root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.resx
@@ -48,4 +48,19 @@
   <data name="ISO13485" xml:space="preserve">
     <value>ISO 13485 - Zdravotnické prostředky</value>
   </data>
+  <data name="PackageRecommendationsTitle" xml:space="preserve">
+    <value>Doporučené balíčky služeb</value>
+  </data>
+  <data name="PackageIso9001Full" xml:space="preserve">
+    <value>ISO 9001 – Kompletní zavedení
+Komplexní projekt od úvodní analýzy přes tvorbu dokumentace až po přípravu na certifikační audit.</value>
+  </data>
+  <data name="PackageImsIntegrated" xml:space="preserve">
+    <value>Integrovaný systém řízení (ISO 9001 + ISO 14001 + ISO 45001)
+Koordinované zavedení kvality, environmentu a BOZP s jednotnou dokumentací a školením.</value>
+  </data>
+  <data name="PackageLabAccreditation" xml:space="preserve">
+    <value>Akreditace laboratoře (ISO/IEC 17025)
+Podpora při nastavení laboratorních procesů, kalibrací a evidence tak, abyste splnili požadavky ČIA.</value>
+  </data>
 </root>

--- a/Resources/Pages.CorporateInquiry.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.en.resx
@@ -183,21 +183,6 @@
   <data name="ISO13485" xml:space="preserve">
     <value>ISO 13485 - Medical devices</value>
   </data>
-  <data name="PackageRecommendationsTitle" xml:space="preserve">
-    <value>Recommended service packages</value>
-  </data>
-  <data name="PackageIso9001Full" xml:space="preserve">
-    <value>ISO 9001 – Full implementation
-End-to-end engagement covering gap analysis, documentation, and certification readiness.</value>
-  </data>
-  <data name="PackageImsIntegrated" xml:space="preserve">
-    <value>Integrated management system (ISO 9001 + ISO 14001 + ISO 45001)
-Combined rollout of quality, environmental, and OH&amp;S standards with aligned processes and training.</value>
-  </data>
-  <data name="PackageLabAccreditation" xml:space="preserve">
-    <value>Laboratory accreditation (ISO/IEC 17025)
-Support with laboratory processes, calibration controls, and records to meet accreditation requirements.</value>
-  </data>
   <data name="ValidationServiceTypeRequired" xml:space="preserve">
     <value>Please select a service type.</value>
   </data>

--- a/Resources/Pages.CorporateInquiry.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.cshtml.resx
@@ -183,21 +183,6 @@
   <data name="ISO13485" xml:space="preserve">
     <value>ISO 13485 - Zdravotnické prostředky</value>
   </data>
-  <data name="PackageRecommendationsTitle" xml:space="preserve">
-    <value>Doporučené balíčky služeb</value>
-  </data>
-  <data name="PackageIso9001Full" xml:space="preserve">
-    <value>ISO 9001 – Kompletní zavedení
-Komplexní projekt od úvodní analýzy přes tvorbu dokumentace až po přípravu na certifikační audit.</value>
-  </data>
-  <data name="PackageImsIntegrated" xml:space="preserve">
-    <value>Integrovaný systém řízení (ISO 9001 + ISO 14001 + ISO 45001)
-Koordinované zavedení kvality, environmentu a BOZP s jednotnou dokumentací a školením.</value>
-  </data>
-  <data name="PackageLabAccreditation" xml:space="preserve">
-    <value>Akreditace laboratoře (ISO/IEC 17025)
-Podpora při nastavení laboratorních procesů, kalibrací a evidence tak, abyste splnili požadavky ČIA.</value>
-  </data>
   <data name="ValidationServiceTypeRequired" xml:space="preserve">
     <value>Vyberte typ služby.</value>
   </data>


### PR DESCRIPTION
## Summary
- add the recommended package title and description resources to the corporate inquiry training step for both locales
- remove duplicate package entries from the parent corporate inquiry page resources once the partial owns them

## Testing
- dotnet build --nologo

------
https://chatgpt.com/codex/tasks/task_e_68e604fea6c083218370f9c95efacce7