### PR TITLE
Fix duplicate embedded resource entry in project file

### DIFF
--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -34,12 +34,6 @@
     <PackageReference Include="WebPush" Version="1.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
-
-
-  <ItemGroup>
-    <EmbeddedResource Include="Resources/**/*.resx" />
-  </ItemGroup>
-
   <ItemGroup>
     <Content Update="EmailTemplates/**/*.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## Summary
- remove the duplicate EmbeddedResource item group from the project file so resources are only included once

## Testing
- DOTNET_CLI_DISABLE_TERMINAL_LOGGER=1 dotnet build SysJaky_N.csproj -p:NpmSkipStaticAssets=true

------
https://chatgpt.com/codex/tasks/task_e_68e6491ba9988321b4693344fa67098e