### PR TITLE
Localize offline page content

### DIFF
--- a/Pages/Offline.cshtml
+++ b/Pages/Offline.cshtml
@@ -1,21 +1,19 @@
 @page "/Offline"
 @model SysJaky_N.Pages.OfflineModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
-    ViewData["Title"] = "Jste offline";
+    ViewData["Title"] = Localizer["Title"];
 }
 
 <section class="pwa-offline">
     <div class="pwa-offline__content">
-        <h1>Jste offline</h1>
-        <p>
-            Vypadá to, že nemáte připojení k internetu. Nejnovější uložené informace o kurzech jsou stále dostupné,
-            ale některé funkce, jako je nákup nebo přihlášení na kurz, budou dostupné po opětovném připojení.
-        </p>
+        <h1>@Localizer["Heading"]</h1>
+        <p>@Localizer["Message"]</p>
         <ul>
-            <li>Prohlížejte si dříve otevřené kurzy a články.</li>
-            <li>Vyplněné formuláře odešleme automaticky, jakmile budete online.</li>
-            <li>Pro plnohodnotný zážitek zkuste obnovit stránku po obnovení připojení.</li>
+            <li>@Localizer["ListItem1"]</li>
+            <li>@Localizer["ListItem2"]</li>
+            <li>@Localizer["ListItem3"]</li>
         </ul>
-        <a class="btn btn-primary" href="/">Zpět na úvodní stránku</a>
+        <a class="btn btn-primary" href="/">@Localizer["BackHome"]</a>
     </div>
 </section>

--- a/Resources/Pages.Offline.cshtml.en.resx
+++ b/Resources/Pages.Offline.cshtml.en.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>You're offline</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>You're offline</value>
+  </data>
+  <data name="Message" xml:space="preserve">
+    <value>It looks like you aren't connected to the internet. The latest saved course information is still available, but some features, such as purchasing or enrolling in a course, will be ready once you're back online.</value>
+  </data>
+  <data name="ListItem1" xml:space="preserve">
+    <value>Browse courses and articles you opened earlier.</value>
+  </data>
+  <data name="ListItem2" xml:space="preserve">
+    <value>We'll submit completed forms automatically as soon as you're online.</value>
+  </data>
+  <data name="ListItem3" xml:space="preserve">
+    <value>For the full experience, try refreshing the page after your connection is restored.</value>
+  </data>
+  <data name="BackHome" xml:space="preserve">
+    <value>Back to homepage</value>
+  </data>
+</root>

--- a/Resources/Pages.Offline.cshtml.resx
+++ b/Resources/Pages.Offline.cshtml.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Jste offline</value>
+  </data>
+  <data name="Heading" xml:space="preserve">
+    <value>Jste offline</value>
+  </data>
+  <data name="Message" xml:space="preserve">
+    <value>Vypadá to, že nemáte připojení k internetu. Nejnovější uložené informace o kurzech jsou stále dostupné, ale některé funkce, jako je nákup nebo přihlášení na kurz, budou dostupné po opětovném připojení.</value>
+  </data>
+  <data name="ListItem1" xml:space="preserve">
+    <value>Prohlížejte si dříve otevřené kurzy a články.</value>
+  </data>
+  <data name="ListItem2" xml:space="preserve">
+    <value>Vyplněné formuláře odešleme automaticky, jakmile budete online.</value>
+  </data>
+  <data name="ListItem3" xml:space="preserve">
+    <value>Pro plnohodnotný zážitek zkuste obnovit stránku po obnovení připojení.</value>
+  </data>
+  <data name="BackHome" xml:space="preserve">
+    <value>Zpět na úvodní stránku</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- inject the view localizer into the offline Razor page and use it for the title, message, list, and button text
- add Czech and English resource files for the offline page content

## Testing
- ⚠️ `dotnet build /p:NpmSkipStaticAssets=true` *(hangs because the build triggers npm asset bundling in this environment, so the command was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e658d9578883218aa0eebf3ef7e3e4