### PR TITLE
Ensure StepTraining package cards use localized resource entries

### DIFF
--- a/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.en.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.en.resx
@@ -52,15 +52,12 @@
     <value>Recommended service packages</value>
   </data>
   <data name="PackageIso9001Full" xml:space="preserve">
-    <value>ISO 9001 – Full implementation
-End-to-end engagement covering gap analysis, documentation, and certification readiness.</value>
+    <value>ISO 9001 – Full implementation&#x0a;End-to-end engagement covering gap analysis, documentation, and certification readiness.</value>
   </data>
   <data name="PackageImsIntegrated" xml:space="preserve">
-    <value>Integrated management system (ISO 9001 + ISO 14001 + ISO 45001)
-Combined rollout of quality, environmental, and OH&amp;S standards with aligned processes and training.</value>
+    <value>Integrated management system (ISO 9001 + ISO 14001 + ISO 45001)&#x0a;Combined rollout of quality, environmental, and OH&amp;S standards with aligned processes and training.</value>
   </data>
   <data name="PackageLabAccreditation" xml:space="preserve">
-    <value>Laboratory accreditation (ISO/IEC 17025)
-Support with laboratory processes, calibration controls, and records to meet accreditation requirements.</value>
+    <value>Laboratory accreditation (ISO/IEC 17025)&#x0a;Support with laboratory processes, calibration controls, and records to meet accreditation requirements.</value>
   </data>
 </root>

--- a/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.resx
+++ b/Resources/Pages.CorporateInquiry.Partials._StepTraining.cshtml.resx
@@ -52,15 +52,12 @@
     <value>Doporučené balíčky služeb</value>
   </data>
   <data name="PackageIso9001Full" xml:space="preserve">
-    <value>ISO 9001 – Kompletní zavedení
-Komplexní projekt od úvodní analýzy přes tvorbu dokumentace až po přípravu na certifikační audit.</value>
+    <value>ISO 9001 – Kompletní zavedení&#x0a;Komplexní projekt od úvodní analýzy přes tvorbu dokumentace až po přípravu na certifikační audit.</value>
   </data>
   <data name="PackageImsIntegrated" xml:space="preserve">
-    <value>Integrovaný systém řízení (ISO 9001 + ISO 14001 + ISO 45001)
-Koordinované zavedení kvality, environmentu a BOZP s jednotnou dokumentací a školením.</value>
+    <value>Integrovaný systém řízení (ISO 9001 + ISO 14001 + ISO 45001)&#x0a;Koordinované zavedení kvality, environmentu a BOZP s jednotnou dokumentací a školením.</value>
   </data>
   <data name="PackageLabAccreditation" xml:space="preserve">
-    <value>Akreditace laboratoře (ISO/IEC 17025)
-Podpora při nastavení laboratorních procesů, kalibrací a evidence tak, abyste splnili požadavky ČIA.</value>
+    <value>Akreditace laboratoře (ISO/IEC 17025)&#x0a;Podpora při nastavení laboratorních procesů, kalibrací a evidence tak, abyste splnili požadavky ČIA.</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- encode the package recommendation resources in the StepTraining partial with explicit newline separators so the title and blurb localize correctly in Czech and English
- confirm the parent page does not duplicate these keys, preventing divergence between page and partial resources

## Testing
- not run (localization-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e60a04fdb88321aef0c9bcd6f078ac