### PR TITLE
Refactor Pohoda XML builder to use DTOs

### DIFF
--- a/Controllers/InvoicesController.cs
+++ b/Controllers/InvoicesController.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Xml.Schema;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using SysJaky_N.Models.Billing;
 using SysJaky_N.Services.Pohoda;
 
 namespace SysJaky_N.Controllers;
@@ -158,7 +157,7 @@ public sealed class InvoicesController : ControllerBase
         return StatusCode(statusCode, problem);
     }
 
-    private static Invoice MapInvoice(CreateInvoiceRequest request)
+    private static InvoiceDto MapInvoice(CreateInvoiceRequest request)
     {
         if (request.Header is null)
         {
@@ -209,7 +208,9 @@ public sealed class InvoicesController : ControllerBase
                 item.Rate))
             .ToList();
 
-        var summary = new VatSummary(
+        return InvoiceDto.Create(
+            header,
+            items,
             request.Summary.TotalExclVat,
             request.Summary.TotalVat,
             request.Summary.TotalInclVat,
@@ -218,8 +219,6 @@ public sealed class InvoicesController : ControllerBase
             request.Summary.LowRateVat,
             request.Summary.HighRateBase,
             request.Summary.HighRateVat);
-
-        return Invoice.Create(header, items, summary);
     }
 
     public sealed record InvoiceCreatedResponse(

--- a/Services/Pohoda/InvoiceDto.cs
+++ b/Services/Pohoda/InvoiceDto.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace SysJaky_N.Services.Pohoda;
+
+public enum VatRate
+{
+    None,
+    Low,
+    High
+}
+
+public sealed record CustomerIdentity(
+    [property: StringLength(255)] string? Company,
+    [property: StringLength(255)] string? Name,
+    [property: StringLength(255)] string? Street,
+    [property: StringLength(255)] string? City,
+    [property: StringLength(32)] string? Zip,
+    [property: StringLength(64)] string? Country);
+
+public sealed record InvoiceItem(
+    [property: Required, StringLength(255)] string Name,
+    [property: Range(1, int.MaxValue)] int Quantity,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal UnitPriceExclVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal TotalExclVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal VatAmount,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal TotalInclVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal Discount,
+    VatRate Rate)
+{
+    public decimal DiscountPercentage => TotalInclVat == 0m
+        ? 0m
+        : Math.Round(Discount / TotalInclVat * 100m, 2, MidpointRounding.AwayFromZero);
+}
+
+public sealed record InvoiceHeader(
+    [property: Required, StringLength(64)] string InvoiceType,
+    [property: Required, StringLength(64)] string OrderNumber,
+    [property: Required, StringLength(256)] string Text,
+    [property: DataType(DataType.Date)] DateOnly Date,
+    [property: DataType(DataType.Date)] DateOnly TaxDate,
+    [property: DataType(DataType.Date)] DateOnly DueDate,
+    [property: Required, StringLength(32)] string VariableSymbol,
+    [property: StringLength(32)] string? SpecificSymbol,
+    CustomerIdentity? Customer,
+    [property: StringLength(512)] string? Note);
+
+public sealed record InvoiceDto(
+    [property: Required] InvoiceHeader Header,
+    [property: Required] IReadOnlyList<InvoiceItem> Items,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal TotalExclVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal TotalVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal TotalInclVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal? NoneRateBase,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal? LowRateBase,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal? LowRateVat,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal? HighRateBase,
+    [property: Range(typeof(decimal), PohodaInvoiceValidationConstants.DecimalMinimum, PohodaInvoiceValidationConstants.DecimalMaximum)] decimal? HighRateVat)
+{
+    public static InvoiceDto Create(
+        InvoiceHeader header,
+        IEnumerable<InvoiceItem> items,
+        decimal totalExclVat,
+        decimal totalVat,
+        decimal totalInclVat,
+        decimal? noneRateBase,
+        decimal? lowRateBase,
+        decimal? lowRateVat,
+        decimal? highRateBase,
+        decimal? highRateVat)
+    {
+        ArgumentNullException.ThrowIfNull(header);
+        ArgumentNullException.ThrowIfNull(items);
+
+        var materializedItems = items as IList<InvoiceItem> ?? items.ToList();
+        if (materializedItems.Count == 0)
+        {
+            throw new ValidationException("Invoice must contain at least one item.");
+        }
+
+        IReadOnlyList<InvoiceItem> readOnlyItems = materializedItems as IReadOnlyList<InvoiceItem>
+            ?? new ReadOnlyCollection<InvoiceItem>(materializedItems.ToList());
+
+        return new InvoiceDto(
+            header,
+            readOnlyItems,
+            totalExclVat,
+            totalVat,
+            totalInclVat,
+            noneRateBase,
+            lowRateBase,
+            lowRateVat,
+            highRateBase,
+            highRateVat);
+    }
+}
+
+internal static class PohodaInvoiceValidationConstants
+{
+    public const string DecimalMinimum = "0";
+    public const string DecimalMaximum = "79228162514264337593543950335";
+}

--- a/Services/Pohoda/PohodaOrderPayload.cs
+++ b/Services/Pohoda/PohodaOrderPayload.cs
@@ -1,12 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.IO;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
-using SysJaky_N.Models.Billing;
+using System.Linq;
 
 namespace SysJaky_N.Services.Pohoda;
 
@@ -26,13 +26,13 @@ public static class PohodaOrderPayload
         Windows1250Encoding = Encoding.GetEncoding("windows-1250");
     }
 
