### PR TITLE
Localize chatbot and newsletter API pages

### DIFF
--- a/Pages/Api/Chatbot.cshtml
+++ b/Pages/Api/Chatbot.cshtml
@@ -1,9 +1,10 @@
 @page "{handler?}"
 @model SysJaky_N.Pages.Api.ChatbotModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
     Layout = null;
 }
 
 <section class="container-xl py-5">
-    <p class="text-muted">Tento endpoint poskytuje API pro firemního chatbota.</p>
+    <p class="text-muted">@Localizer["Description"]</p>
 </section>

--- a/Pages/Api/Newsletter.cshtml
+++ b/Pages/Api/Newsletter.cshtml
@@ -1,9 +1,14 @@
 @page "{handler?}"
 @model SysJaky_N.Pages.Api.NewsletterModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
 @{
     if (Model.ShowConfirmationResult)
     {
         ViewData["Title"] = Model.ConfirmationTitle;
+    }
+    else
+    {
+        ViewData["Title"] = Localizer["Title"].Value;
     }
 }
 
@@ -17,6 +22,6 @@
 else
 {
     <section class="container-xl py-5">
-        <p class="text-muted">Tento endpoint slouží pro newsletter API.</p>
+        <p class="text-muted">@Localizer["Description"]</p>
     </section>
 }

--- a/Resources/Pages.Api.Chatbot.cshtml.en.resx
+++ b/Resources/Pages.Api.Chatbot.cshtml.en.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Description" xml:space="preserve">
+    <value>This endpoint provides the API for the company chatbot.</value>
+  </data>
+</root>

--- a/Resources/Pages.Api.Chatbot.cshtml.resx
+++ b/Resources/Pages.Api.Chatbot.cshtml.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Description" xml:space="preserve">
+    <value>Tento endpoint poskytuje API pro firemního chatbota.</value>
+  </data>
+</root>

--- a/Resources/Pages.Api.Newsletter.cshtml.en.resx
+++ b/Resources/Pages.Api.Newsletter.cshtml.en.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Newsletter API</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>This endpoint serves as the newsletter API.</value>
+  </data>
+</root>

--- a/Resources/Pages.Api.Newsletter.cshtml.resx
+++ b/Resources/Pages.Api.Newsletter.cshtml.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Newsletter API</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Tento endpoint slouží pro newsletter API.</value>
+  </data>
+</root>

--- a/Resources/Pages.Api.NewsletterModel.cs.en.resx
+++ b/Resources/Pages.Api.NewsletterModel.cs.en.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Validation.Email.Invalid" xml:space="preserve">
+    <value>Please enter a valid email address.</value>
+  </data>
+  <data name="Validation.Consent.Required" xml:space="preserve">
+    <value>Consent is required to subscribe to the newsletter.</value>
+  </data>
+  <data name="Json.AlreadySubscribed" xml:space="preserve">
+    <value>This email address is already subscribed.</value>
+  </data>
+  <data name="Json.ConfirmationEmailSent" xml:space="preserve">
+    <value>Thank you! We've sent a confirmation email.</value>
+  </data>
+  <data name="Confirmation.DefaultTitle" xml:space="preserve">
+    <value>Subscription confirmation</value>
+  </data>
+  <data name="Confirmation.InvalidLink" xml:space="preserve">
+    <value>The link is invalid. Please try again.</value>
+  </data>
+  <data name="Confirmation.InvalidOrExpired" xml:space="preserve">
+    <value>The link is invalid or has expired.</value>
+  </data>
+  <data name="Confirmation.AlreadyConfirmed" xml:space="preserve">
+    <value>The subscription for this email address has already been confirmed.</value>
+  </data>
+  <data name="Confirmation.CompletedTitle" xml:space="preserve">
+    <value>Confirmation completed</value>
+  </data>
+  <data name="Confirmation.CompletedMessage" xml:space="preserve">
+    <value>Thank you, your newsletter subscription has been successfully confirmed.</value>
+  </data>
+</root>

--- a/Resources/Pages.Api.NewsletterModel.cs.resx
+++ b/Resources/Pages.Api.NewsletterModel.cs.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Validation.Email.Invalid" xml:space="preserve">
+    <value>Zadejte platný e-mail.</value>
+  </data>
+  <data name="Validation.Consent.Required" xml:space="preserve">
+    <value>Pro přihlášení k newsletteru je nutný souhlas.</value>
+  </data>
+  <data name="Json.AlreadySubscribed" xml:space="preserve">
+    <value>Tento e-mail je již přihlášen k odběru.</value>
+  </data>
+  <data name="Json.ConfirmationEmailSent" xml:space="preserve">
+    <value>Děkujeme! Odeslali jsme potvrzovací e-mail.</value>
+  </data>
+  <data name="Confirmation.DefaultTitle" xml:space="preserve">
+    <value>Potvrzení odběru</value>
+  </data>
+  <data name="Confirmation.InvalidLink" xml:space="preserve">
+    <value>Odkaz je neplatný. Zkuste to prosím znovu.</value>
+  </data>
+  <data name="Confirmation.InvalidOrExpired" xml:space="preserve">
+    <value>Odkaz je neplatný nebo již vypršel.</value>
+  </data>
+  <data name="Confirmation.AlreadyConfirmed" xml:space="preserve">
+    <value>Odběr tohoto e-mailu byl již potvrzen.</value>
+  </data>
+  <data name="Confirmation.CompletedTitle" xml:space="preserve">
+    <value>Potvrzení dokončeno</value>
+  </data>
+  <data name="Confirmation.CompletedMessage" xml:space="preserve">
+    <value>Děkujeme, váš odběr newsletteru byl úspěšně potvrzen.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- inject view localizers into the chatbot and newsletter API Razor pages and move literal text into resources
- add localized resource files for both Czech and English for the chatbot and newsletter API pages and page model
- use an IStringLocalizer in the newsletter page model so HTML and JSON responses surface localized validation and confirmation messages

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e658d95d988321a6b75f0e569159ae