### PR TITLE
Fix Offline Razor Page activation failure

### DIFF
--- a/Pages/Offline.cshtml
+++ b/Pages/Offline.cshtml
@@ -1,5 +1,5 @@
 @page "/Offline"
-@model Microsoft.AspNetCore.Mvc.RazorPages.PageModel
+@model SysJaky_N.Pages.OfflineModel
 @{
     ViewData["Title"] = "Jste offline";
 }

--- a/Pages/Offline.cshtml.cs
+++ b/Pages/Offline.cshtml.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace SysJaky_N.Pages
+{
+    public class OfflineModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `OfflineModel` page model for the offline page so Razor can instantiate it
- point `Offline.cshtml` at the new strongly typed model instead of the abstract base type

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e62ffed5dc8321a30aeae961716c6c