-    public static string CreateInvoiceDataPack(Invoice invoice, string? applicationName = null)
+    public static string CreateInvoiceDataPack(InvoiceDto invoice, string? applicationName = null)
     {
         ArgumentNullException.ThrowIfNull(invoice);
 
         var header = BuildInvoiceHeader(invoice.Header);
         var detail = BuildInvoiceDetail(invoice.Items);
-        var summary = BuildInvoiceSummary(invoice.Summary);
+        var summary = BuildInvoiceSummary(invoice);
 
         var dataPack = new XElement(Dat + "dataPack",
             new XAttribute(XNamespace.Xmlns + "dat", Dat),
@@ -195,17 +195,17 @@ public static class PohodaOrderPayload
         return detail;
     }
 
-    private static XElement BuildInvoiceSummary(VatSummary summary)
+    private static XElement BuildInvoiceSummary(InvoiceDto invoice)
     {
         var summaryElement = new XElement(Inv + "invoiceSummary",
             new XElement(Inv + "round", "none"),
             new XElement(Inv + "homeCurrency",
-                summary.NoneRateBase is > 0m ? new XElement(Typ + "priceNone", FormatDecimal(summary.NoneRateBase.Value)) : null,
-                summary.LowRateBase is > 0m ? new XElement(Typ + "priceLow", FormatDecimal(summary.LowRateBase.Value)) : null,
-                summary.LowRateVat is > 0m ? new XElement(Typ + "priceLowVAT", FormatDecimal(summary.LowRateVat.Value)) : null,
-                summary.HighRateBase is > 0m ? new XElement(Typ + "priceHigh", FormatDecimal(summary.HighRateBase.Value)) : null,
-                summary.HighRateVat is > 0m ? new XElement(Typ + "priceHighVAT", FormatDecimal(summary.HighRateVat.Value)) : null,
-                new XElement(Typ + "priceSum", FormatDecimal(summary.TotalInclVat))));
+                invoice.NoneRateBase is > 0m ? new XElement(Typ + "priceNone", FormatDecimal(invoice.NoneRateBase.Value)) : null,
+                invoice.LowRateBase is > 0m ? new XElement(Typ + "priceLow", FormatDecimal(invoice.LowRateBase.Value)) : null,
+                invoice.LowRateVat is > 0m ? new XElement(Typ + "priceLowVAT", FormatDecimal(invoice.LowRateVat.Value)) : null,
+                invoice.HighRateBase is > 0m ? new XElement(Typ + "priceHigh", FormatDecimal(invoice.HighRateBase.Value)) : null,
+                invoice.HighRateVat is > 0m ? new XElement(Typ + "priceHighVAT", FormatDecimal(invoice.HighRateVat.Value)) : null,
+                new XElement(Typ + "priceSum", FormatDecimal(invoice.TotalInclVat))));
 
         return summaryElement;
     }

