### PR TITLE
Use https-Production launch profile

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -18,13 +18,13 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "https": {
+    "https-Production": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7130;http://localhost:5257",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Production"
       }
     },
     "IIS Express": {


### PR DESCRIPTION
## Summary
- switch the default https launch profile to https-Production
- ensure the production environment variables are used when launching via Visual Studio

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e654ff5d44832196bf41d207e40e52