### PR TITLE
Configure resx metadata without duplicating includes

### DIFF
--- a/SysJaky_N.csproj
+++ b/SysJaky_N.csproj
@@ -14,6 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Resources/**/*.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>%(FileName).Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Ixnas.AltchaNet" Version="1.1.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageReference Include="ClosedXML" Version="0.102.2" />
@@ -34,12 +41,6 @@
     <PackageReference Include="WebPush" Version="1.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
-
-
-  <ItemGroup>
-    <EmbeddedResource Include="Resources/**/*.resx" />
-  </ItemGroup>
-
   <ItemGroup>
     <Content Update="EmailTemplates/**/*.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## Summary
- keep the wildcard resx ItemGroup and convert the additional group to Update so it augments metadata without re-adding the items

## Testing
- DOTNET_CLI_DISABLE_TERMINAL_LOGGER=1 dotnet build SysJaky_N.csproj -p:NpmSkipStaticAssets=true

------
https://chatgpt.com/codex/tasks/task_e_68e6491ba9988321b4693344fa67098e