### PR TITLE
Localize shared marketing partials

### DIFF
--- a/Pages/Shared/_Chatbot.cshtml
+++ b/Pages/Shared/_Chatbot.cshtml
@@ -1,41 +1,54 @@
+@using System.Text.Json
 @model SysJaky_N.Models.ViewModels.ChatbotWidgetViewModel
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+@{
+    var serializerOptions = new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    var quickRepliesJson = Localizer["QuickRepliesJson"].Value;
+    var quickReplies = JsonSerializer.Deserialize<string[]>(quickRepliesJson ?? "[]", serializerOptions) ?? Array.Empty<string>();
+}
 
 <div class="chatbot" data-chatbot data-chatbot-autoinit="@(Model.AutoInitialize ? "true" : "false")">
     <button type="button" class="chatbot-toggle" data-chatbot-toggle aria-haspopup="dialog" aria-expanded="false" aria-controls="chatbot-panel">
-        <span class="visually-hidden">Otevřít chat s virtuálním poradcem</span>
+        <span class="visually-hidden">@Localizer["ToggleLabel"]</span>
         <i class="bi bi-chat-dots"></i>
     </button>
-    <div class="chatbot-panel" id="chatbot-panel" role="dialog" aria-modal="false" aria-label="Virtuální poradce" hidden>
+    <div class="chatbot-panel" id="chatbot-panel" role="dialog" aria-modal="false" aria-label="@Localizer["PanelAriaLabel"]" hidden>
         <div class="chatbot-header">
             <div class="chatbot-header-text">
-                <h2 class="chatbot-title">Virtuální poradce</h2>
-                <p class="chatbot-subtitle">Rád poradím s výběrem vhodného kurzu.</p>
+                <h2 class="chatbot-title">@Localizer["Title"]</h2>
+                <p class="chatbot-subtitle">@Localizer["Subtitle"]</p>
             </div>
-            <button type="button" class="chatbot-close" data-chatbot-close aria-label="Zavřít chat">
+            <button type="button" class="chatbot-close" data-chatbot-close aria-label="@Localizer["CloseLabel"]">
                 <i class="bi bi-x"></i>
             </button>
         </div>
         <div class="chatbot-body">
             <div class="chatbot-messages" data-chatbot-messages role="log" aria-live="polite" tabindex="0"></div>
-            <div class="chatbot-quick-replies" data-chatbot-quick-replies role="group" aria-label="Rychlé dotazy">
-                <button type="button" class="chatbot-quick-reply" data-quick-reply="Hledám školení pro ISO 9001">Hledám školení pro ISO 9001</button>
-                <button type="button" class="chatbot-quick-reply" data-quick-reply="Kdy začíná nejbližší kurz?">Kdy začíná nejbližší kurz?</button>
-                <button type="button" class="chatbot-quick-reply" data-quick-reply="Kolik to stojí?">Kolik to stojí?</button>
+            <div class="chatbot-quick-replies" data-chatbot-quick-replies role="group" aria-label="@Localizer["QuickRepliesAriaLabel"]">
+                @foreach (var reply in quickReplies)
+                {
+                    <button type="button" class="chatbot-quick-reply" data-quick-reply="@reply">@reply</button>
+                }
             </div>
             <form class="chatbot-form" data-chatbot-form novalidate>
-                <label class="visually-hidden" for="chatbot-input">Vaše zpráva</label>
-                <input id="chatbot-input" class="chatbot-input" type="text" name="message" placeholder="Napište dotaz..." autocomplete="off" required />
+                <label class="visually-hidden" for="chatbot-input">@Localizer["MessageLabel"]</label>
+                <input id="chatbot-input" class="chatbot-input" type="text" name="message" placeholder="@Localizer["MessagePlaceholder"]" autocomplete="off" required />
                 <button type="submit" class="chatbot-send">
-                    <span>Odeslat</span>
+                    <span>@Localizer["SendButton"]</span>
                 </button>
             </form>
-            <button type="button" class="chatbot-escalate" data-chatbot-escalate>Potřebuji mluvit s člověkem</button>
+            <button type="button" class="chatbot-escalate" data-chatbot-escalate>@Localizer["EscalateButton"]</button>
             <form class="chatbot-escalate-form" data-chatbot-escalate-form hidden novalidate>
-                <p class="chatbot-escalate-description">Vyplňte prosím e-mail, kolega se vám ozve co nejdříve.</p>
-                <label class="chatbot-label" for="chatbot-escalate-email">E-mail</label>
-                <input id="chatbot-escalate-email" class="chatbot-input" type="email" name="email" placeholder="vas@email.cz" autocomplete="email" required />
-                <button type="submit" class="chatbot-send">Odeslat požadavek</button>
-                <button type="button" class="chatbot-cancel-escalation" data-chatbot-cancel-escalation>Zavřít</button>
+                <p class="chatbot-escalate-description">@Localizer["EscalateDescription"]</p>
+                <label class="chatbot-label" for="chatbot-escalate-email">@Localizer["EscalateEmailLabel"]</label>
+                <input id="chatbot-escalate-email" class="chatbot-input" type="email" name="email" placeholder="@Localizer["EscalateEmailPlaceholder"]" autocomplete="email" required />
+                <button type="submit" class="chatbot-send">@Localizer["EscalateSubmit"]</button>
+                <button type="button" class="chatbot-cancel-escalation" data-chatbot-cancel-escalation>@Localizer["EscalateCancel"]</button>
             </form>
         </div>
     </div>

