### PR TITLE
Modernize CSS theme variables and utilities

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -11,7 +11,7 @@ html {
 }
 
 :root {
-  /* Friendly Academia brand */
+  /* Moderní barevná paleta */
   --primary: #2563eb;
   --primary-dark: #1d4ed8;
   --primary-light: #60a5fa;
@@ -19,12 +19,17 @@ html {
   --primary-50: #eef2ff;
 
   --accent: #06b6d4;
-  --accent-dark: #0e7490;
+  --accent-dark: #0891b2;
   --accent-ink: #0f172a;
-  --accent-600: #0e7490;
+  --accent-600: #0891b2;
   --warning: #f59e0b;
 
   --ink: #0f172a;
+
+  /* Gradienty */
+  --gradient-primary: linear-gradient(135deg, #2563eb 0%, #06b6d4 55%, #f59e0b 130%);
+  --gradient-hero: radial-gradient(1200px 400px at 50% -120px, rgba(255, 255, 255, 0.12), transparent),
+    linear-gradient(135deg, #2563eb 0%, #06b6d4 55%, #f59e0b 130%);
 
   /* Neutral palette */
   --neutral-900: #0f172a;
@@ -38,9 +43,20 @@ html {
 
   --surface: #ffffff;
   --background: #f8fafc;
-  --radius-lg: 1.25rem;
-  --radius-xl: 1.5rem;
-  --shadow-soft: 0 32px 64px rgba(37, 99, 235, 0.12);
+
+  /* Rádiusy */
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+  --radius-2xl: 1.5rem;
+
+  /* Stíny */
+  --shadow-sm: 0 2px 8px rgba(37, 99, 235, 0.08);
+  --shadow-md: 0 8px 24px rgba(37, 99, 235, 0.12);
+  --shadow-lg: 0 16px 48px rgba(37, 99, 235, 0.15);
+  --shadow-xl: 0 24px 64px rgba(37, 99, 235, 0.18);
+  --shadow-soft: 0 16px 48px rgba(37, 99, 235, 0.15);
 
   /* Bootstrap CSS variables (override) */
   --bs-body-font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
@@ -81,10 +97,7 @@ html {
 body {
   margin: 0;
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  background-color: var(--background);
-  background-image:
-    radial-gradient(60% 40% at 10% 10%, rgba(37, 99, 235, 0.08), transparent 65%),
-    radial-gradient(45% 35% at 80% 0%, rgba(6, 182, 212, 0.08), transparent 70%);
+  background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
   color: var(--neutral-700);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
@@ -149,6 +162,19 @@ small {
   transform: translateY(0);
   outline: 3px solid rgba(255, 255, 255, 0.85);
   outline-offset: 2px;
+}
+
+/* Gradient & shadow utilities */
+.gradient-blue-cyan {
+  background: linear-gradient(125deg, rgba(37, 99, 235, 0.95) 0%, rgba(6, 182, 212, 0.9) 100%);
+}
+
+.gradient-stats {
+  background: linear-gradient(to right, #2563eb, #06b6d4);
+}
+
+.shadow-modern {
+  box-shadow: 0 8px 32px rgba(37, 99, 235, 0.15);
 }
 
 .visually-hidden-focusable:not(:focus):not(:focus-within) {


### PR DESCRIPTION
## Summary
- refresh root CSS variables with modern palette, gradients, and updated radii and shadows
- switch the body background to a soft blue gradient for a lighter default appearance
- add reusable gradient and shadow utility classes for future styling needs

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e653219df08321a435a42a5b8fd02d