--- a/Services/Pohoda/PohodaXmlBuilder.cs
+++ b/Services/Pohoda/PohodaXmlBuilder.cs
@@ -1,14 +1,24 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Schema;
-using SysJaky_N.Models.Billing;
 
 namespace SysJaky_N.Services.Pohoda;
 
 public sealed class PohodaXmlBuilder
 {
     private readonly IReadOnlyCollection<XmlSchema> _schemas;
+    private static readonly Encoding Windows1250Encoding;
+
+    static PohodaXmlBuilder()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        Windows1250Encoding = Encoding.GetEncoding("windows-1250");
+    }
 
     public PohodaXmlBuilder(IEnumerable<XmlSchema> schemas)
     {
@@ -21,13 +31,209 @@ public sealed class PohodaXmlBuilder
             ?? schemas.ToList().AsReadOnly();
     }
 
-    public string BuildIssuedInvoiceXml(Invoice invoice, string? applicationName = null)
+    public string BuildIssuedInvoiceXml(InvoiceDto invoice, string? applicationName = null)
     {
         ArgumentNullException.ThrowIfNull(invoice);
 
-        var xml = PohodaOrderPayload.CreateInvoiceDataPack(invoice, applicationName);
-        PohodaOrderPayload.ValidateAgainstXsd(xml, _schemas);
+        var settings = new XmlWriterSettings
+        {
+            Encoding = Windows1250Encoding,
+            Indent = true,
+            OmitXmlDeclaration = false,
+            NewLineHandling = NewLineHandling.Entitize
+        };
+
+        using var stream = new MemoryStream();
+        using (var writer = XmlWriter.Create(stream, settings))
+        {
+            WriteInvoice(writer, invoice, applicationName);
+        }
+
+        var xml = Windows1250Encoding.GetString(stream.ToArray());
+        ValidateAgainstSchemas(xml);
         return xml;
     }
 