--- a/Pages/Shared/_FAQ.cshtml
+++ b/Pages/Shared/_FAQ.cshtml
@@ -1,4 +1,25 @@
+@using System.Collections.Generic
+@using System.Text.Json
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+@functions {
+    private sealed record FaqCategory(string Key, string Label);
+
+    private sealed record FaqItem(string Category, string Question, string Answer, bool Expanded);
+}
+
 @{
+    var serializerOptions = new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    var categoriesJson = Localizer["CategoriesJson"].Value;
+    var faqCategories = JsonSerializer.Deserialize<List<FaqCategory>>(categoriesJson ?? "[]", serializerOptions) ?? new List<FaqCategory>();
+
+    var faqItemsJson = Localizer["FaqItemsJson"].Value;
+    var faqItems = JsonSerializer.Deserialize<List<FaqItem>>(faqItemsJson ?? "[]", serializerOptions) ?? new List<FaqItem>();
+
     var faqId = $"faq-{Guid.NewGuid():N}";
     var accordionId = $"{faqId}-accordion";
     var searchInputId = $"{faqId}-search";
@@ -7,145 +28,50 @@
 
 <section class="faq" data-faq data-faq-id="@faqId">
     <header class="faq-header">
-        <h2 class="faq-title">Nejčastější dotazy</h2>
-        <p class="faq-subtitle">Najděte odpovědi na nejčastější otázky k přípravě na certifikaci, školením i samotnému auditu.</p>
+        <h2 class="faq-title">@Localizer["Title"]</h2>
+        <p class="faq-subtitle">@Localizer["Subtitle"]</p>
         <div class="faq-search">
-            <label class="form-label" for="@searchInputId">Vyhledat dotaz</label>
+            <label class="form-label" for="@searchInputId">@Localizer["SearchLabel"]</label>
             <div class="input-group">
                 <span class="input-group-text" id="@searchIconId"><i class="bi bi-search"></i></span>
-                <input id="@searchInputId" class="form-control" type="search" placeholder="Začněte psát dotaz..." aria-describedby="@searchIconId" autocomplete="off" data-faq-search />
+                <input id="@searchInputId" class="form-control" type="search" placeholder="@Localizer["SearchPlaceholder"]" aria-describedby="@searchIconId" autocomplete="off" data-faq-search />
             </div>
         </div>
     </header>
 
-    <div class="faq-categories" role="tablist" aria-label="Kategorie otázek">
-        <button type="button" class="faq-category active" data-faq-category="all">Vše</button>
-        <button type="button" class="faq-category" data-faq-category="general">Obecné otázky</button>
-        <button type="button" class="faq-category" data-faq-category="training">Školení</button>
-        <button type="button" class="faq-category" data-faq-category="certification">Certifikace</button>
+    <div class="faq-categories" role="tablist" aria-label="@Localizer["CategoriesAriaLabel"]">
+        @for (var i = 0; i < faqCategories.Count; i++)
+        {
+            var category = faqCategories[i];
+            <button type="button" class="faq-category @(i == 0 ? "active" : null)" data-faq-category="@category.Key">@category.Label</button>
+        }
     </div>
 
     <p class="faq-empty-message" aria-live="polite" hidden data-faq-empty>
-        Nenašli jsme žádný dotaz, který by odpovídal vašemu vyhledávání.
+        @Localizer["EmptyMessage"]
     </p>
 
     <div class="accordion faq-accordion" id="@accordionId">
-        <div class="accordion-item" data-faq-item data-faq-category="general">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-general-1")">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-general-1")" aria-expanded="true" aria-controls="@($"{faqId}-collapse-general-1")">
-                    Jak dlouho trvá příprava k certifikaci?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-general-1")" class="accordion-collapse collapse show" aria-labelledby="@($"{faqId}-heading-general-1")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Záleží na velikosti organizace a současném stavu. Obvykle 3-12 měsíců. Kontaktujte nás pro odhad.
-                </div>
-            </div>
-        </div>
+        @for (var i = 0; i < faqItems.Count; i++)
+        {
+            var item = faqItems[i];
+            var headingId = $"{faqId}-heading-{item.Category}-{i + 1}";
+            var collapseId = $"{faqId}-collapse-{item.Category}-{i + 1}";
+            var isExpanded = item.Expanded;
 
-        <div class="accordion-item" data-faq-item data-faq-category="general">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-general-2")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-general-2")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-general-2")">
-                    Kolik stojí certifikace ISO?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-general-2")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-general-2")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Náklady zahrnují: školení (15-50 tis. Kč), poradenství (dle rozsahu), certifikační audit (30-100 tis. Kč dle velikosti firmy).
+            <div class="accordion-item" data-faq-item data-faq-category="@item.Category">
+                <h3 class="accordion-header" id="@headingId">
+                    <button class="accordion-button @(isExpanded ? null : "collapsed")" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="@(isExpanded ? "true" : "false")" aria-controls="@collapseId">
+                        @item.Question
+                    </button>
+                </h3>
+                <div id="@collapseId" class="accordion-collapse collapse @(isExpanded ? "show" : null)" aria-labelledby="@headingId" data-bs-parent="#@accordionId">
+                    <div class="accordion-body">
+                        @item.Answer
+                    </div>
                 </div>
             </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="general">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-general-3")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-general-3")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-general-3")">
-                    Potřebujeme externí poradce?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-general-3")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-general-3")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Není povinné, ale výrazně to urychlí proces a zvýší šanci na úspěch v prvním auditu.
-                </div>
-            </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="training">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-training-1")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-training-1")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-training-1")">
-                    Jaký je rozdíl mezi osvědčením a certifikátem?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-training-1")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-training-1")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Osvědčení potvrzuje účast na kurzu. Certifikát získáte po úspěšném složení závěrečné zkoušky.
-                </div>
-            </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="training">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-training-2")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-training-2")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-training-2")">
-                    Jsou vaše kurzy akreditované?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-training-2")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-training-2")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Ano, naše kurzy splňují požadavky certifikačních orgánů a jsou uznávané v ČR i zahraničí.
-                </div>
-            </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="training">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-training-3")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-training-3")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-training-3")">
-                    Můžeme absolvovat školení ve firmě?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-training-3")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-training-3")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Ano, připravíme program na míru od 4 účastníků.
-                </div>
-            </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="certification">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-certification-1")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-certification-1")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-certification-1")">
-                    Kdo provádí certifikační audit?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-certification-1")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-certification-1")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Nezávislý certifikační orgán akreditovaný ČIA (např. TÜV, Bureau Veritas, LRQA).
-                </div>
-            </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="certification">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-certification-2")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-certification-2")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-certification-2")">
-                    Jak často probíhají dozorové audity?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-certification-2")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-certification-2")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Obvykle 1x ročně po dobu 3 let platnosti certifikátu.
-                </div>
-            </div>
-        </div>
-
-        <div class="accordion-item" data-faq-item data-faq-category="certification">
-            <h3 class="accordion-header" id="@($"{faqId}-heading-certification-3")">
-                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@($"{faqId}-collapse-certification-3")" aria-expanded="false" aria-controls="@($"{faqId}-collapse-certification-3")">
-                    Co když v auditu najdou neshody?
-                </button>
-            </h3>
-            <div id="@($"{faqId}-collapse-certification-3")" class="accordion-collapse collapse" aria-labelledby="@($"{faqId}-heading-certification-3")" data-bs-parent="#@accordionId">
-                <div class="accordion-body">
-                    Menší neshody řešíte akčním plánem. Větší mohou vést k odložení certifikace - pomůžeme vám je odstranit.
-                </div>
-            </div>
-        </div>
+        }
     </div>
 </section>
 

