### PR TITLE
Localize calendar page

### DIFF
--- a/Pages/Calendar/Index.cshtml
+++ b/Pages/Calendar/Index.cshtml
@@ -1,41 +1,42 @@
 @page
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = "Kalendář kurzů";
+    ViewData["Title"] = Localizer["Title"];
 }
 
 <div class="row g-4">
     <div class="col-lg-3">
         <div class="card shadow-sm border-0">
             <div class="card-header bg-white">
-                <h2 class="h5 mb-0">Filtry</h2>
+                <h2 class="h5 mb-0">@Localizer["FiltersHeading"]</h2>
             </div>
             <div class="card-body">
                 <form id="calendarFilters" class="vstack gap-3" novalidate>
                     <div>
-                        <label class="form-label" for="normFilter">Norma</label>
+                        <label class="form-label" for="normFilter">@Localizer["NormLabel"]</label>
                         <select class="form-select" id="normFilter" data-filter="norms" multiple size="6" aria-describedby="normFilterHelp">
                         </select>
-                        <div id="normFilterHelp" class="form-text">Vyberte jednu nebo více norem ISO.</div>
+                        <div id="normFilterHelp" class="form-text">@Localizer["NormHelp"]</div>
                     </div>
                     <div>
-                        <label class="form-label" for="cityFilter">Město</label>
+                        <label class="form-label" for="cityFilter">@Localizer["CityLabel"]</label>
                         <select class="form-select" id="cityFilter" data-filter="cities" multiple size="6" aria-describedby="cityFilterHelp">
                         </select>
-                        <div id="cityFilterHelp" class="form-text">Filtrovat dle místa konání.</div>
+                        <div id="cityFilterHelp" class="form-text">@Localizer["CityHelp"]</div>
                     </div>
                     <div>
-                        <label class="form-label" for="modeFilter">Režim</label>
+                        <label class="form-label" for="modeFilter">@Localizer["ModeLabel"]</label>
                         <select class="form-select" id="modeFilter" data-filter="types" multiple size="5" aria-describedby="modeFilterHelp">
                         </select>
-                        <div id="modeFilterHelp" class="form-text">Můžete kombinovat více režimů.</div>
+                        <div id="modeFilterHelp" class="form-text">@Localizer["ModeHelp"]</div>
                     </div>
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" value="true" id="availableFilter" data-filter="onlyAvailable" />
-                        <label class="form-check-label" for="availableFilter">Pouze volná místa</label>
+                        <label class="form-check-label" for="availableFilter">@Localizer["AvailableOnlyLabel"]</label>
                     </div>
                     <div class="d-flex justify-content-between align-items-center">
                         <span class="text-muted small" data-filter="summary"></span>
-                        <button type="button" class="btn btn-link btn-sm p-0" data-filter="reset">Vymazat</button>
+                        <button type="button" class="btn btn-link btn-sm p-0" data-filter="reset">@Localizer["ResetFilters"]</button>
                     </div>
                 </form>
             </div>
@@ -45,27 +46,27 @@
         <div class="card shadow-sm border-0" data-calendar>
             <div class="card-header bg-white d-flex flex-wrap gap-3 align-items-center justify-content-between">
                 <div class="d-flex align-items-center gap-2">
-                    <button type="button" class="btn btn-outline-secondary" data-calendar-nav="prev" aria-label="Předchozí">&larr;</button>
-                    <button type="button" class="btn btn-outline-secondary" data-calendar-nav="today">Dnes</button>
-                    <button type="button" class="btn btn-outline-secondary" data-calendar-nav="next" aria-label="Další">&rarr;</button>
+                    <button type="button" class="btn btn-outline-secondary" data-calendar-nav="prev" aria-label='@Localizer["PrevAriaLabel"]'>&larr;</button>
+                    <button type="button" class="btn btn-outline-secondary" data-calendar-nav="today">@Localizer["TodayButton"]</button>
+                    <button type="button" class="btn btn-outline-secondary" data-calendar-nav="next" aria-label='@Localizer["NextAriaLabel"]'>&rarr;</button>
                     <h1 class="h4 mb-0" data-calendar-title></h1>
                 </div>
-                <div class="btn-group" role="group" aria-label="Změna zobrazení">
-                    <button type="button" class="btn btn-outline-primary active" data-calendar-view="month">Měsíc</button>
-                    <button type="button" class="btn btn-outline-primary" data-calendar-view="week">Týden</button>
-                    <button type="button" class="btn btn-outline-primary" data-calendar-view="day">Den</button>
+                <div class="btn-group" role="group" aria-label='@Localizer["ViewToggleAriaLabel"]'>
+                    <button type="button" class="btn btn-outline-primary active" data-calendar-view="month">@Localizer["MonthView"]</button>
+                    <button type="button" class="btn btn-outline-primary" data-calendar-view="week">@Localizer["WeekView"]</button>
+                    <button type="button" class="btn btn-outline-primary" data-calendar-view="day">@Localizer["DayView"]</button>
                 </div>
             </div>
             <div class="card-body">
                 <div class="d-flex flex-column gap-3">
                     <div class="alert alert-info d-none" role="status" data-calendar-loading>
-                        Načítám termíny…
+                        @Localizer["LoadingAlert"]
                     </div>
                     <div class="alert alert-danger d-none" role="status" data-calendar-error>
