### PR TITLE
Localize admin dashboard label

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -56,8 +56,7 @@
                             {
                                 <a class="btn btn-dark d-flex align-items-center gap-2 px-3" asp-page="/Admin/Dashboard/Index">
                                     <i class="bi bi-speedometer2" aria-hidden="true"></i>
-                                    <!-- ✅ SPRÁVNĚ: Admin Dashboard zůstává v češtině -->
-                                    <span>Admin Dashboard</span>
+                                    <span>@Localizer["AdminDashboard"]</span>
                                 </a>
                             }
                             <button class="btn btn-light btn-sm rounded-pill px-4 d-flex align-items-center gap-2"

--- a/Resources/Pages.Shared._Layout.cshtml.en.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.en.resx
@@ -46,7 +46,7 @@
     <value>Privacy</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">
-    <value>Administration</value>
+    <value>Admin Dashboard</value>
   </data>
   <data name="AdvisorButton" xml:space="preserve">
     <value>Get advice</value>

--- a/Resources/Pages.Shared._Layout.cshtml.resx
+++ b/Resources/Pages.Shared._Layout.cshtml.resx
@@ -46,7 +46,7 @@
     <value>Ochrana soukromí</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">
-    <value>Administrace</value>
+    <value>Admin Dashboard</value>
   </data>
   <data name="AdvisorButton" xml:space="preserve">
     <value>Poradit s výběrem</value>

--- a/Resources/Views/Shared/_Layout.cshtml.en.resx
+++ b/Resources/Views/Shared/_Layout.cshtml.en.resx
@@ -46,7 +46,7 @@
     <value>Privacy</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">
-    <value>Administration</value>
+    <value>Admin Dashboard</value>
   </data>
   <data name="AdvisorButton" xml:space="preserve">
     <value>Get advice</value>

--- a/Resources/Views/Shared/_Layout.cshtml.resx
+++ b/Resources/Views/Shared/_Layout.cshtml.resx
@@ -46,7 +46,7 @@
     <value>Ochrana soukromí</value>
   </data>
   <data name="AdminDashboard" xml:space="preserve">
-    <value>Administrace</value>
+    <value>Admin Dashboard</value>
   </data>
   <data name="AdvisorButton" xml:space="preserve">
     <value>Poradit s výběrem</value>


### PR DESCRIPTION
## Summary
- update the admin dashboard button in the shared layout to use the localized resource string
- align English and Czech resource entries with the new "Admin Dashboard" text for both page and view layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e65f596588832183365049b072dda7