### PR TITLE
Add localized service overview snippets to shared resources

### DIFF
--- a/Resources/SharedResource.cs.en.resx
+++ b/Resources/SharedResource.cs.en.resx
@@ -118,6 +118,18 @@
   <data name="HeroSecondaryCTA" xml:space="preserve">
     <value>Request in-company training</value>
   </data>
+  <data name="ConsultingIntro" xml:space="preserve">
+    <value>Consulting engagements: We lead them from the initial process analysis through tailored improvements to a management system fully aligned with ISO and accreditation requirements.</value>
+  </data>
+  <data name="TrainingIntro" xml:space="preserve">
+    <value>Training and workshops: We coach quality managers, internal auditors, and specialists to apply the standards in daily operations and foster a culture of continual improvement.</value>
+  </data>
+  <data name="AuditSupport" xml:space="preserve">
+    <value>Audit support: We prepare you for internal and certification audits, deliver gap analyses, and assist with corrective actions as well as communication with the certification body.</value>
+  </data>
+  <data name="DocumentTemplates" xml:space="preserve">
+    <value>Documentation templates: We supply clear templates for policies, process maps, checklists, and records to accelerate documentation and simplify ongoing system maintenance.</value>
+  </data>
   <data name="PersonaLabel" xml:space="preserve">
     <value>Select your role in the quality system</value>
   </data>

--- a/Resources/SharedResource.cs.resx
+++ b/Resources/SharedResource.cs.resx
@@ -118,6 +118,18 @@
   <data name="HeroSecondaryCTA" xml:space="preserve">
     <value>Nechat si připravit firemní řešení</value>
   </data>
+  <data name="ConsultingIntro" xml:space="preserve">
+    <value>Poradenské projekty: Vedeme je od úvodní analýzy procesů přes návrh opatření až po zavedení systému řízení v souladu s požadavky ISO a akreditačních předpisů.</value>
+  </data>
+  <data name="TrainingIntro" xml:space="preserve">
+    <value>Školení a workshopy: Školíme manažery kvality, interní auditory i odborné pracovníky, aby dokázali normy aplikovat v praxi a podporovat kulturu neustálého zlepšování.</value>
+  </data>
+  <data name="AuditSupport" xml:space="preserve">
+    <value>Podpora auditů: Připravíme vás na interní i certifikační audity, provedeme gap analýzy a pomůžeme s nápravnými opatřeními i komunikací s certifikačním orgánem.</value>
+  </data>
+  <data name="DocumentTemplates" xml:space="preserve">
+    <value>Šablony dokumentace: Poskytujeme přehledné šablony směrnic, procesních map, checklistů a záznamů, které urychlí dokumentaci a usnadní následnou údržbu systému.</value>
+  </data>
   <data name="PersonaLabel" xml:space="preserve">
     <value>Vyberte svou roli v systému jakosti</value>
   </data>


### PR DESCRIPTION
## Summary
- add localized service overview snippet text to the shared resource resx files so the service overview partial displays translated copy in both languages

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e609f96850832195b0a14423928231