-                        Nepodařilo se načíst data. Zkuste to prosím znovu.
+                        @Localizer["ErrorAlert"]
                     </div>
                     <div class="alert alert-warning d-none" role="status" data-calendar-empty>
-                        Pro zadané filtry nebyly nalezeny žádné termíny.
+                        @Localizer["EmptyAlert"]
                     </div>
                     <div class="table-responsive" data-calendar-container>
                     </div>

--- a/Resources/Pages.Calendar.Index.cshtml.en.resx
+++ b/Resources/Pages.Calendar.Index.cshtml.en.resx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Course calendar</value>
+  </data>
+  <data name="FiltersHeading" xml:space="preserve">
+    <value>Filters</value>
+  </data>
+  <data name="NormLabel" xml:space="preserve">
+    <value>Standard</value>
+  </data>
+  <data name="NormHelp" xml:space="preserve">
+    <value>Select one or more ISO standards.</value>
+  </data>
+  <data name="CityLabel" xml:space="preserve">
+    <value>City</value>
+  </data>
+  <data name="CityHelp" xml:space="preserve">
+    <value>Filter by event location.</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Mode</value>
+  </data>
+  <data name="ModeHelp" xml:space="preserve">
+    <value>You can combine multiple modes.</value>
+  </data>
+  <data name="AvailableOnlyLabel" xml:space="preserve">
+    <value>Only available seats</value>
+  </data>
+  <data name="ResetFilters" xml:space="preserve">
+    <value>Clear</value>
+  </data>
+  <data name="PrevAriaLabel" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="TodayButton" xml:space="preserve">
+    <value>Today</value>
+  </data>
+  <data name="NextAriaLabel" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="ViewToggleAriaLabel" xml:space="preserve">
+    <value>Change view</value>
+  </data>
+  <data name="MonthView" xml:space="preserve">
+    <value>Month</value>
+  </data>
+  <data name="WeekView" xml:space="preserve">
+    <value>Week</value>
+  </data>
+  <data name="DayView" xml:space="preserve">
+    <value>Day</value>
+  </data>
+  <data name="LoadingAlert" xml:space="preserve">
+    <value>Loading sessions…</value>
+  </data>
+  <data name="ErrorAlert" xml:space="preserve">
+    <value>Failed to load data. Please try again.</value>
+  </data>
+  <data name="EmptyAlert" xml:space="preserve">
+    <value>No sessions were found for the selected filters.</value>
+  </data>
+</root>

--- a/Resources/Pages.Calendar.Index.cshtml.resx
+++ b/Resources/Pages.Calendar.Index.cshtml.resx
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Kalendář kurzů</value>
+  </data>
+  <data name="FiltersHeading" xml:space="preserve">
+    <value>Filtry</value>
+  </data>
+  <data name="NormLabel" xml:space="preserve">
+    <value>Norma</value>
+  </data>
+  <data name="NormHelp" xml:space="preserve">
+    <value>Vyberte jednu nebo více norem ISO.</value>
+  </data>
+  <data name="CityLabel" xml:space="preserve">
+    <value>Město</value>
+  </data>
+  <data name="CityHelp" xml:space="preserve">
+    <value>Filtrovat dle místa konání.</value>
+  </data>
+  <data name="ModeLabel" xml:space="preserve">
+    <value>Režim</value>
+  </data>
+  <data name="ModeHelp" xml:space="preserve">
+    <value>Můžete kombinovat více režimů.</value>
+  </data>
+  <data name="AvailableOnlyLabel" xml:space="preserve">
+    <value>Pouze volná místa</value>
+  </data>
+  <data name="ResetFilters" xml:space="preserve">
+    <value>Vymazat</value>
+  </data>
+  <data name="PrevAriaLabel" xml:space="preserve">
+    <value>Předchozí</value>
+  </data>
+  <data name="TodayButton" xml:space="preserve">
+    <value>Dnes</value>
+  </data>
+  <data name="NextAriaLabel" xml:space="preserve">
+    <value>Další</value>
+  </data>
+  <data name="ViewToggleAriaLabel" xml:space="preserve">
+    <value>Změna zobrazení</value>
+  </data>
+  <data name="MonthView" xml:space="preserve">
+    <value>Měsíc</value>
+  </data>
+  <data name="WeekView" xml:space="preserve">
+    <value>Týden</value>
+  </data>
+  <data name="DayView" xml:space="preserve">
+    <value>Den</value>
+  </data>
+  <data name="LoadingAlert" xml:space="preserve">
+    <value>Načítám termíny…</value>
+  </data>
+  <data name="ErrorAlert" xml:space="preserve">
+    <value>Nepodařilo se načíst data. Zkuste to prosím znovu.</value>
+  </data>
+  <data name="EmptyAlert" xml:space="preserve">
+    <value>Pro zadané filtry nebyly nalezeny žádné termíny.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- inject the view localizer into the calendar page and replace hard-coded Czech text with localized lookups
- add Czech default and English resource files for the calendar page covering all UI labels and alerts

## Testing
- dotnet build SysJaky_N.csproj -v minimal /p:NpmSkipStaticAssets=true

------
https://chatgpt.com/codex/tasks/task_e_68e658c977cc8321adbad0f3f2ee6f55