### PR TITLE
Handle disabled Pohoda exports and add manual processing

### DIFF
--- a/Pages/Admin/Orders/PohodaExportJobs.cshtml
+++ b/Pages/Admin/Orders/PohodaExportJobs.cshtml
@@ -14,6 +14,12 @@
     <div class="alert alert-info">@Model.StatusMessage</div>
 }
 
+<div class="d-flex justify-content-end mb-3">
+    <form method="post" asp-page-handler="ProcessPending">
+        <button type="submit" class="btn btn-outline-primary">@Localizer["ActionProcessPending"]</button>
+    </form>
+</div>
+
 <div class="row g-3 mb-4">
     @foreach (var status in Enum.GetValues<PohodaExportJobStatus>())
     {

--- a/Pages/Admin/Orders/PohodaExportJobs.cshtml.cs
+++ b/Pages/Admin/Orders/PohodaExportJobs.cshtml.cs
@@ -132,6 +132,16 @@ public class PohodaExportJobsModel : PageModel
         return RedirectToPage();
     }
 
+    public async Task<IActionResult> OnPostProcessPendingAsync(CancellationToken cancellationToken)
+    {
+        var processed = await _pohodaExportService
+            .ProcessPendingJobsAsync(cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        StatusMessage = _localizer["StatusProcessedPending", processed];
+        return RedirectToPage();
+    }
+
     public sealed class PohodaExportJobRow
     {
         public int Id { get; init; }

--- a/Resources/Pages/Admin/Orders/PohodaExportJobsModel.en.resx
+++ b/Resources/Pages/Admin/Orders/PohodaExportJobsModel.en.resx
@@ -69,6 +69,9 @@
   <data name="ActionForce" xml:space="preserve">
     <value>Force export</value>
   </data>
+  <data name="ActionProcessPending" xml:space="preserve">
+    <value>Process pending jobs</value>
+  </data>
   <data name="TableNote" xml:space="preserve">
     <value>Showing the 100 most recent Pohoda export jobs.</value>
   </data>
@@ -95,5 +98,8 @@
   </data>
   <data name="StatusJobExecutionFailed" xml:space="preserve">
     <value>Job {0} could not be executed. Check the logs.</value>
+  </data>
+  <data name="StatusProcessedPending" xml:space="preserve">
+    <value>Processed {0} jobs.</value>
   </data>
 </root>

--- a/Resources/Pages/Admin/Orders/PohodaExportJobsModel.resx
+++ b/Resources/Pages/Admin/Orders/PohodaExportJobsModel.resx
@@ -69,6 +69,9 @@
   <data name="ActionForce" xml:space="preserve">
     <value>Vynutit export</value>
   </data>
+  <data name="ActionProcessPending" xml:space="preserve">
+    <value>Zpracovat čekající joby</value>
+  </data>
   <data name="TableNote" xml:space="preserve">
     <value>Zobrazuje posledních 100 exportních jobů do Pohody.</value>
   </data>
@@ -95,5 +98,8 @@
   </data>
   <data name="StatusJobExecutionFailed" xml:space="preserve">
     <value>Job {0} se nepodařilo spustit. Zkontrolujte logy.</value>
+  </data>
+  <data name="StatusProcessedPending" xml:space="preserve">
+    <value>Zpracováno {0} jobů.</value>
   </data>
 </root>

--- a/Services/Pohoda/IPohodaExportService.cs
+++ b/Services/Pohoda/IPohodaExportService.cs
@@ -11,4 +11,6 @@ public interface IPohodaExportService
     Task ExportOrderAsync(PohodaExportJob job, CancellationToken cancellationToken = default);
 
     Task MarkInvoiceGeneratedAsync(Order order, string invoicePath, CancellationToken cancellationToken = default);
+
+    Task<int> ProcessPendingJobsAsync(int? maxJobs = null, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- generate Pohoda XML exports immediately into the configured temp directory when the integration is disabled
- add an admin control and service entry point to process pending Pohoda export jobs on demand
- extend Pohoda export unit tests for immediate file generation and manual job processing

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68f729a62be88321a852593dcb755361