### PR TITLE
Refactor specialization rendering on the index page

### DIFF
--- a/Pages/Index.cshtml
+++ b/Pages/Index.cshtml
@@ -3,6 +3,109 @@
 @inject Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer T
 @{
     ViewData["Title"] = T["Title"];
+
+    var specializations = new[]
+    {
+        new
+        {
+            CardTitle = "ISO 9001",
+            IconTitle = "ISO 9001",
+            CardDescription = "Systém managementu kvality",
+            IconDescription = "Systém managementu kvality",
+            CardIconClass = "bi bi-award-fill",
+            CardGradient = "linear-gradient(135deg, #2563eb 0%, #3b82f6 100%)",
+            IconColorClass = "iso-9001",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "ISO 14001",
+            IconTitle = "ISO 14001",
+            CardDescription = "Environmentální management",
+            IconDescription = "Systém environmentálního managementu",
+            CardIconClass = "bi bi-tree-fill",
+            CardGradient = "linear-gradient(135deg, #10b981 0%, #34d399 100%)",
+            IconColorClass = "iso-14001",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "ISO 17025",
+            IconTitle = "ISO/IEC 17025",
+            CardDescription = "Akreditace laboratoří",
+            IconDescription = "Akreditace zkušebních a kalibračních laboratoří",
+            CardIconClass = "bi bi-clipboard-data-fill",
+            CardGradient = "linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%)",
+            IconColorClass = "iso-17025",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "ISO 15189",
+            IconTitle = "ISO 15189",
+            CardDescription = "Zdravotnické laboratoře",
+            IconDescription = "Kvalita zdravotnických laboratoří",
+            CardIconClass = "bi bi-hospital-fill",
+            CardGradient = "linear-gradient(135deg, #ef4444 0%, #f87171 100%)",
+            IconColorClass = "iso-15189",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "HACCP",
+            IconTitle = "HACCP",
+            CardDescription = "Bezpečnost potravin",
+            IconDescription = "Bezpečnost a kontrola potravin",
+            CardIconClass = "bi bi-egg-fill",
+            CardGradient = "linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%)",
+            IconColorClass = "haccp",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "ISO 45001",
+            IconTitle = "ISO 45001",
+            CardDescription = "Bezpečnost práce",
+            IconDescription = "Bezpečnost a ochrana zdraví při práci",
+            CardIconClass = "bi bi-shield-fill-check",
+            CardGradient = "linear-gradient(135deg, #eab308 0%, #facc15 100%)",
+            IconColorClass = "iso-45001",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "ISO 27001",
+            IconTitle = "ISO/IEC 27001",
+            CardDescription = "Informační bezpečnost",
+            IconDescription = "Řízení bezpečnosti informací",
+            CardIconClass = "bi bi-shield-lock-fill",
+            CardGradient = "linear-gradient(135deg, #6366f1 0%, #818cf8 100%)",
+            IconColorClass = "iso-27001",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "IATF 16949",
+            IconTitle = "IATF 16949",
+            CardDescription = "Automobilový průmysl",
+            IconDescription = "Automotive Quality Management",
+            CardIconClass = "bi bi-car-front-fill",
+            CardGradient = "linear-gradient(135deg, #475569 0%, #64748b 100%)",
+            IconColorClass = "iatf-16949",
+            SecondaryIconClass = "bi bi-award-fill"
+        },
+        new
+        {
+            CardTitle = "ISO 13485",
+            IconTitle = "ISO 13485",
+            CardDescription = "Zdravotnické prostředky",
+            IconDescription = "Management kvality zdravotnických prostředků",
+            CardIconClass = "bi bi-heart-pulse-fill",
+            CardGradient = "linear-gradient(135deg, #ec4899 0%, #f472b6 100%)",
+            IconColorClass = "iso-13485",
+            SecondaryIconClass = "bi bi-award-fill"
+        }
+    };
 }
 
 <style>
@@ -395,142 +498,22 @@
 
         <!-- Grid s ISO normami -->
         <div class="row g-4">