--- a/Pages/Shared/_IsoStandardsOverview.cshtml
+++ b/Pages/Shared/_IsoStandardsOverview.cshtml
@@ -1,107 +1,30 @@
+@using System.Collections.Generic
+@using System.Text.Json
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+@functions {
+    private sealed record IsoCourse(string Name, string Url);
+
+    private sealed record IsoStandard(string Title, string Icon, string Description, IReadOnlyList<IsoCourse> Courses);
+}
+
+@{
+    var serializerOptions = new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    var standardsJson = Localizer["StandardsJson"].Value;
+    var standards = JsonSerializer.Deserialize<List<IsoStandard>>(standardsJson ?? "[]", serializerOptions) ?? new List<IsoStandard>();
+}
+
 <section class="iso-standards py-5 bg-light">
     <div class="container">
         <div class="text-center mb-5">
-            <h2 class="fw-bold">Přehled klíčových norem ISO a IATF</h2>
-            <p class="text-muted mb-0">Vyberte si normu a objevte doporučené kurzy, které vám pomohou splnit požadavky na kvalitu, bezpečnost a compliance.</p>
+            <h2 class="fw-bold">@Localizer["Heading"]</h2>
+            <p class="text-muted mb-0">@Localizer["Description"]</p>
         </div>
         <div class="row g-4">