+    private static void WriteInvoice(XmlWriter writer, InvoiceDto invoice, string? applicationName)
+    {
+        const string DatNamespace = "http://www.stormware.cz/schema/version_2/data.xsd";
+        const string InvNamespace = "http://www.stormware.cz/schema/version_2/invoice.xsd";
+        const string TypNamespace = "http://www.stormware.cz/schema/version_2/type.xsd";
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement("dat", "dataPack", DatNamespace);
+        writer.WriteAttributeString("xmlns", "dat", null, DatNamespace);
+        writer.WriteAttributeString("xmlns", "inv", null, InvNamespace);
+        writer.WriteAttributeString("xmlns", "typ", null, TypNamespace);
+
+        var identifier = $"Invoice-{invoice.Header.OrderNumber}";
+        writer.WriteAttributeString("id", identifier);
+        writer.WriteAttributeString("version", "2.0");
+        if (!string.IsNullOrWhiteSpace(applicationName))
+        {
+            writer.WriteAttributeString("application", applicationName);
+        }
+
+        writer.WriteStartElement("dat", "dataPackItem", DatNamespace);
+        writer.WriteAttributeString("id", identifier);
+        writer.WriteAttributeString("version", "2.0");
+
+        writer.WriteStartElement("inv", "invoice", InvNamespace);
+        WriteInvoiceHeader(writer, invoice.Header, InvNamespace, TypNamespace);
+        WriteInvoiceDetail(writer, invoice.Items, InvNamespace, TypNamespace);
+        WriteInvoiceSummary(writer, invoice, InvNamespace, TypNamespace);
+        writer.WriteEndElement();
+
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
+    }
+
+    private static void WriteInvoiceHeader(XmlWriter writer, InvoiceHeader header, string invNamespace, string typNamespace)
+    {
+        writer.WriteStartElement("inv", "invoiceHeader", invNamespace);
+        writer.WriteElementString("inv", "invoiceType", invNamespace, header.InvoiceType);
+        writer.WriteElementString("inv", "numberOrder", invNamespace, header.OrderNumber);
+        writer.WriteElementString("inv", "text", invNamespace, header.Text);
+        writer.WriteElementString("inv", "date", invNamespace, header.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        writer.WriteElementString("inv", "dateTax", invNamespace, header.TaxDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        writer.WriteElementString("inv", "dateDue", invNamespace, header.DueDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        writer.WriteElementString("inv", "symVar", invNamespace, header.VariableSymbol);
+
+        if (!string.IsNullOrWhiteSpace(header.SpecificSymbol))
+        {
+            writer.WriteElementString("inv", "symSpec", invNamespace, header.SpecificSymbol);
+        }
+
+        if (header.Customer is not null)
+        {
+            writer.WriteStartElement("inv", "partnerIdentity", invNamespace);
+            writer.WriteStartElement("typ", "address", typNamespace);
+            WriteCustomerField(writer, typNamespace, "company", header.Customer.Company);
+            WriteCustomerField(writer, typNamespace, "name", header.Customer.Name);
+            WriteCustomerField(writer, typNamespace, "street", header.Customer.Street);
+            WriteCustomerField(writer, typNamespace, "city", header.Customer.City);
+            WriteCustomerField(writer, typNamespace, "zip", header.Customer.Zip);
+            WriteCustomerField(writer, typNamespace, "country", header.Customer.Country);
+            writer.WriteEndElement();
+            writer.WriteEndElement();
+        }
+
+        if (!string.IsNullOrWhiteSpace(header.Note))
+        {
+            writer.WriteElementString("inv", "note", invNamespace, header.Note);
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void WriteCustomerField(XmlWriter writer, string typNamespace, string elementName, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            writer.WriteElementString("typ", elementName, typNamespace, value);
+        }
+    }
+
+    private static void WriteInvoiceDetail(XmlWriter writer, IReadOnlyCollection<InvoiceItem> items, string invNamespace, string typNamespace)
+    {
+        writer.WriteStartElement("inv", "invoiceDetail", invNamespace);
+
+        foreach (var item in items)
+        {
+            writer.WriteStartElement("inv", "invoiceItem", invNamespace);
+            writer.WriteElementString("inv", "text", invNamespace, item.Name);
+            writer.WriteElementString("inv", "quantity", invNamespace, item.Quantity.ToString(CultureInfo.InvariantCulture));
+            writer.WriteElementString("inv", "rateVAT", invNamespace, MapVatRate(item.Rate));
+
+            writer.WriteStartElement("inv", "homeCurrency", invNamespace);
+            writer.WriteElementString("typ", "unitPrice", typNamespace, FormatDecimal(item.UnitPriceExclVat));
+            writer.WriteElementString("typ", "price", typNamespace, FormatDecimal(item.TotalExclVat));
+            writer.WriteElementString("typ", "priceVAT", typNamespace, FormatDecimal(item.VatAmount));
+            writer.WriteElementString("typ", "priceSum", typNamespace, FormatDecimal(item.TotalInclVat));
+            writer.WriteEndElement();
+
+            if (item.Discount > 0m)
+            {
+                writer.WriteElementString("inv", "discountPercentage", invNamespace, FormatDecimal(item.DiscountPercentage));
+            }
+
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+    }
+
+    private static void WriteInvoiceSummary(XmlWriter writer, InvoiceDto invoice, string invNamespace, string typNamespace)
+    {
+        writer.WriteStartElement("inv", "invoiceSummary", invNamespace);
+        writer.WriteElementString("inv", "round", invNamespace, "none");
+        writer.WriteStartElement("inv", "homeCurrency", invNamespace);
+
+        WriteOptionalSummaryElement(writer, typNamespace, "priceNone", invoice.NoneRateBase);
+        WriteOptionalSummaryElement(writer, typNamespace, "priceLow", invoice.LowRateBase);
+        WriteOptionalSummaryElement(writer, typNamespace, "priceLowVAT", invoice.LowRateVat);
+        WriteOptionalSummaryElement(writer, typNamespace, "priceHigh", invoice.HighRateBase);
+        WriteOptionalSummaryElement(writer, typNamespace, "priceHighVAT", invoice.HighRateVat);
+        writer.WriteElementString("typ", "priceSum", typNamespace, FormatDecimal(invoice.TotalInclVat));
+
+        writer.WriteEndElement();
+        writer.WriteEndElement();
+    }
+
+    private static void WriteOptionalSummaryElement(XmlWriter writer, string typNamespace, string elementName, decimal? value)
+    {
+        if (value is > 0m)
+        {
+            writer.WriteElementString("typ", elementName, typNamespace, FormatDecimal(value.Value));
+        }
+    }
+
+    private static string MapVatRate(VatRate rate) => rate switch
+    {
+        VatRate.High => "high",
+        VatRate.Low => "low",
+        _ => "none"
+    };
+
+    private static string FormatDecimal(decimal value)
+        => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    private void ValidateAgainstSchemas(string xml)
+    {
+        if (_schemas.Count == 0)
+        {
+            return;
+        }
+
+        var settings = new XmlReaderSettings
+        {
+            ValidationType = ValidationType.Schema
+        };
+
+        foreach (var schema in _schemas)
+        {
+            settings.Schemas.Add(schema);
+        }
+
+        var errors = new List<string>();
+        settings.ValidationEventHandler += (_, args) =>
+        {
+            if (args.Severity == XmlSeverityType.Error)
+            {
+                errors.Add(args.Message);
+            }
+        };
+
+        using var stringReader = new StringReader(xml);
+        using var reader = XmlReader.Create(stringReader, settings);
+        while (reader.Read())
+        {
+        }
+
+        if (errors.Count > 0)
+        {
+            throw new XmlSchemaValidationException($"XML validation failed: {string.Join("; ", errors)}");
+        }
+    }
 }

--- a/SysJaky_N.Tests/InvoiceApiTests.cs
+++ b/SysJaky_N.Tests/InvoiceApiTests.cs
@@ -7,7 +7,6 @@ using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using SysJaky_N.Controllers;
-using SysJaky_N.Models.Billing;
 using SysJaky_N.Services.Pohoda;
 
 namespace SysJaky_N.Tests;

--- a/SysJaky_N.Tests/OrderToInvoiceMapperTests.cs
+++ b/SysJaky_N.Tests/OrderToInvoiceMapperTests.cs
@@ -18,7 +18,7 @@ public class OrderToInvoiceMapperTests
         Assert.NotNull(invoice.Header);
         Assert.Equal($"Objednávka {order.Id}", invoice.Header.Text);
         Assert.Equal(order.Items.Count, invoice.Items.Count);
-        Assert.Equal(order.Total, invoice.Summary.TotalInclVat);
+        Assert.Equal(order.Total, invoice.TotalInclVat);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add immutable Pohoda invoice DTOs to represent headers, items, and totals
- refactor order mapping, API mapping, and Pohoda XML builder to emit issued invoices from the new DTOs via XmlWriter
- update Pohoda order payload helper and related tests to consume the new DTO pipeline

## Testing
- dotnet test


------
https://chatgpt.com/codex/tasks/task_e_68f88ada81c083218a4791c9755758a7