-
-            <!-- ISO 9001 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);">
-                                <i class="bi bi-award-fill text-white" style="font-size: 1.5rem;"></i>
+            @foreach (var specialization in specializations)
+            {
+                <div class="col-12 col-md-6 col-lg-4">
+                    <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
+                        <div class="card-body p-4">
+                            <div class="d-flex align-items-center mb-3">
+                                <div class="rounded-3 p-3 me-3" style="background: @specialization.CardGradient;">
+                                    <i class="@specialization.CardIconClass text-white" style="font-size: 1.5rem;"></i>
+                                </div>
+                                <h3 class="h4 mb-0 fw-bold">@specialization.CardTitle</h3>
                             </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 9001</h3>
+                            <p class="text-muted mb-0">@specialization.CardDescription</p>
                         </div>
-                        <p class="text-muted mb-0">Systém managementu kvality</p>
                     </div>
                 </div>
-            </div>
-
-            <!-- ISO 14001 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #10b981 0%, #34d399 100%);">
-                                <i class="bi bi-tree-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 14001</h3>
-                        </div>
-                        <p class="text-muted mb-0">Environmentální management</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ISO 17025 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%);">
-                                <i class="bi bi-clipboard-data-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 17025</h3>
-                        </div>
-                        <p class="text-muted mb-0">Akreditace laboratoří</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ISO 15189 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #ef4444 0%, #f87171 100%);">
-                                <i class="bi bi-hospital-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 15189</h3>
-                        </div>
-                        <p class="text-muted mb-0">Zdravotnické laboratoře</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- HACCP -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #f59e0b 0%, #fbbf24 100%);">
-                                <i class="bi bi-egg-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">HACCP</h3>
-                        </div>
-                        <p class="text-muted mb-0">Bezpečnost potravin</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ISO 45001 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #eab308 0%, #facc15 100%);">
-                                <i class="bi bi-shield-fill-check text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 45001</h3>
-                        </div>
-                        <p class="text-muted mb-0">Bezpečnost práce</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ISO 27001 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #6366f1 0%, #818cf8 100%);">
-                                <i class="bi bi-shield-lock-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 27001</h3>
-                        </div>
-                        <p class="text-muted mb-0">Informační bezpečnost</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- IATF 16949 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #475569 0%, #64748b 100%);">
-                                <i class="bi bi-car-front-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">IATF 16949</h3>
-                        </div>
-                        <p class="text-muted mb-0">Automobilový průmysl</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- ISO 13485 -->
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 border-0 shadow-sm hover-lift" style="border-radius: 1rem; transition: transform 0.2s, box-shadow 0.2s; cursor: pointer;">
-                    <div class="card-body p-4">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="rounded-3 p-3 me-3" style="background: linear-gradient(135deg, #ec4899 0%, #f472b6 100%);">
-                                <i class="bi bi-heart-pulse-fill text-white" style="font-size: 1.5rem;"></i>
-                            </div>
-                            <h3 class="h4 mb-0 fw-bold">ISO 13485</h3>
-                        </div>
-                        <p class="text-muted mb-0">Zdravotnické prostředky</p>
-                    </div>
-                </div>
-            </div>
-
+            }
         </div>
     </div>
 </section>
@@ -573,87 +556,18 @@
             <p class="section-subheading lead">Odborně vás provedeme certifikací podle nejžádanějších mezinárodních norem.</p>
         </div>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-9001 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
+            @foreach (var specialization in specializations)
+            {
+                <div class="col">
+                    <div class="specialization-card h-100 text-center p-4">
+                        <div class="specialization-icon @specialization.IconColorClass mb-3">
+                            <i class="@specialization.SecondaryIconClass" aria-hidden="true"></i>
+                        </div>
+                        <h3 class="h4 fw-bold mb-2">@specialization.IconTitle</h3>
+                        <p class="text-muted mb-0">@specialization.IconDescription</p>
                     </div>
-                    <h3 class="h4 fw-bold mb-2">ISO 9001</h3>
-                    <p class="text-muted mb-0">Systém managementu kvality</p>
                 </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-14001 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">ISO 14001</h3>
-                    <p class="text-muted mb-0">Systém environmentálního managementu</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-17025 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">ISO/IEC 17025</h3>
-                    <p class="text-muted mb-0">Akreditace zkušebních a kalibračních laboratoří</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-15189 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">ISO 15189</h3>
-                    <p class="text-muted mb-0">Kvalita zdravotnických laboratoří</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon haccp mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">HACCP</h3>
-                    <p class="text-muted mb-0">Bezpečnost a kontrola potravin</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-45001 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">ISO 45001</h3>
-                    <p class="text-muted mb-0">Bezpečnost a ochrana zdraví při práci</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-27001 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">ISO/IEC 27001</h3>
-                    <p class="text-muted mb-0">Řízení bezpečnosti informací</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iatf-16949 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">IATF 16949</h3>
-                    <p class="text-muted mb-0">Automotive Quality Management</p>
-                </div>
-            </div>
-            <div class="col">
-                <div class="specialization-card h-100 text-center p-4">
-                    <div class="specialization-icon iso-13485 mb-3">
-                        <i class="bi bi-award-fill" aria-hidden="true"></i>
-                    </div>
-                    <h3 class="h4 fw-bold mb-2">ISO 13485</h3>
-                    <p class="text-muted mb-0">Management kvality zdravotnických prostředků</p>
-                </div>
-            </div>
+            }
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- consolidate the ISO specialization information into a single data collection on the index page
- render both specialization sections from the shared data to remove duplicated markup while preserving design

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e65bc934f88321a84665100530af5b