### PR TITLE
Allow external font providers in CSP connect-src

### DIFF
--- a/Middleware/ContentSecurityPolicyMiddleware.cs
+++ b/Middleware/ContentSecurityPolicyMiddleware.cs
@@ -19,7 +19,7 @@ public class ContentSecurityPolicyMiddleware
 
     private static string BuildPolicyValue(IHostEnvironment environment)
     {
-        var connectSources = "'self'";
+        var connectSources = "'self' https://fonts.googleapis.com https://fonts.gstatic.com https://cdn.jsdelivr.net";
         if (environment.IsDevelopment())
         {
             connectSources += " http://localhost:* https://localhost:* ws://localhost:* wss://localhost:*";


### PR DESCRIPTION
## Summary
- allow the content security policy connect-src directive to contact Google Fonts and jsDelivr
- keep localhost development exceptions when running locally

## Testing
- dotnet build SysJaky_N.sln -nologo

------
https://chatgpt.com/codex/tasks/task_e_68e607de9d508321a4d6e52c40a9a45b