### PR TITLE
Add invoice API endpoints and integration tests

### DIFF
--- a/Controllers/InvoicesController.cs
+++ b/Controllers/InvoicesController.cs
@@ -1,0 +1,377 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Xml.Schema;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SysJaky_N.Models.Billing;
+using SysJaky_N.Services.Pohoda;
+
+namespace SysJaky_N.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class InvoicesController : ControllerBase
+{
+    private readonly IPohodaClient _pohodaClient;
+    private readonly PohodaXmlBuilder _xmlBuilder;
+    private readonly PohodaXmlOptions _options;
+
+    public InvoicesController(
+        IPohodaClient pohodaClient,
+        PohodaXmlBuilder xmlBuilder,
+        PohodaXmlOptions options)
+    {
+        _pohodaClient = pohodaClient ?? throw new ArgumentNullException(nameof(pohodaClient));
+        _xmlBuilder = xmlBuilder ?? throw new ArgumentNullException(nameof(xmlBuilder));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateInvoice([FromBody] CreateInvoiceRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var invoice = MapInvoice(request);
+            var xml = _xmlBuilder.BuildIssuedInvoiceXml(invoice, _options.Application);
+            var correlationId = $"pohoda-api-{Guid.NewGuid():N}";
+            var response = await _pohodaClient
+                .SendInvoiceAsync(xml, correlationId, cancellationToken)
+                .ConfigureAwait(false);
+
+            return Ok(new InvoiceCreatedResponse(
+                response.State,
+                response.DocumentNumber,
+                response.DocumentId,
+                response.Warnings,
+                response.Errors));
+        }
+        catch (Exception ex)
+        {
+            if (TryMapException(ex, out var mapped))
+            {
+                return mapped;
+            }
+
+            throw;
+        }
+    }
+
+    [HttpGet("{idOrNumber}")]
+    public async Task<IActionResult> GetInvoiceStatus(string idOrNumber, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(idOrNumber))
+        {
+            return CreateProblem(
+                StatusCodes.Status400BadRequest,
+                "Invalid identifier",
+                "Invoice identifier must be provided.");
+        }
+
+        var trimmed = idOrNumber.Trim();
+
+        try
+        {
+            var filter = new PohodaListFilter
+            {
+                Number = trimmed,
+                VariableSymbol = trimmed
+            };
+
+            var invoices = await _pohodaClient
+                .ListInvoicesAsync(filter, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (invoices.Count == 0)
+            {
+                return NotFound();
+            }
+
+            return Ok(new InvoiceStatusResponse(trimmed, invoices.ToArray()));
+        }
+        catch (Exception ex)
+        {
+            if (TryMapException(ex, out var mapped))
+            {
+                return mapped;
+            }
+
+            throw;
+        }
+    }
+
+    private bool TryMapException(Exception exception, out IActionResult result)
+    {
+        switch (exception)
+        {
+            case ValidationException validationException:
+                result = CreateProblem(
+                    StatusCodes.Status400BadRequest,
+                    "Invoice validation failed",
+                    validationException.Message);
+                return true;
+            case XmlSchemaValidationException schemaException:
+                result = CreateProblem(
+                    StatusCodes.Status400BadRequest,
+                    "Invoice validation failed",
+                    schemaException.Message);
+                return true;
+            case PohodaXmlException pohodaException:
+                result = CreateProblem(
+                    StatusCodes.Status502BadGateway,
+                    "Pohoda service error",
+                    pohodaException.Message,
+                    problem =>
+                    {
+                        if (pohodaException.PayloadLog?.HasData == true)
+                        {
+                            problem.Extensions["payloadLog"] = new
+                            {
+                                pohodaException.PayloadLog.RequestPath,
+                                pohodaException.PayloadLog.ResponsePath
+                            };
+                        }
+                    });
+                return true;
+            default:
+                result = default!;
+                return false;
+        }
+    }
+
+    private ObjectResult CreateProblem(
+        int statusCode,
+        string title,
+        string detail,
+        Action<ProblemDetails>? configure = null)
+    {
+        var problem = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail
+        };
+
+        configure?.Invoke(problem);
+
+        return StatusCode(statusCode, problem);
+    }
+
+    private static Invoice MapInvoice(CreateInvoiceRequest request)
+    {
+        if (request.Header is null)
+        {
+            throw new ValidationException("Invoice header is required.");
+        }
+
+        if (request.Summary is null)
+        {
+            throw new ValidationException("Invoice summary is required.");
+        }
+
+        if (request.Items is null || request.Items.Count == 0)
+        {
+            throw new ValidationException("Invoice must contain at least one item.");
+        }
+
+        var customer = request.Header.Customer is null
+            ? null
+            : new CustomerIdentity(
+                request.Header.Customer.Company,
+                request.Header.Customer.Name,
+                request.Header.Customer.Street,
+                request.Header.Customer.City,
+                request.Header.Customer.Zip,
+                request.Header.Customer.Country);
+
+        var header = new InvoiceHeader(
+            request.Header.InvoiceType,
+            request.Header.OrderNumber,
+            request.Header.Text,
+            request.Header.Date,
+            request.Header.TaxDate,
+            request.Header.DueDate,
+            request.Header.VariableSymbol,
+            request.Header.SpecificSymbol,
+            customer,
+            request.Header.Note);
+
+        var items = request.Items
+            .Select(item => new InvoiceItem(
+                item.Name,
+                item.Quantity,
+                item.UnitPriceExclVat,
+                item.TotalExclVat,
+                item.VatAmount,
+                item.TotalInclVat,
+                item.Discount,
+                item.Rate))
+            .ToList();
+
+        var summary = new VatSummary(
+            request.Summary.TotalExclVat,
+            request.Summary.TotalVat,
+            request.Summary.TotalInclVat,
+            request.Summary.NoneRateBase,
+            request.Summary.LowRateBase,
+            request.Summary.LowRateVat,
+            request.Summary.HighRateBase,
+            request.Summary.HighRateVat);
+
+        return Invoice.Create(header, items, summary);
+    }
+
+    public sealed record InvoiceCreatedResponse(
+        string State,
+        string? DocumentNumber,
+        string? DocumentId,
+        IReadOnlyList<string> Warnings,
+        IReadOnlyList<string> Errors);
+
+    public sealed record InvoiceStatusResponse(
+        string Query,
+        IReadOnlyCollection<InvoiceStatus> Invoices);
+
+    public sealed class CreateInvoiceRequest
+    {
+        [Required]
+        public InvoiceHeaderDto? Header { get; init; }
+            = default!;
+
+        [Required]
+        [MinLength(1)]
+        public List<InvoiceItemDto>? Items { get; init; }
+            = new();
+
+        [Required]
+        public VatSummaryDto? Summary { get; init; }
+            = default!;
+    }
+
+    public sealed class InvoiceHeaderDto
+    {
+        [Required]
+        [StringLength(64)]
+        public string InvoiceType { get; init; } = string.Empty;
+
+        [Required]
+        [StringLength(64)]
+        public string OrderNumber { get; init; } = string.Empty;
+
+        [Required]
+        [StringLength(256)]
+        public string Text { get; init; } = string.Empty;
+
+        [DataType(DataType.Date)]
+        public DateOnly Date { get; init; }
+            = DateOnly.FromDateTime(DateTime.Today);
+
+        [DataType(DataType.Date)]
+        public DateOnly TaxDate { get; init; }
+            = DateOnly.FromDateTime(DateTime.Today);
+
+        [DataType(DataType.Date)]
+        public DateOnly DueDate { get; init; }
+            = DateOnly.FromDateTime(DateTime.Today);
+
+        [Required]
+        [StringLength(32)]
+        public string VariableSymbol { get; init; } = string.Empty;
+
+        [StringLength(32)]
+        public string? SpecificSymbol { get; init; }
+            = null;
+
+        public CustomerIdentityDto? Customer { get; init; }
+            = null;
+
+        [StringLength(512)]
+        public string? Note { get; init; }
+            = null;
+    }
+
+    public sealed class CustomerIdentityDto
+    {
+        [StringLength(255)]
+        public string? Company { get; init; }
+            = null;
+
+        [StringLength(255)]
+        public string? Name { get; init; }
+            = null;
+
+        [StringLength(255)]
+        public string? Street { get; init; }
+            = null;
+
+        [StringLength(255)]
+        public string? City { get; init; }
+            = null;
+
+        [StringLength(32)]
+        public string? Zip { get; init; }
+            = null;
+
+        [StringLength(64)]
+        public string? Country { get; init; }
+            = null;
+    }
+
+    public sealed class InvoiceItemDto
+    {
+        [Required]
+        [StringLength(255)]
+        public string Name { get; init; } = string.Empty;
+
+        [Range(1, int.MaxValue)]
+        public int Quantity { get; init; }
+            = 1;
+
+        public decimal UnitPriceExclVat { get; init; }
+            = 0m;
+
+        public decimal TotalExclVat { get; init; }
+            = 0m;
+
+        public decimal VatAmount { get; init; }
+            = 0m;
+
+        public decimal TotalInclVat { get; init; }
+            = 0m;
+
+        public decimal Discount { get; init; }
+            = 0m;
+
+        [Required]
+        public VatRate Rate { get; init; }
+            = VatRate.High;
+    }
+
+    public sealed class VatSummaryDto
+    {
+        public decimal TotalExclVat { get; init; }
+            = 0m;
+
+        public decimal TotalVat { get; init; }
+            = 0m;
+
+        public decimal TotalInclVat { get; init; }
+            = 0m;
+
+        public decimal? NoneRateBase { get; init; }
+            = null;
+
+        public decimal? LowRateBase { get; init; }
+            = null;
+
+        public decimal? LowRateVat { get; init; }
+            = null;
+
+        public decimal? HighRateBase { get; init; }
+            = null;
+
+        public decimal? HighRateVat { get; init; }
+            = null;
+    }
+}

