### PR TITLE
Add ISO standards section to homepage

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -292,6 +292,11 @@
         margin-bottom: 0;
     }
 
+    .hover-lift:hover {
+        transform: translateY(-4px);
+        box-shadow: 0 12px 24px rgba(37, 99, 235, 0.15) !important;
+    }
+
     @@media (max-width: 575.98px) {
         .specialization-card {
             text-align: center;
@@ -371,6 +376,161 @@
                 <span class="hero-chip">@T["ChipAccreditation"]</span>
                 <span class="hero-chip">@T["ChipInternalAudits"]</span>
             </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5 mb-5">
+    <div class="container-xl">
+
+        <!-- Nadpis sekce -->
+        <div class="text-center mb-5">
+            <h2 class="display-5 fw-bold mb-3" style="color: #2563eb;">
+                Naše specializace
+            </h2>
+            <p class="lead text-muted">
+                Poskytujeme komplexní poradenství a školení pro následující normy
+            </p>
+        </div>
+
+        <!-- Grid s ISO normami -->
+        <div class="row g-4">
+
+            <!-- ISO 9001 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);">
+                                <i class="bi bi-award-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 9001</h3>
+                        </div>
+                        <p class="text-muted mb-0">Systém managementu kvality</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ISO 14001 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #10b981 0%, #34d399 100%);">
+                                <i class="bi bi-tree-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 14001</h3>
+                        </div>
+                        <p class="text-muted mb-0">Environmentální management</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ISO 17025 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%);">
+                                <i class="bi bi-clipboard-data-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 17025</h3>
+                        </div>
+                        <p class="text-muted mb-0">Akreditace laboratoří</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ISO 15189 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #ef4444 0%, #f87171 100%);">
+                                <i class="bi bi-hospital-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 15189</h3>
+                        </div>
+                        <p class="text-muted mb-0">Zdravotnické laboratoře</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- HACCP -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%);">
+                                <i class="bi bi-egg-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">HACCP</h3>
+                        </div>
+                        <p class="text-muted mb-0">Bezpečnost potravin</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ISO 45001 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #eab308 0%, #facc15 100%);">
+                                <i class="bi bi-shield-fill-check text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 45001</h3>
+                        </div>
+                        <p class="text-muted mb-0">Bezpečnost práce</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ISO 27001 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #6366f1 0%, #818cf8 100%);">
+                                <i class="bi bi-shield-lock-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 27001</h3>
+                        </div>
+                        <p class="text-muted mb-0">Informační bezpečnost</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- IATF 16949 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #475569 0%, #64748b 100%);">
+                                <i class="bi bi-car-front-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">IATF 16949</h3>
+                        </div>
+                        <p class="text-muted mb-0">Automobilový průmysl</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ISO 13485 -->
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                    <div class="card-body p-4">
+                        <div class="d-flex align-items-center mb-3">
+                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #ec4899 0%, #f472b6 100%);">
+                                <i class="bi bi-heart-pulse-fill text-white" style="font-size: 1.5rem;"></i>
+                            </div>
+                            <h3 class="h4 mb-0 fw-bold">ISO 13485</h3>
+                        </div>
+                        <p class="text-muted mb-0">Zdravotnické prostředky</p>
+                    </div>
+                </div>
+            </div>
+
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add an ISO standards section after the hero on the home page to highlight key certifications
- include a hover lift effect for the new cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65722391c8321867309162c4702e9