### PR TITLE
Revamp hero section styling on home page

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -5,22 +5,187 @@
     ViewData["Title"] = T["Title"];
 }
 
-@await Html.PartialAsync("_Hero", new HeroViewModel
-    {
-        Title = T["Home.Hero.Title"].Value,
-        Subtitle = T["Home.Hero.Subtitle"].Value,
-        PrimaryCta = T["Home.Hero.PrimaryCta"].Value,
-        SecondaryCta = T["Home.Hero.SecondaryCta"].Value,
-        SearchPlaceholder = T["Home.Hero.Search.Placeholder"].Value,
-        Chips = new()
-        {
-            T["Home.Hero.Chips.Online"].Value,
-            T["Home.Hero.Chips.Retraining"].Value,
-            T["Home.Hero.Chips.Certificate"].Value,
-            T["Home.Hero.Chips.Accreditation"].Value,
-            T["Home.Hero.Chips.InternalAudits"].Value
+<style>
+    .hero-gradient {
+        background: linear-gradient(135deg, #2563eb 0%, #06b6d4 55%, #f59e0b 130%);
+        color: #f8fafc;
+        position: relative;
+        overflow: hidden;
+    }
+
+    .hero-gradient::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.2), transparent 55%),
+            radial-gradient(circle at 20% 80%, rgba(15, 23, 42, 0.15), transparent 50%);
+        pointer-events: none;
+    }
+
+    .hero-content {
+        position: relative;
+        z-index: 1;
+    }
+
+    .hero-gradient-heading {
+        font-size: clamp(2.8rem, 4vw + 1rem, 4.75rem);
+        font-weight: 800;
+        line-height: 1.05;
+        background: linear-gradient(135deg, #f8fafc 10%, rgba(255, 255, 255, 0.82) 45%, #fde68a 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 1.5rem;
+    }
+
+    .hero-subheading {
+        font-size: clamp(1.125rem, 1.5vw + 0.75rem, 1.5rem);
+        font-weight: 500;
+        max-width: 44rem;
+        color: rgba(248, 250, 252, 0.9);
+    }
+
+    .hero-usp-card {
+        backdrop-filter: blur(18px);
+        background-color: rgba(15, 23, 42, 0.22);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 1rem;
+        color: #e2e8f0;
+        padding: 1rem 1.25rem;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.2);
+    }
+
+    .hero-usp-card i {
+        font-size: 1.75rem;
+        color: #fef3c7;
+    }
+
+    .hero-search {
+        background: rgba(15, 23, 42, 0.35);
+        border-radius: 1.5rem;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        padding: 1rem;
+        box-shadow: 0 25px 60px rgba(15, 23, 42, 0.25);
+        backdrop-filter: blur(12px);
+    }
+
+    .hero-search .form-control {
+        border-radius: 1rem;
+        border: 0;
+        padding: 0.95rem 1.2rem;
+        font-size: 1.05rem;
+    }
+
+    .hero-search .btn {
+        border-radius: 1rem;
+        padding-inline: 1.5rem;
+        font-weight: 600;
+    }
+
+    .hero-chips-wrapper {
+        position: relative;
+        z-index: 1;
+    }
+
+    .hero-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.55rem 1.25rem;
+        border-radius: 999px;
+        background-color: rgba(255, 255, 255, 0.32);
+        color: #0f172a;
+        font-weight: 500;
+        letter-spacing: 0.01em;
+        border: 1px solid rgba(255, 255, 255, 0.45);
+        transition: background-color 0.2s ease, transform 0.2s ease, color 0.2s ease;
+        backdrop-filter: blur(8px);
+    }
+
+    .hero-chip:hover,
+    .hero-chip:focus-visible {
+        background-color: rgba(255, 255, 255, 0.5);
+        color: #0f172a;
+        transform: translateY(-2px);
+        text-decoration: none;
+    }
+
+    @@media (max-width: 767.98px) {
+        .hero-usp-card {
+            text-align: center;
         }
-    })
+
+        .hero-search {
+            padding: 0.75rem;
+        }
+
+        .hero-search .btn {
+            width: 100%;
+        }
+    }
+</style>
+
+<section class="hero-gradient py-5">
+    <div class="container-xl hero-content">
+        <div class="row justify-content-between align-items-center g-5">
+            <div class="col-lg-7">
+                <h1 class="hero-gradient-heading">@T["HeroMainHeading"]</h1>
+                <p class="hero-subheading mb-4">@T["HeroSubheading"]</p>
+
+                <div class="row g-3 g-lg-4 mb-4 mb-lg-5">
+                    <div class="col-md-4">
+                        <div class="hero-usp-card h-100 d-flex align-items-start gap-3">
+                            <i class="bi bi-stars" aria-hidden="true"></i>
+                            <span>@T["HeroUSP1"]</span>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="hero-usp-card h-100 d-flex align-items-start gap-3">
+                            <i class="bi bi-mortarboard" aria-hidden="true"></i>
+                            <span>@T["HeroUSP2"]</span>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div class="hero-usp-card h-100 d-flex align-items-start gap-3">
+                            <i class="bi bi-shield-check" aria-hidden="true"></i>
+                            <span>@T["HeroUSP3"]</span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="d-flex flex-column flex-sm-row gap-3 mb-4">
+                    <a class="btn btn-lg btn-light text-primary fw-semibold shadow-sm" href="/Courses/Index">@T["HeroPrimaryCTA"]</a>
+                    <a class="btn btn-lg btn-outline-light fw-semibold" href="/About">@T["HeroSecondaryCTA"]</a>
+                </div>
+            </div>
+
+            <div class="col-lg-5">
+                <form class="hero-search" method="get" action="/Courses/Search" role="search">
+                    <label class="visually-hidden" for="hero-search-input">@T["HeroSearchLabel"]</label>
+                    <div class="d-flex flex-column flex-md-row gap-3">
+                        <input type="search"
+                               class="form-control form-control-lg flex-grow-1"
+                               id="hero-search-input"
+                               name="query"
+                               placeholder="@T["HeroSearchPlaceholder"]"
+                               aria-label="@T["HeroSearchAriaLabel"]">
+                        <button type="submit" class="btn btn-primary btn-lg flex-shrink-0">@T["HeroSubmit"]</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="hero-chips-wrapper mt-5">
+            <div class="d-flex flex-wrap gap-2 justify-content-center justify-content-lg-start">
+                <span class="hero-chip">@T["ChipOnline"]</span>
+                <span class="hero-chip">@T["ChipRetraining"]</span>
+                <span class="hero-chip">@T["ChipCertificate"]</span>
+                <span class="hero-chip">@T["ChipAccreditation"]</span>
+                <span class="hero-chip">@T["ChipInternalAudits"]</span>
+            </div>
+        </div>
+    </div>
+</section>
 
 <section class="container-xl mb-4">
     <div class="trust-stripe rounded-4 p-3">


### PR DESCRIPTION
## Summary
- replace the shared hero partial on the home page with an inline hero layout that uses the new gradient heading, USP icons, CTAs, and search bar copy
- add custom styling for the hero background, gradient text, USP cards, call-to-action buttons, and supporting chip list under the hero
- render the requested chip labels just below the hero content with translucent backgrounds and hover transitions

## Testing
- `dotnet run` *(fails: missing Microsoft.NETCore.App runtime 8.0.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e62fd140b483218856ebe5c0635f03