### PR TITLE
Add statistics section before footer

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -153,6 +153,42 @@
         </main>
     </div>
 
+    <section class="py-5 my-5" style="background: linear-gradient(to right, #2563eb, #06b6d4); border-radius: 1.5rem;">
+        <div class="container-xl">
+            <div class="row g-4 text-center text-white">
+
+                <div class="col-6 col-md-3">
+                    <div class="p-3">
+                        <div class="display-3 fw-bold mb-2">20+</div>
+                        <div style="opacity: 0.9; font-size: 0.95rem;">Let zkušeností</div>
+                    </div>
+                </div>
+
+                <div class="col-6 col-md-3">
+                    <div class="p-3">
+                        <div class="display-3 fw-bold mb-2">500+</div>
+                        <div style="opacity: 0.9; font-size: 0.95rem;">Spokojených klientů</div>
+                    </div>
+                </div>
+
+                <div class="col-6 col-md-3">
+                    <div class="p-3">
+                        <div class="display-3 fw-bold mb-2">2000+</div>
+                        <div style="opacity: 0.9; font-size: 0.95rem;">Realizovaných školení</div>
+                    </div>
+                </div>
+
+                <div class="col-6 col-md-3">
+                    <div class="p-3">
+                        <div class="display-3 fw-bold mb-2">15</div>
+                        <div style="opacity: 0.9; font-size: 0.95rem;">Certifikovaných lektorů</div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </section>
+
     <footer class="footer app-footer mt-5 bg-gray-900 text-white" role="contentinfo">
         <div class="container-xxl py-5">
             <div class="row gy-4">


### PR DESCRIPTION
## Summary
- insert a gradient statistics section ahead of the site footer in the shared layout to highlight key company metrics

## Testing
- dotnet run --project SysJaky_N.csproj --urls http://0.0.0.0:5000 *(fails: required .NET 8.0 runtime is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e6572c84c483219b118d19e15f61a1