### PR TITLE
Update Pohoda XML builder tests to use DTO

### DIFF
--- a/Services/Pohoda/PohodaXmlBuilder.cs
+++ b/Services/Pohoda/PohodaXmlBuilder.cs
@@ -148,9 +148,6 @@ public sealed class PohodaXmlBuilder
 
             writer.WriteStartElement("inv", "homeCurrency", invNamespace);
             writer.WriteElementString("typ", "unitPrice", typNamespace, FormatDecimal(item.UnitPriceExclVat));
-            writer.WriteElementString("typ", "price", typNamespace, FormatDecimal(item.TotalExclVat));
-            writer.WriteElementString("typ", "priceVAT", typNamespace, FormatDecimal(item.VatAmount));
-            writer.WriteElementString("typ", "priceSum", typNamespace, FormatDecimal(item.TotalInclVat));
             writer.WriteEndElement();
 
             if (item.Discount > 0m)


### PR DESCRIPTION
## Summary
- replace golden-file PohodaXmlBuilder tests with a DTO-driven sample that asserts XML content through XPath
- ensure the sample verifies declaration encoding, VAT classifications, rounding, and absence of item price fields
- update PohodaXmlBuilder to omit price, priceVAT, and priceSum elements from invoice detail homeCurrency blocks

## Testing
- `dotnet test --no-restore >/tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68ff3d434d9c8321a45481f693025b4a