### PR TITLE
Ensure SharedResource marker class uses resource namespace

### DIFF
--- a/Resources/SharedResource.cs
+++ b/Resources/SharedResource.cs
@@ -1,3 +1,8 @@
-namespace SysJaky_N;
+namespace SysJaky_N.Resources;
 
-public class SharedResource { }
+/// <summary>
+/// Marker class for IStringLocalizer. This is NOT a static class.
+/// </summary>
+public class SharedResource
+{
+}


### PR DESCRIPTION
## Summary
- ensure the SharedResource marker class resides under the SysJaky_N.Resources namespace
- add an XML summary clarifying its use for IStringLocalizer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e636b5d55c8321b350d0bf7fe7d727