-            @{
-                var standards = new[]
-                {
-                    new
-                    {
-                        Title = "ISO 9001 - Systém managementu kvality",
-                        Icon = "bi-patch-check-fill",
-                        Description = "Pro všechny typy organizací usilujících o zvyšování kvality výrobků a služeb. Zaměření na procesní řízení, management rizik, spokojenost zákazníků a kontinuální zlepšování.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Úvod do ISO 9001", "/Courses/Index?search=ISO%209001"),
-                            ("Manažer kvality", "/Courses/Index?search=Mana%C5%BEer%20kvality"),
-                            ("Interní auditor kvality", "/Courses/Index?search=Intern%C3%AD%20auditor%20kvality")
-                        }
-                    },
-                    new
-                    {
-                        Title = "ISO 14001 - Environmentální management",
-                        Icon = "bi-globe2",
-                        Description = "Pro organizace, které chtějí systematicky řídit environmentální dopady své činnosti. Snižování ekologické stopy, compliance s legislativou, šetrné hospodaření se zdroji.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Interní auditor EMS", "/Courses/Index?search=Intern%C3%AD%20auditor%20EMS"),
-                            ("Manažer integrovaného systému", "/Courses/Index?search=Mana%C5%BEer%20integrovan%C3%A9ho%20syst%C3%A9mu")
-                        }
-                    },
-                    new
-                    {
-                        Title = "ISO/IEC 17025 - Akreditace laboratoří",
-                        Icon = "bi-diagram-3",
-                        Description = "Mezinárodně uznávaný standard pro zkušební a kalibrační laboratoře. Zajišťuje technickou způsobilost, validitu výsledků a srovnatelnost měření.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Manažer kvality laboratoře", "/Courses/Index?search=Mana%C5%BEer%20kvality%20laborato%C5%99e"),
-                            ("Interní auditor laboratoře", "/Courses/Index?search=Intern%C3%AD%20auditor%20laborato%C5%99e"),
-                            ("Metrolog", "/Courses/Index?search=Metrolog")
-                        }
-                    },
-                    new
-                    {
-                        Title = "ISO 15189 - Zdravotnické laboratoře",
-                        Icon = "bi-hospital",
-                        Description = "Specifické požadavky pro zdravotnické laboratoře. Kombinuje technické požadavky s managementem kvality zaměřeným na bezpečnost pacientů.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Manažer kvality zdravotnické laboratoře", "/Courses/Index?search=Mana%C5%BEer%20kvality%20zdravotnick%C3%A9%20laborato%C5%99e"),
-                            ("Interní auditor zdravotnické laboratoře", "/Courses/Index?search=Intern%C3%AD%20auditor%20zdravotnick%C3%A9%20laborato%C5%99e")
-                        }
-                    },
-                    new
-                    {
-                        Title = "ISO 45001 - BOZP",
-                        Icon = "bi-shield-plus",
-                        Description = "Systém managementu bezpečnosti a ochrany zdraví při práci. Prevence pracovních úrazů, identifikace rizik, zapojení zaměstnanců.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Interní auditor BOZP", "/Courses/Index?search=Intern%C3%AD%20auditor%20BOZP"),
-                            ("Manažer integrovaného systému", "/Courses/Index?search=Mana%C5%BEer%20integrovan%C3%A9ho%20syst%C3%A9mu")
-                        }
-                    },
-                    new
-                    {
-                        Title = "ISO 27001 - Informační bezpečnost",
-                        Icon = "bi-shield-lock-fill",
-                        Description = "Ochrana citlivých informací, řízení kybernetických rizik, compliance s GDPR a dalšími předpisy o ochraně dat.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Úvod do ISO 27001", "/Courses/Index?search=ISO%2027001"),
-                            ("Interní auditor ISMS", "/Courses/Index?search=Intern%C3%AD%20auditor%20ISMS")
-                        }
-                    },
-                    new
-                    {
-                        Title = "IATF 16949 - Automobilový průmysl",
-                        Icon = "bi-gear-wide-connected",
-                        Description = "Specifický standard kvality pro dodavatele automobilového průmyslu. Nástroje jako APQP, PPAP, FMEA, SPC.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Manažer kvality automotive", "/Courses/Index?search=Mana%C5%BEer%20kvality%20automotive"),
-                            ("APQP a PPAP", "/Courses/Index?search=APQP%20PPAP"),
-                            ("Core Tools", "/Courses/Index?search=Core%20Tools")
-                        }
-                    },
-                    new
-                    {
-                        Title = "ISO 13485 - Zdravotnické prostředky",
-                        Icon = "bi-heart-pulse-fill",
-                        Description = "Pro výrobce a distributory zdravotnických prostředků. Zaměření na bezpečnost, regulatory compliance a řízení rizik.",
-                        Courses = new (string Name, string Url)[]
-                        {
-                            ("Úvod do ISO 13485", "/Courses/Index?search=ISO%2013485"),
-                            ("Manažer kvality zdravotnických prostředků", "/Courses/Index?search=Mana%C5%BEer%20kvality%20zdravotnick%C3%BDch%20prost%C5%99edk%C5%AF")
-                        }
-                    }
-                };
-            }
-
             @foreach (var standard in standards)
             {
                 <div class="col-12 col-md-6 col-xl-3 d-flex">
@@ -115,9 +38,9 @@
                             </div>
                             <p class="text-muted flex-grow-1">@standard.Description</p>
                             <div>
-                                <h4 class="h6 text-uppercase text-primary mb-2">Doporučené kurzy</h4>
+                                <h4 class="h6 text-uppercase text-primary mb-2">@Localizer["RecommendedCoursesHeading"]</h4>
                                 <ul class="list-unstyled mb-0">
-                                    @foreach (var course in standard.Courses)
+                                    @foreach (var course in standard.Courses ?? Array.Empty<IsoCourse>())
                                     {
                                         <li class="mb-1">
                                             <a class="link-underline link-underline-opacity-0 link-primary" href="@course.Url">

--- a/Pages/Shared/_Testimonials.cshtml
+++ b/Pages/Shared/_Testimonials.cshtml
@@ -1,52 +1,37 @@
+@using System.Collections.Generic
+@using System.Text.Json
+@inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer Localizer
+
+@functions {
+    private sealed record TestimonialEntry(string Quote, string Name, string Title, string Company, string ImageUrl, int Rating);
+}
+
 @{
-    var testimonials = new[]
+    var serializerOptions = new JsonSerializerOptions
     {
-        new
-        {
-            Quote = "Absolvovali jsme komplexní přípravu k certifikaci ISO 9001. Profesionální přístup, srozumitelný výklad a praktické příklady nám velmi pomohly. Certifikaci jsme získali na první pokus.",
-            Name = "Ing. Jana Nováková",
-            Title = "Manažerka kvality",
-            Company = "XYZ s.r.o.",
-            ImageUrl = "https://via.placeholder.com/120",
-            Rating = 5
-        },
-        new
-        {
-            Quote = "Lektorský tým kombinuje teoretické znalosti s praktickými zkušenostmi. Díky jejich školení máme připravený interní tým auditorů.",
-            Name = "Petr Svoboda",
-            Title = "Jednatel",
-            Company = "ABC Lab a.s.",
-            ImageUrl = "https://via.placeholder.com/120",
-            Rating = 5
-        },
-        new
-        {
-            Quote = "Firemní školení na míru přesně odpovídalo potřebám naší organizace. Oceňujeme flexibilitu a odbornost lektorů.",
-            Name = "Mgr. Marie Dvořáková",
-            Title = "HR Manager",
-            Company = "DEF Group",
-            ImageUrl = "https://via.placeholder.com/120",
-            Rating = 5
-        }
+        PropertyNameCaseInsensitive = true
     };
+
+    var testimonialsJson = Localizer["TestimonialsJson"].Value;
+    var testimonials = JsonSerializer.Deserialize<List<TestimonialEntry>>(testimonialsJson ?? "[]", serializerOptions) ?? new List<TestimonialEntry>();
 }
 
 <section class="container py-5" aria-labelledby="testimonialsHeading">
     <div class="text-center mb-4">
-        <h2 id="testimonialsHeading" class="fw-bold">Co o nás říkají klienti</h2>
-        <p class="text-muted mb-0">Reálné zkušenosti firem, které s námi spolupracovaly</p>
+        <h2 id="testimonialsHeading" class="fw-bold">@Localizer["Heading"]</h2>
+        <p class="text-muted mb-0">@Localizer["Subheading"]</p>
     </div>
 
     <div id="testimonialsCarousel" class="carousel slide" data-bs-ride="carousel" data-bs-interval="7000">
         <div class="carousel-indicators">
-            @for (var i = 0; i < testimonials.Length; i++)
+            @for (var i = 0; i < testimonials.Count; i++)
             {
-                <button type="button" data-bs-target="#testimonialsCarousel" data-bs-slide-to="@i" class="@(i == 0 ? "active" : null)" aria-current="@(i == 0 ? "true" : "false")" aria-label="Testimonial @(i + 1)"></button>
+                <button type="button" data-bs-target="#testimonialsCarousel" data-bs-slide-to="@i" class="@(i == 0 ? "active" : null)" aria-current="@(i == 0 ? "true" : "false")" aria-label="@Localizer["IndicatorLabel", i + 1]"></button>
             }
         </div>
 
         <div class="carousel-inner">
-            @for (var i = 0; i < testimonials.Length; i++)
+            @for (var i = 0; i < testimonials.Count; i++)
             {
                 var testimonial = testimonials[i];
                 <div class="carousel-item @(i == 0 ? "active" : null)">
@@ -62,7 +47,7 @@
                                         <i class="bi bi-star-fill"></i>
                                     }
                                 </div>
-                                <span class="visually-hidden">Hodnocení: @testimonial.Rating z 5</span>
+                                <span class="visually-hidden">@Localizer["RatingLabel", testimonial.Rating]</span>
                             </div>
                         </div>
                         <div class="col-md-6">
@@ -81,11 +66,11 @@
 
         <button class="carousel-control-prev" type="button" data-bs-target="#testimonialsCarousel" data-bs-slide="prev">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Předchozí</span>
+            <span class="visually-hidden">@Localizer["Prev"]</span>
         </button>
         <button class="carousel-control-next" type="button" data-bs-target="#testimonialsCarousel" data-bs-slide="next">
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
-            <span class="visually-hidden">Další</span>
+            <span class="visually-hidden">@Localizer["Next"]</span>
         </button>
     </div>
 </section>

--- a/Resources/Pages.Shared._Chatbot.cshtml.en.resx
+++ b/Resources/Pages.Shared._Chatbot.cshtml.en.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ToggleLabel" xml:space="preserve">
+    <value>Open chat with the virtual advisor</value>
+  </data>
+  <data name="PanelAriaLabel" xml:space="preserve">
+    <value>Virtual advisor</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Virtual advisor</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>I'm happy to recommend the right course for you.</value>
+  </data>
+  <data name="CloseLabel" xml:space="preserve">
+    <value>Close chat</value>
+  </data>
+  <data name="QuickRepliesAriaLabel" xml:space="preserve">
+    <value>Quick questions</value>
+  </data>
+  <data name="QuickRepliesJson" xml:space="preserve">
+    <value><![CDATA[[
+  "I'm looking for ISO 9001 training",
+  "When does the next course start?",
+  "How much does it cost?"
+]]]></value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Your message</value>
+  </data>
+  <data name="MessagePlaceholder" xml:space="preserve">
+    <value>Type your question...</value>
+  </data>
+  <data name="SendButton" xml:space="preserve">
+    <value>Send</value>
+  </data>
+  <data name="EscalateButton" xml:space="preserve">
+    <value>I need to talk to a person</value>
+  </data>
+  <data name="EscalateDescription" xml:space="preserve">
+    <value>Please leave your email and a colleague will get back to you shortly.</value>
+  </data>
+  <data name="EscalateEmailLabel" xml:space="preserve">
+    <value>Email</value>
+  </data>
+  <data name="EscalateEmailPlaceholder" xml:space="preserve">
+    <value>you@example.com</value>
+  </data>
+  <data name="EscalateSubmit" xml:space="preserve">
+    <value>Send request</value>
+  </data>
+  <data name="EscalateCancel" xml:space="preserve">
+    <value>Close</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._Chatbot.cshtml.resx
+++ b/Resources/Pages.Shared._Chatbot.cshtml.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ToggleLabel" xml:space="preserve">
+    <value>Otevřít chat s virtuálním poradcem</value>
+  </data>
+  <data name="PanelAriaLabel" xml:space="preserve">
+    <value>Virtuální poradce</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Virtuální poradce</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>Rád poradím s výběrem vhodného kurzu.</value>
+  </data>
+  <data name="CloseLabel" xml:space="preserve">
+    <value>Zavřít chat</value>
+  </data>
+  <data name="QuickRepliesAriaLabel" xml:space="preserve">
+    <value>Rychlé dotazy</value>
+  </data>
+  <data name="QuickRepliesJson" xml:space="preserve">
+    <value><![CDATA[[
+  "Hledám školení pro ISO 9001",
+  "Kdy začíná nejbližší kurz?",
+  "Kolik to stojí?"
+]]]></value>
+  </data>
+  <data name="MessageLabel" xml:space="preserve">
+    <value>Vaše zpráva</value>
+  </data>
+  <data name="MessagePlaceholder" xml:space="preserve">
+    <value>Napište dotaz...</value>
+  </data>
+  <data name="SendButton" xml:space="preserve">
+    <value>Odeslat</value>
+  </data>
+  <data name="EscalateButton" xml:space="preserve">
+    <value>Potřebuji mluvit s člověkem</value>
+  </data>
+  <data name="EscalateDescription" xml:space="preserve">
+    <value>Vyplňte prosím e-mail, kolega se vám ozve co nejdříve.</value>
+  </data>
+  <data name="EscalateEmailLabel" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="EscalateEmailPlaceholder" xml:space="preserve">
+    <value>vas@email.cz</value>
+  </data>
+  <data name="EscalateSubmit" xml:space="preserve">
+    <value>Odeslat požadavek</value>
+  </data>
+  <data name="EscalateCancel" xml:space="preserve">
+    <value>Zavřít</value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._FAQ.cshtml.en.resx
+++ b/Resources/Pages.Shared._FAQ.cshtml.en.resx
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Frequently asked questions</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>Find answers to the questions we hear most often about certification preparation, training, and the audit itself.</value>
+  </data>
+  <data name="SearchLabel" xml:space="preserve">
+    <value>Search questions</value>
+  </data>
+  <data name="SearchPlaceholder" xml:space="preserve">
+    <value>Start typing your question...</value>
+  </data>
+  <data name="CategoriesAriaLabel" xml:space="preserve">
+    <value>Question categories</value>
+  </data>
+  <data name="EmptyMessage" xml:space="preserve">
+    <value>We couldn't find any questions matching your search.</value>
+  </data>
+  <data name="CategoriesJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Key": "all",
+    "Label": "All"
+  },
+  {
+    "Key": "general",
+    "Label": "General questions"
+  },
+  {
+    "Key": "training",
+    "Label": "Training"
+  },
+  {
+    "Key": "certification",
+    "Label": "Certification"
+  }
+]]]></value>
+  </data>
+  <data name="FaqItemsJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Category": "general",
+    "Question": "How long does certification preparation take?",
+    "Answer": "It depends on your organisation's size and current maturity. Most companies need 3-12 months. Contact us for an estimate tailored to you.",
+    "Expanded": true
+  },
+  {
+    "Category": "general",
+    "Question": "How much does ISO certification cost?",
+    "Answer": "Expect to budget for training (CZK 15-50k), consulting (depending on scope), and the certification audit (CZK 30-100k based on company size).",
+    "Expanded": false
+  },
+  {
+    "Category": "general",
+    "Question": "Do we need external consultants?",
+    "Answer": "It's not mandatory, but experts significantly accelerate the project and increase the likelihood of passing the first audit.",
+    "Expanded": false
+  },
+  {
+    "Category": "training",
+    "Question": "What is the difference between a certificate of attendance and a certification?",
+    "Answer": "A certificate of attendance confirms you joined the course. You receive a certification after passing the final examination.",
+    "Expanded": false
+  },
+  {
+    "Category": "training",
+    "Question": "Are your courses accredited?",
+    "Answer": "Yes, our programmes meet certification body requirements and are recognised in the Czech Republic and abroad.",
+    "Expanded": false
+  },
+  {
+    "Category": "training",
+    "Question": "Can we arrange on-site training?",
+    "Answer": "Absolutely. We deliver tailored in-company programmes for teams of four or more participants.",
+    "Expanded": false
+  },
+  {
+    "Category": "certification",
+    "Question": "Who performs the certification audit?",
+    "Answer": "An independent certification body accredited by the Czech Accreditation Institute (e.g. TÜV, Bureau Veritas, LRQA).",
+    "Expanded": false
+  },
+  {
+    "Category": "certification",
+    "Question": "How often are surveillance audits scheduled?",
+    "Answer": "Typically once per year for the three-year certification cycle.",
+    "Expanded": false
+  },
+  {
+    "Category": "certification",
+    "Question": "What happens if the audit finds nonconformities?",
+    "Answer": "Minor findings are resolved with an action plan. Major ones can delay certification—we'll help you implement the fixes quickly.",
+    "Expanded": false
+  }
+]]]></value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._FAQ.cshtml.resx
+++ b/Resources/Pages.Shared._FAQ.cshtml.resx
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Title" xml:space="preserve">
+    <value>Nejčastější dotazy</value>
+  </data>
+  <data name="Subtitle" xml:space="preserve">
+    <value>Najděte odpovědi na nejčastější otázky k přípravě na certifikaci, školením i samotnému auditu.</value>
+  </data>
+  <data name="SearchLabel" xml:space="preserve">
+    <value>Vyhledat dotaz</value>
+  </data>
+  <data name="SearchPlaceholder" xml:space="preserve">
+    <value>Začněte psát dotaz...</value>
+  </data>
+  <data name="CategoriesAriaLabel" xml:space="preserve">
+    <value>Kategorie otázek</value>
+  </data>
+  <data name="EmptyMessage" xml:space="preserve">
+    <value>Nenašli jsme žádný dotaz, který by odpovídal vašemu vyhledávání.</value>
+  </data>
+  <data name="CategoriesJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Key": "all",
+    "Label": "Vše"
+  },
+  {
+    "Key": "general",
+    "Label": "Obecné otázky"
+  },
+  {
+    "Key": "training",
+    "Label": "Školení"
+  },
+  {
+    "Key": "certification",
+    "Label": "Certifikace"
+  }
+]]]></value>
+  </data>
+  <data name="FaqItemsJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Category": "general",
+    "Question": "Jak dlouho trvá příprava k certifikaci?",
+    "Answer": "Záleží na velikosti organizace a současném stavu. Obvykle 3-12 měsíců. Kontaktujte nás pro odhad.",
+    "Expanded": true
+  },
+  {
+    "Category": "general",
+    "Question": "Kolik stojí certifikace ISO?",
+    "Answer": "Náklady zahrnují: školení (15-50 tis. Kč), poradenství (dle rozsahu), certifikační audit (30-100 tis. Kč dle velikosti firmy).",
+    "Expanded": false
+  },
+  {
+    "Category": "general",
+    "Question": "Potřebujeme externí poradce?",
+    "Answer": "Není povinné, ale výrazně to urychlí proces a zvýší šanci na úspěch v prvním auditu.",
+    "Expanded": false
+  },
+  {
+    "Category": "training",
+    "Question": "Jaký je rozdíl mezi osvědčením a certifikátem?",
+    "Answer": "Osvědčení potvrzuje účast na kurzu. Certifikát získáte po úspěšném složení závěrečné zkoušky.",
+    "Expanded": false
+  },
+  {
+    "Category": "training",
+    "Question": "Jsou vaše kurzy akreditované?",
+    "Answer": "Ano, naše kurzy splňují požadavky certifikačních orgánů a jsou uznávané v ČR i zahraničí.",
+    "Expanded": false
+  },
+  {
+    "Category": "training",
+    "Question": "Můžeme absolvovat školení ve firmě?",
+    "Answer": "Ano, připravíme program na míru od 4 účastníků.",
+    "Expanded": false
+  },
+  {
+    "Category": "certification",
+    "Question": "Kdo provádí certifikační audit?",
+    "Answer": "Nezávislý certifikační orgán akreditovaný ČIA (např. TÜV, Bureau Veritas, LRQA).",
+    "Expanded": false
+  },
+  {
+    "Category": "certification",
+    "Question": "Jak často probíhají dozorové audity?",
+    "Answer": "Obvykle 1x ročně po dobu 3 let platnosti certifikátu.",
+    "Expanded": false
+  },
+  {
+    "Category": "certification",
+    "Question": "Co když v auditu najdou neshody?",
+    "Answer": "Menší neshody řešíte akčním plánem. Větší mohou vést k odložení certifikace - pomůžeme vám je odstranit.",
+    "Expanded": false
+  }
+]]]></value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._IsoStandardsOverview.cshtml.en.resx
+++ b/Resources/Pages.Shared._IsoStandardsOverview.cshtml.en.resx
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Overview of key ISO and IATF standards</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Select a standard and explore recommended courses that help you meet quality, safety, and compliance requirements.</value>
+  </data>
+  <data name="RecommendedCoursesHeading" xml:space="preserve">
+    <value>Recommended courses</value>
+  </data>
+  <data name="StandardsJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Title": "ISO 9001 - Quality management system",
+    "Icon": "bi-patch-check-fill",
+    "Description": "Designed for all organisations focused on improving product and service quality. Emphasises process management, risk thinking, customer satisfaction, and continual improvement.",
+    "Courses": [
+      {
+        "Name": "Introduction to ISO 9001",
+        "Url": "/Courses/Index?search=ISO%209001"
+      },
+      {
+        "Name": "Quality Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality"
+      },
+      {
+        "Name": "Internal Quality Auditor",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20kvality"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 14001 - Environmental management",
+    "Icon": "bi-globe2",
+    "Description": "For organisations that want to manage environmental impacts systematically. Focus on reducing footprint, staying compliant with legislation, and using resources responsibly.",
+    "Courses": [
+      {
+        "Name": "Internal EMS Auditor",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20EMS"
+      },
+      {
+        "Name": "Integrated Management System Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20integrovan%C3%A9ho%20syst%C3%A9mu"
+      }
+    ]
+  },
+  {
+    "Title": "ISO/IEC 17025 - Laboratory accreditation",
+    "Icon": "bi-diagram-3",
+    "Description": "Internationally recognised standard for testing and calibration laboratories. Ensures technical competence, valid results, and comparable measurements.",
+    "Courses": [
+      {
+        "Name": "Laboratory Quality Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20laborato%C5%99e"
+      },
+      {
+        "Name": "Internal Laboratory Auditor",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20laborato%C5%99e"
+      },
+      {
+        "Name": "Metrologist",
+        "Url": "/Courses/Index?search=Metrolog"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 15189 - Medical laboratories",
+    "Icon": "bi-hospital",
+    "Description": "Specific requirements for medical laboratories, combining technical competence with patient-safety-focused quality management.",
+    "Courses": [
+      {
+        "Name": "Medical Laboratory Quality Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20zdravotnick%C3%A9%20laborato%C5%99e"
+      },
+      {
+        "Name": "Internal Medical Laboratory Auditor",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20zdravotnick%C3%A9%20laborato%C5%99e"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 45001 - Occupational health and safety",
+    "Icon": "bi-shield-plus",
+    "Description": "Management system for protecting employee health and safety. Prevents workplace injuries, identifies risks, and engages people.",
+    "Courses": [
+      {
+        "Name": "Occupational H&amp;S Internal Auditor",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20BOZP"
+      },
+      {
+        "Name": "Integrated Management System Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20integrovan%C3%A9ho%20syst%C3%A9mu"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 27001 - Information security",
+    "Icon": "bi-shield-lock-fill",
+    "Description": "Protects sensitive information, manages cyber risks, and supports GDPR and other data protection compliance.",
+    "Courses": [
+      {
+        "Name": "Introduction to ISO 27001",
+        "Url": "/Courses/Index?search=ISO%2027001"
+      },
+      {
+        "Name": "Internal ISMS Auditor",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20ISMS"
+      }
+    ]
+  },
+  {
+    "Title": "IATF 16949 - Automotive industry",
+    "Icon": "bi-gear-wide-connected",
+    "Description": "Specialised quality standard for automotive suppliers, covering tools such as APQP, PPAP, FMEA, and SPC.",
+    "Courses": [
+      {
+        "Name": "Automotive Quality Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20automotive"
+      },
+      {
+        "Name": "APQP &amp; PPAP",
+        "Url": "/Courses/Index?search=APQP%20PPAP"
+      },
+      {
+        "Name": "Core Tools",
+        "Url": "/Courses/Index?search=Core%20Tools"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 13485 - Medical devices",
+    "Icon": "bi-heart-pulse-fill",
+    "Description": "For manufacturers and distributors of medical devices with emphasis on safety, regulatory compliance, and risk management.",
+    "Courses": [
+      {
+        "Name": "Introduction to ISO 13485",
+        "Url": "/Courses/Index?search=ISO%2013485"
+      },
+      {
+        "Name": "Medical Device Quality Manager",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20zdravotnick%C3%BDch%20prost%C5%99edk%C5%AF"
+      }
+    ]
+  }
+]]]></value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._IsoStandardsOverview.cshtml.resx
+++ b/Resources/Pages.Shared._IsoStandardsOverview.cshtml.resx
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Přehled klíčových norem ISO a IATF</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>Vyberte si normu a objevte doporučené kurzy, které vám pomohou splnit požadavky na kvalitu, bezpečnost a compliance.</value>
+  </data>
+  <data name="RecommendedCoursesHeading" xml:space="preserve">
+    <value>Doporučené kurzy</value>
+  </data>
+  <data name="StandardsJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Title": "ISO 9001 - Systém managementu kvality",
+    "Icon": "bi-patch-check-fill",
+    "Description": "Pro všechny typy organizací usilujících o zvyšování kvality výrobků a služeb. Zaměření na procesní řízení, management rizik, spokojenost zákazníků a kontinuální zlepšování.",
+    "Courses": [
+      {
+        "Name": "Úvod do ISO 9001",
+        "Url": "/Courses/Index?search=ISO%209001"
+      },
+      {
+        "Name": "Manažer kvality",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality"
+      },
+      {
+        "Name": "Interní auditor kvality",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20kvality"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 14001 - Environmentální management",
+    "Icon": "bi-globe2",
+    "Description": "Pro organizace, které chtějí systematicky řídit environmentální dopady své činnosti. Snižování ekologické stopy, compliance s legislativou, šetrné hospodaření se zdroji.",
+    "Courses": [
+      {
+        "Name": "Interní auditor EMS",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20EMS"
+      },
+      {
+        "Name": "Manažer integrovaného systému",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20integrovan%C3%A9ho%20syst%C3%A9mu"
+      }
+    ]
+  },
+  {
+    "Title": "ISO/IEC 17025 - Akreditace laboratoří",
+    "Icon": "bi-diagram-3",
+    "Description": "Mezinárodně uznávaný standard pro zkušební a kalibrační laboratoře. Zajišťuje technickou způsobilost, validitu výsledků a srovnatelnost měření.",
+    "Courses": [
+      {
+        "Name": "Manažer kvality laboratoře",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20laborato%C5%99e"
+      },
+      {
+        "Name": "Interní auditor laboratoře",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20laborato%C5%99e"
+      },
+      {
+        "Name": "Metrolog",
+        "Url": "/Courses/Index?search=Metrolog"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 15189 - Zdravotnické laboratoře",
+    "Icon": "bi-hospital",
+    "Description": "Specifické požadavky pro zdravotnické laboratoře. Kombinuje technické požadavky s managementem kvality zaměřeným na bezpečnost pacientů.",
+    "Courses": [
+      {
+        "Name": "Manažer kvality zdravotnické laboratoře",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20zdravotnick%C3%A9%20laborato%C5%99e"
+      },
+      {
+        "Name": "Interní auditor zdravotnické laboratoře",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20zdravotnick%C3%A9%20laborato%C5%99e"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 45001 - BOZP",
+    "Icon": "bi-shield-plus",
+    "Description": "Systém managementu bezpečnosti a ochrany zdraví při práci. Prevence pracovních úrazů, identifikace rizik, zapojení zaměstnanců.",
+    "Courses": [
+      {
+        "Name": "Interní auditor BOZP",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20BOZP"
+      },
+      {
+        "Name": "Manažer integrovaného systému",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20integrovan%C3%A9ho%20syst%C3%A9mu"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 27001 - Informační bezpečnost",
+    "Icon": "bi-shield-lock-fill",
+    "Description": "Ochrana citlivých informací, řízení kybernetických rizik, compliance s GDPR a dalšími předpisy o ochraně dat.",
+    "Courses": [
+      {
+        "Name": "Úvod do ISO 27001",
+        "Url": "/Courses/Index?search=ISO%2027001"
+      },
+      {
+        "Name": "Interní auditor ISMS",
+        "Url": "/Courses/Index?search=Intern%C3%AD%20auditor%20ISMS"
+      }
+    ]
+  },
+  {
+    "Title": "IATF 16949 - Automobilový průmysl",
+    "Icon": "bi-gear-wide-connected",
+    "Description": "Specifický standard kvality pro dodavatele automobilového průmyslu. Nástroje jako APQP, PPAP, FMEA, SPC.",
+    "Courses": [
+      {
+        "Name": "Manažer kvality automotive",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20automotive"
+      },
+      {
+        "Name": "APQP a PPAP",
+        "Url": "/Courses/Index?search=APQP%20PPAP"
+      },
+      {
+        "Name": "Core Tools",
+        "Url": "/Courses/Index?search=Core%20Tools"
+      }
+    ]
+  },
+  {
+    "Title": "ISO 13485 - Zdravotnické prostředky",
+    "Icon": "bi-heart-pulse-fill",
+    "Description": "Pro výrobce a distributory zdravotnických prostředků. Zaměření na bezpečnost, regulatory compliance a řízení rizik.",
+    "Courses": [
+      {
+        "Name": "Úvod do ISO 13485",
+        "Url": "/Courses/Index?search=ISO%2013485"
+      },
+      {
+        "Name": "Manažer kvality zdravotnických prostředků",
+        "Url": "/Courses/Index?search=Mana%C5%BEer%20kvality%20zdravotnick%C3%BDch%20prost%C5%99edk%C5%AF"
+      }
+    ]
+  }
+]]]></value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._Testimonials.cshtml.en.resx
+++ b/Resources/Pages.Shared._Testimonials.cshtml.en.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>What our clients say</value>
+  </data>
+  <data name="Subheading" xml:space="preserve">
+    <value>Real-world stories from organisations that partnered with us</value>
+  </data>
+  <data name="IndicatorLabel" xml:space="preserve">
+    <value>Testimonial {0}</value>
+  </data>
+  <data name="RatingLabel" xml:space="preserve">
+    <value>Rating: {0} out of 5</value>
+  </data>
+  <data name="Prev" xml:space="preserve">
+    <value>Previous</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Next</value>
+  </data>
+  <data name="TestimonialsJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Quote": "We completed a full ISO 9001 preparation programme. The team's professional approach, clear explanations, and practical examples helped us a lot. We passed the certification on the first attempt.",
+    "Name": "Ing. Jana Nováková",
+    "Title": "Quality Manager",
+    "Company": "XYZ s.r.o.",
+    "ImageUrl": "https://via.placeholder.com/120",
+    "Rating": 5
+  },
+  {
+    "Quote": "The trainers combine deep theory with hands-on experience. Thanks to their course we now have an in-house audit team ready to go.",
+    "Name": "Petr Svoboda",
+    "Title": "Managing Director",
+    "Company": "ABC Lab a.s.",
+    "ImageUrl": "https://via.placeholder.com/120",
+    "Rating": 5
+  },
+  {
+    "Quote": "The tailored in-company training matched our organisation's needs perfectly. We appreciated the lecturers' flexibility and expertise.",
+    "Name": "Mgr. Marie Dvořáková",
+    "Title": "HR Manager",
+    "Company": "DEF Group",
+    "ImageUrl": "https://via.placeholder.com/120",
+    "Rating": 5
+  }
+]]]></value>
+  </data>
+</root>

--- a/Resources/Pages.Shared._Testimonials.cshtml.resx
+++ b/Resources/Pages.Shared._Testimonials.cshtml.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Co o nás říkají klienti</value>
+  </data>
+  <data name="Subheading" xml:space="preserve">
+    <value>Reálné zkušenosti firem, které s námi spolupracovaly</value>
+  </data>
+  <data name="IndicatorLabel" xml:space="preserve">
+    <value>Reference {0}</value>
+  </data>
+  <data name="RatingLabel" xml:space="preserve">
+    <value>Hodnocení: {0} z 5</value>
+  </data>
+  <data name="Prev" xml:space="preserve">
+    <value>Předchozí</value>
+  </data>
+  <data name="Next" xml:space="preserve">
+    <value>Další</value>
+  </data>
+  <data name="TestimonialsJson" xml:space="preserve">
+    <value><![CDATA[[
+  {
+    "Quote": "Absolvovali jsme komplexní přípravu k certifikaci ISO 9001. Profesionální přístup, srozumitelný výklad a praktické příklady nám velmi pomohly. Certifikaci jsme získali na první pokus.",
+    "Name": "Ing. Jana Nováková",
+    "Title": "Manažerka kvality",
+    "Company": "XYZ s.r.o.",
+    "ImageUrl": "https://via.placeholder.com/120",
+    "Rating": 5
+  },
+  {
+    "Quote": "Lektorský tým kombinuje teoretické znalosti s praktickými zkušenostmi. Díky jejich školení máme připravený interní tým auditorů.",
+    "Name": "Petr Svoboda",
+    "Title": "Jednatel",
+    "Company": "ABC Lab a.s.",
+    "ImageUrl": "https://via.placeholder.com/120",
+    "Rating": 5
+  },
+  {
+    "Quote": "Firemní školení na míru přesně odpovídalo potřebám naší organizace. Oceňujeme flexibilitu a odbornost lektorů.",
+    "Name": "Mgr. Marie Dvořáková",
+    "Title": "HR Manager",
+    "Company": "DEF Group",
+    "ImageUrl": "https://via.placeholder.com/120",
+    "Rating": 5
+  }
+]]]></value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- inject view localizers into the landing page partials and hydrate their content from localized resources
- replace hard-coded FAQ, chatbot, testimonial, and ISO standards copy with localized strings and structured JSON data
- add Czech and English .resx files for each partial so marketing content switches correctly with the culture

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e658da27548321b442183a75dcc64d