--- a/Program.Partial.cs
+++ b/Program.Partial.cs
@@ -1,0 +1,5 @@
+namespace SysJaky_N;
+
+public partial class Program
+{
+}

--- a/Program.cs
+++ b/Program.cs
@@ -454,6 +454,19 @@ try
                 JsonSerializer.Serialize(response, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
         }
     });
+    app.MapGet("/health/pohoda", async (
+        IPohodaClient pohodaClient,
+        CancellationToken cancellationToken) =>
+    {
+        var healthy = await pohodaClient.CheckStatusAsync(cancellationToken).ConfigureAwait(false);
+        return healthy
+            ? Results.Content("{\"status\":\"Healthy\"}", "application/json")
+            : Results.Content(
+                "{\"status\":\"Unhealthy\"}",
+                "application/json",
+                contentEncoding: System.Text.Encoding.UTF8,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+    });
     app.MapGet("/Orders/Edit/{id:int}", (int id) => Results.Redirect($"/Admin/Orders/Edit/{id}", true));
     app.MapPost("/payment/webhook", async (HttpRequest request, PaymentService paymentService) =>
     {

--- a/SysJaky_N.Tests/InvoiceApiTests.cs
+++ b/SysJaky_N.Tests/InvoiceApiTests.cs
@@ -1,0 +1,238 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SysJaky_N.Controllers;
+using SysJaky_N.Models.Billing;
+using SysJaky_N.Services.Pohoda;
+
+namespace SysJaky_N.Tests;
+
+public class InvoiceApiTests
+{
+    [Fact]
+    public async Task PostInvoices_ReturnsDocumentInfo()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var pohodaClient = factory.PohodaClientMock;
+        pohodaClient.Reset();
+
+        pohodaClient
+            .Setup(client => client.SendInvoiceAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PohodaResponse(
+                "ok",
+                "INV-001",
+                "12345",
+                Array.Empty<string>(),
+                Array.Empty<string>()));
+
+        using var client = CreateHttpClient(factory);
+        var response = await client.PostAsJsonAsync("/api/invoices", CreateInvoiceRequest());
+
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<InvoicesController.InvoiceCreatedResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("INV-001", payload.DocumentNumber);
+        Assert.Equal("12345", payload.DocumentId);
+
+        pohodaClient.Verify(client => client.SendInvoiceAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PostInvoices_ReturnsBadGatewayWhenPohodaFails()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var pohodaClient = factory.PohodaClientMock;
+        pohodaClient.Reset();
+
+        pohodaClient
+            .Setup(client => client.SendInvoiceAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PohodaXmlException(
+                "Remote failure",
+                payloadLog: new PohodaPayloadLog("request.xml", "response.xml")));
+
+        using var client = CreateHttpClient(factory);
+        var response = await client.PostAsJsonAsync("/api/invoices", CreateInvoiceRequest());
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal("Pohoda service error", problem.Title);
+        Assert.True(problem.Extensions.ContainsKey("payloadLog"));
+
+        pohodaClient.Verify(client => client.SendInvoiceAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetInvoices_ReturnsStatuses()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var pohodaClient = factory.PohodaClientMock;
+        pohodaClient.Reset();
+
+        var status = new InvoiceStatus(
+            "2024-0001",
+            "1001",
+            121m,
+            true,
+            DateOnly.FromDateTime(DateTime.Today.AddDays(14)),
+            DateOnly.FromDateTime(DateTime.Today));
+
+        pohodaClient
+            .Setup(client => client.ListInvoicesAsync(
+                It.IsAny<PohodaListFilter>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { status });
+
+        using var client = CreateHttpClient(factory);
+        var response = await client.GetAsync("/api/invoices/2024-0001");
+
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<InvoicesController.InvoiceStatusResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("2024-0001", payload.Query);
+        Assert.Single(payload.Invoices);
+        Assert.Equal(status.Number, payload.Invoices.First().Number);
+
+        pohodaClient.Verify(client => client.ListInvoicesAsync(
+            It.IsAny<PohodaListFilter>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetInvoices_ReturnsNotFoundWhenMissing()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var pohodaClient = factory.PohodaClientMock;
+        pohodaClient.Reset();
+
+        pohodaClient
+            .Setup(client => client.ListInvoicesAsync(
+                It.IsAny<PohodaListFilter>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<InvoiceStatus>());
+
+        using var client = CreateHttpClient(factory);
+        var response = await client.GetAsync("/api/invoices/missing");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        pohodaClient.Verify(client => client.ListInvoicesAsync(
+            It.IsAny<PohodaListFilter>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HealthCheck_ReturnsOkWhenHealthy()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var pohodaClient = factory.PohodaClientMock;
+        pohodaClient.Reset();
+
+        pohodaClient
+            .Setup(client => client.CheckStatusAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        using var client = CreateHttpClient(factory);
+        var response = await client.GetAsync("/health/pohoda");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        pohodaClient.Verify(client => client.CheckStatusAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task HealthCheck_ReturnsServiceUnavailableWhenUnhealthy()
+    {
+        using var factory = new TestWebApplicationFactory();
+        var pohodaClient = factory.PohodaClientMock;
+        pohodaClient.Reset();
+
+        pohodaClient
+            .Setup(client => client.CheckStatusAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        using var client = CreateHttpClient(factory);
+        var response = await client.GetAsync("/health/pohoda");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+
+        pohodaClient.Verify(client => client.CheckStatusAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static HttpClient CreateHttpClient(TestWebApplicationFactory factory)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.AcceptEncoding.Clear();
+        client.DefaultRequestHeaders.AcceptEncoding.ParseAdd("identity");
+        return client;
+    }
+
+    private static InvoicesController.CreateInvoiceRequest CreateInvoiceRequest()
+    {
+        return new InvoicesController.CreateInvoiceRequest
+        {
+            Header = new InvoicesController.InvoiceHeaderDto
+            {
+                InvoiceType = "issuedInvoice",
+                OrderNumber = "ORDER-1",
+                Text = "Test invoice",
+                Date = DateOnly.FromDateTime(DateTime.Today),
+                TaxDate = DateOnly.FromDateTime(DateTime.Today),
+                DueDate = DateOnly.FromDateTime(DateTime.Today.AddDays(14)),
+                VariableSymbol = "1234567890",
+                Customer = new InvoicesController.CustomerIdentityDto
+                {
+                    Company = "ACME",
+                    Name = "John Doe",
+                    Street = "Main Street 1",
+                    City = "Prague",
+                    Zip = "11000",
+                    Country = "CZ"
+                },
+                Note = "Test note"
+            },
+            Items = new List<InvoicesController.InvoiceItemDto>
+            {
+                new()
+                {
+                    Name = "Course",
+                    Quantity = 1,
+                    UnitPriceExclVat = 100m,
+                    TotalExclVat = 100m,
+                    VatAmount = 21m,
+                    TotalInclVat = 121m,
+                    Discount = 0m,
+                    Rate = VatRate.High
+                }
+            },
+            Summary = new InvoicesController.VatSummaryDto
+            {
+                TotalExclVat = 100m,
+                TotalVat = 21m,
+                TotalInclVat = 121m,
+                HighRateBase = 100m,
+                HighRateVat = 21m
+            }
+        };
+    }
+}

--- a/SysJaky_N.Tests/SysJaky_N.Tests.csproj
+++ b/SysJaky_N.Tests/SysJaky_N.Tests.csproj
@@ -10,9 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/SysJaky_N.Tests/TestWebApplicationFactory.cs
+++ b/SysJaky_N.Tests/TestWebApplicationFactory.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using SysJaky_N.Services.Pohoda;
+
+namespace SysJaky_N.Tests;
+
+public sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    public Mock<IPohodaClient> PohodaClientMock { get; } = new(MockBehavior.Strict);
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((context, configurationBuilder) =>
+        {
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["UseInMemoryDatabase"] = "true"
+            });
+        });
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll(typeof(IPohodaClient));
+            services.AddSingleton(_ => PohodaClientMock.Object);
+
+            services.RemoveAll(typeof(IHostedService));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add an API controller for Pohoda invoice export and status lookup with structured error mapping
- expose a Pohoda XML client health endpoint
- add integration tests with a mocked IPohodaClient and supporting test infrastructure

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build SysJaky_N.Tests/SysJaky_N.Tests.csproj`
- `dotnet vstest SysJaky_N.Tests/bin/Debug/net9.0/SysJaky_N.Tests.dll /Logger:trx;LogFileName=TestResults.trx`


------
https://chatgpt.com/codex/tasks/task_e_68f87280d0408321aab3e345a56f4fdd